### PR TITLE
perf(rw-storage-fs): parallelize filesystem scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `rw techdocs build` now renders pages in parallel, significantly speeding up diagram-heavy sites
+- Startup scan is now ~3x faster on large sites (parallel directory walking and document building)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1432,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1845,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3016,7 +3055,9 @@ name = "rw-storage-fs"
 version = "0.1.7"
 dependencies = [
  "glob",
+ "ignore",
  "notify",
+ "rayon",
  "regex",
  "rw-storage",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "2"
 serde = { version = "1.0", features = ["derive"] }
 toml = "1.0"
 hex = "0.4"
+ignore = "0.4"
 pretty_assertions = "1.4"
 pulldown-cmark = { version = "0.13", default-features = false, features = ["simd"] }
 rayon = "1.10"

--- a/crates/rw-storage-fs/Cargo.toml
+++ b/crates/rw-storage-fs/Cargo.toml
@@ -12,10 +12,12 @@ workspace = true
 [dependencies]
 rw-storage = { workspace = true }
 glob = { workspace = true }
+ignore = { workspace = true }
 notify = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
+rayon = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- Parallelize directory walking using the `ignore` crate's `WalkBuilder::build_parallel()` (multi-threaded work-stealing)
- Parallelize document building (title extraction + YAML metadata parsing) using rayon's `par_iter()`
- Add scan timing instrumentation via `tracing::info`

Measured on a 1551-file documentation site:

| Phase | Before | After | Speedup |
|-------|--------|-------|---------|
| Walk (directory traversal) | 200ms | 83ms | 2.4x |
| Build (file reads + parsing) | 361ms | 105ms | 3.4x |
| **Total** | **561ms** | **188ms** | **3.0x** |

## Test plan

- [x] All 88 `rw-storage-fs` tests pass (including symlink, hidden file, and metadata tests)
- [x] Verified on real 1551-file site with `RUST_LOG=info rw serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)