### PR TITLE
Fix live reload scroll position reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Article links resolve correctly without `/docs/` prefix
 - Comment preservation works when table content changes
 - Live reload triggers page refresh correctly
+- Live reload preserves scroll position when content updates
 - Navigation updates on consecutive clicks
 - Breadcrumbs exclude non-navigable paths and current page
 - Diagram sizing displays at correct physical size

--- a/frontend/src/pages/Page.svelte
+++ b/frontend/src/pages/Page.svelte
@@ -16,7 +16,7 @@
 
   onMount(() => {
     return liveReload.onReload(() => {
-      page.load(extractDocPath(get(path)), { bypassCache: true });
+      page.load(extractDocPath(get(path)), { bypassCache: true, silent: true });
     });
   });
 

--- a/frontend/src/stores/page.ts
+++ b/frontend/src/stores/page.ts
@@ -24,20 +24,24 @@ function createPageStore() {
     subscribe,
 
     /** Load a page by path, cancelling any in-flight request */
-    async load(path: string, options?: { bypassCache?: boolean }) {
+    async load(path: string, options?: { bypassCache?: boolean; silent?: boolean }) {
       // Cancel any in-flight request
       if (abortController) {
         abortController.abort();
       }
       abortController = new AbortController();
 
-      // Atomic reset to loading state
-      set({ ...initialState, loading: true });
+      // Silent mode skips loading state (used for live reload to preserve scroll)
+      if (!options?.silent) {
+        set({ ...initialState, loading: true });
+      }
 
       try {
-        const data = await fetchPage(path, { ...options, signal: abortController.signal });
+        const data = await fetchPage(path, {
+          bypassCache: options?.bypassCache,
+          signal: abortController.signal,
+        });
         set({ data, loading: false, error: null, notFound: false });
-        // Update document title
         if (data.meta.title) {
           document.title = `${data.meta.title} - Docstage`;
         }


### PR DESCRIPTION
Add silent option to page.load() that skips the loading state reset, preserving scroll position during content updates. Used by live reload to update content in-place without disrupting the user's view.