### PR TITLE
Store internal paths without leading slash

### DIFF
--- a/crates/rw-server/src/handlers/mod.rs
+++ b/crates/rw-server/src/handlers/mod.rs
@@ -3,3 +3,15 @@
 pub(crate) mod config;
 pub(crate) mod navigation;
 pub(crate) mod pages;
+
+/// Convert internal path (without leading slash) to URL path (with leading slash).
+///
+/// The site stores paths without leading slashes (e.g., "guide", "domain/page", "" for root),
+/// but the frontend expects URL paths with leading slashes (e.g., "/guide", "/domain/page", "/").
+pub(crate) fn to_url_path(path: &str) -> String {
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{path}")
+    }
+}

--- a/crates/rw-server/src/handlers/navigation.rs
+++ b/crates/rw-server/src/handlers/navigation.rs
@@ -9,19 +9,48 @@ use axum::extract::State;
 use rw_site::NavItem;
 use serde::Serialize;
 
+use crate::handlers::to_url_path;
 use crate::state::AppState;
 
 /// Response for GET /api/navigation.
 #[derive(Serialize)]
 pub(crate) struct NavigationResponse {
     /// Navigation tree items.
-    items: Vec<NavItem>,
+    items: Vec<NavItemResponse>,
+}
+
+/// Navigation item for JSON response with URL paths (leading slash).
+#[derive(Serialize)]
+struct NavItemResponse {
+    /// Display title.
+    title: String,
+    /// Link target path (with leading slash for frontend).
+    path: String,
+    /// Child navigation items.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    children: Vec<NavItemResponse>,
+}
+
+impl From<NavItem> for NavItemResponse {
+    fn from(item: NavItem) -> Self {
+        Self {
+            title: item.title,
+            path: to_url_path(&item.path),
+            children: item
+                .children
+                .into_iter()
+                .map(NavItemResponse::from)
+                .collect(),
+        }
+    }
 }
 
 /// Handle GET /api/navigation.
 pub(crate) async fn get_navigation(State(state): State<Arc<AppState>>) -> Json<NavigationResponse> {
     let items = state.site.navigation();
-    Json(NavigationResponse { items })
+    Json(NavigationResponse {
+        items: items.into_iter().map(NavItemResponse::from).collect(),
+    })
 }
 
 #[cfg(test)]
@@ -30,17 +59,21 @@ mod tests {
 
     #[test]
     fn test_navigation_response_serialization() {
+        // Create NavItem with internal path (no leading slash)
+        let nav_item = NavItem {
+            title: "Guide".to_string(),
+            path: "guide".to_string(),
+            children: vec![],
+        };
+        // Convert to NavItemResponse which adds leading slash
         let response = NavigationResponse {
-            items: vec![NavItem {
-                title: "Guide".to_string(),
-                path: "/guide".to_string(),
-                children: vec![],
-            }],
+            items: vec![NavItemResponse::from(nav_item)],
         };
 
         let json = serde_json::to_value(&response).unwrap();
 
         assert_eq!(json["items"][0]["title"], "Guide");
+        // JSON serialization should have leading slash
         assert_eq!(json["items"][0]["path"], "/guide");
     }
 }

--- a/crates/rw-server/src/live_reload/manager.rs
+++ b/crates/rw-server/src/live_reload/manager.rs
@@ -10,6 +10,8 @@ use tokio::sync::broadcast;
 use rw_site::Site;
 use rw_storage::{Storage, StorageEventKind, WatchHandle};
 
+use crate::handlers::to_url_path;
+
 /// Event sent to connected WebSocket clients when files change.
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct ReloadEvent {
@@ -101,10 +103,10 @@ impl LiveReloadManager {
             return;
         };
 
-        // Broadcast reload event
+        // Broadcast reload event with URL path (add leading slash for frontend)
         let reload_event = ReloadEvent {
             event_type: "reload".to_string(),
-            path: doc_path,
+            path: to_url_path(&doc_path),
         };
         let _ = broadcaster.send(reload_event);
     }


### PR DESCRIPTION
Remove redundant path normalization by storing paths without leading slashes in Site and SiteState. Add leading slash only at the API serialization boundary for frontend compatibility.

- Remove normalize_path() from SiteState
- Update source_path_to_url() to return paths without leading slash
- Add shared to_url_path() helper in handlers module
- Update all tests to use new path format