### PR TITLE
perf(rw-techdocs): parallelize page rendering with rayon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `rw techdocs build` now renders pages in parallel, significantly speeding up diagram-heavy sites
+
 ### Fixed
 
 - Fixed heading anchors for non-Latin characters (Cyrillic, CJK, etc.) producing empty IDs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,6 +3033,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "minijinja",
+ "rayon",
  "rw-assets",
  "rw-cache",
  "rw-site",

--- a/crates/rw-techdocs/Cargo.toml
+++ b/crates/rw-techdocs/Cargo.toml
@@ -16,6 +16,7 @@ rw-site = { workspace = true }
 rw-storage = { workspace = true }
 
 minijinja = { workspace = true }
+rayon = { workspace = true }
 
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1"


### PR DESCRIPTION
## Summary

- Replace sequential page rendering loop in `StaticSiteBuilder::build()` with `rayon::par_iter().try_for_each()`
- Diagram-heavy projects now render pages concurrently, bounded by slowest page instead of sum of all pages
- No API changes — same output, faster execution

## Test Plan

- [x] All 30 `rw-techdocs` tests pass
- [x] `cargo clippy -p rw-techdocs` — zero warnings
- [ ] Manual test: `rw techdocs build` on a diagram-heavy project and compare wall-clock time

🤖 Generated with [Claude Code](https://claude.com/claude-code)