### PR TITLE
Fix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **cargo-dist builds** now embed frontend assets in binary to prevent 404 errors on installation
+- **build.rs** automatically builds frontend assets when `embed-assets` feature is enabled
 
 ## [0.1.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rw"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "console",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "rw-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "rw-confluence"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "hex",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "rw-diagrams"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "hex",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "rw-renderer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pretty_assertions",
  "pulldown-cmark",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "rw-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "rw-site"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "regex",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "rw-storage"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "glob",
  "notify",

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Edit `rw.toml` with your settings and place `private_key.pem` in the project roo
 cargo install --path crates/rw
 
 # Or build release binary with embedded assets
+# Note: Frontend assets are automatically built by build.rs
 cargo build -p rw --release --features embed-assets
 ```
 

--- a/crates/rw-server/build.rs
+++ b/crates/rw-server/build.rs
@@ -1,0 +1,45 @@
+fn main() {
+    // Only build frontend when embed-assets feature is enabled
+    #[cfg(feature = "embed-assets")]
+    {
+        use std::path::Path;
+        use std::process::Command;
+
+        let frontend_dir = Path::new("../../frontend");
+
+        // Install dependencies if node_modules doesn't exist
+        if !frontend_dir.join("node_modules").exists() {
+            let install = Command::new("npm")
+                .current_dir(frontend_dir)
+                .arg("ci")
+                .output()
+                .expect("failed to run npm ci");
+
+            if !install.status.success() {
+                panic!(
+                    "failed to install frontend dependencies:\n{}",
+                    std::str::from_utf8(&install.stderr).unwrap()
+                );
+            }
+        }
+
+        // Build frontend assets
+        let output = Command::new("npm")
+            .current_dir(frontend_dir)
+            .arg("run")
+            .arg("build")
+            .output()
+            .expect("failed to build the frontend");
+
+        if !output.status.success() {
+            panic!(
+                "failed to build frontend:\n{}",
+                std::str::from_utf8(&output.stderr).unwrap()
+            );
+        }
+
+        // Rebuild if frontend files or build script changes
+        println!("cargo:rerun-if-changed=../../frontend");
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+}


### PR DESCRIPTION
Add build script to rw-server that automatically runs npm build when the embed-assets feature is enabled. This ensures frontend assets are built before Cargo embeds them, fixing cargo-dist builds without requiring GitHub Actions workflow modifications.

The build script:
- Runs npm ci if node_modules is missing
- Executes npm run build in frontend directory
- Only activates with embed-assets feature flag

All GitHub Actions runners have Node.js 20+ and npm pre-installed, so this works out of the box without additional setup.