### PR TITLE
Add Windows to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,11 @@ jobs:
         working-directory: frontend
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Add Windows (`windows-latest`) to the test job matrix in CI
- Tests now run on both Ubuntu and Windows in parallel

## Test plan
- [x] Verify both Linux and Windows test jobs pass in CI
- [x] Confirm cargo caching works on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)