### PR TITLE
feat: apply relative_links and trailing_slash to diagram $link URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `relative_links` option in `PageRendererConfig` (default `false`, opt-in for TechDocs)
 - `trailing_slash` option in `MarkdownRenderer` and `PageRendererConfig` for URLs with trailing slashes (e.g., `/a/b/` instead of `/a/b`), needed for TechDocs static site output
 - Meta diagram includes: PlantUML `!include` directives resolve C4 model macros from `meta.yaml` metadata (supports domain/system/service types)
+- Diagram `$link` URLs now respect `relative_links` and `trailing_slash` settings via `LinkConfig` on `DiagramProcessor`
 
 ### Changed
 

--- a/crates/rw-diagrams/src/lib.rs
+++ b/crates/rw-diagrams/src/lib.rs
@@ -40,6 +40,6 @@ mod plantuml;
 mod processor;
 
 pub use cache::DiagramKey;
-pub use meta_includes::{EntityInfo, MetaIncludeSource, resolve_meta_include};
+pub use meta_includes::{EntityInfo, LinkConfig, MetaIncludeSource, resolve_meta_include};
 pub use output::{DiagramOutput, DiagramTagGenerator, RenderedDiagramInfo};
 pub use processor::{DiagramProcessor, to_extracted_diagram, to_extracted_diagrams};

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -267,7 +267,7 @@ impl PageRenderer {
             renderer = renderer.with_title_extraction();
         }
 
-        if let Some(processor) = self.create_diagram_processor(meta_include_source) {
+        if let Some(processor) = self.create_diagram_processor(base_path, meta_include_source) {
             renderer = renderer.with_processor(processor);
         }
 
@@ -276,6 +276,7 @@ impl PageRenderer {
 
     fn create_diagram_processor(
         &self,
+        base_path: &str,
         meta_include_source: Option<Arc<dyn MetaIncludeSource>>,
     ) -> Option<DiagramProcessor> {
         let url = self.kroki_url.as_ref()?;
@@ -287,6 +288,14 @@ impl PageRenderer {
 
         if let Some(source) = meta_include_source {
             processor = processor.with_meta_include_source(source);
+        }
+
+        if self.relative_links || self.trailing_slash {
+            processor = processor.with_link_config(
+                format!("/{base_path}"),
+                self.relative_links,
+                self.trailing_slash,
+            );
         }
 
         Some(processor)


### PR DESCRIPTION
## Summary

- Diagram C4 macro `$link` URLs now respect `relative_links` and `trailing_slash` renderer settings
- Added `LinkConfig` struct threaded through `DiagramProcessor` → `prepare_diagram_source()` → `resolve_meta_include()` → `render_c4_macro()`
- When `LinkConfig` is `None` (default / Confluence), behavior is unchanged

## Test plan

- [x] 4 new unit tests for `LinkConfig` (trailing slash, relative links, both, no URL)
- [x] All 700 existing tests pass
- [x] Clippy clean, formatter applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)