### PR TITLE
feat(renderer): add link_prefix for embedding with URL prefix

### DIFF
--- a/crates/rw-napi/src/lib.rs
+++ b/crates/rw-napi/src/lib.rs
@@ -56,12 +56,17 @@ pub struct RwSite {
 // napi-rs requires owned types for JavaScript bindings.
 #[allow(clippy::needless_pass_by_value)]
 #[napi]
-pub fn create_site(docs_dir: String, kroki_url: Option<String>) -> Result<RwSite> {
+pub fn create_site(
+    docs_dir: String,
+    kroki_url: Option<String>,
+    link_prefix: Option<String>,
+) -> Result<RwSite> {
     let storage = Arc::new(FsStorage::new(PathBuf::from(&docs_dir)));
     let cache: Arc<dyn rw_cache::Cache> = Arc::new(NullCache);
     let config = PageRendererConfig {
         extract_title: true,
         kroki_url,
+        link_prefix,
         ..Default::default()
     };
     let site = Arc::new(Site::new(storage, cache, config));

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -63,6 +63,8 @@ pub struct MarkdownRenderer<B: RenderBackend> {
     relative_links: bool,
     /// Append trailing slash to resolved link paths.
     trailing_slash: bool,
+    /// Prefix prepended to all resolved internal link paths (e.g. `/rw-docs`).
+    link_prefix: Option<String>,
     _backend: PhantomData<B>,
 }
 
@@ -87,6 +89,7 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
             directives: None,
             relative_links: false,
             trailing_slash: false,
+            link_prefix: None,
             _backend: PhantomData,
         }
     }
@@ -181,6 +184,21 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
     #[must_use]
     pub fn with_trailing_slash(mut self, enabled: bool) -> Self {
         self.trailing_slash = enabled;
+        self
+    }
+
+    /// Set a prefix for all resolved internal link paths (e.g., `/rw-docs`).
+    ///
+    /// When set, absolute link paths like `/docs/guide` become `/rw-docs/docs/guide`.
+    /// External links, fragment links, and protocol-relative links are not affected.
+    ///
+    /// The prefix is not applied when [`with_relative_links`](Self::with_relative_links)
+    /// is enabled, since that converts paths to relative form.
+    ///
+    /// The prefix should not end with `/` to avoid double slashes in output.
+    #[must_use]
+    pub fn with_link_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.link_prefix = Some(prefix.into());
         self
     }
 
@@ -288,12 +306,13 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         }
     }
 
-    /// Apply trailing-slash and relative-link transformations to a resolved href.
+    /// Apply link-prefix, trailing-slash, and relative-link transformations to a resolved href.
     ///
     /// Handles fragment (`#section`) correctly by splitting before path manipulation
     /// and rejoining after.
     fn resolve_href(&self, href: &str) -> String {
-        if (!self.trailing_slash && !self.relative_links) || !href.starts_with('/') {
+        let needs_transform = self.trailing_slash || self.relative_links;
+        if (!needs_transform && self.link_prefix.is_none()) || !href.starts_with('/') {
             return href.to_owned();
         }
 
@@ -317,6 +336,17 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
                 relative_path(&format!("{from}/"), &path)
             } else {
                 relative_path(from, &path)
+            }
+        } else {
+            path
+        };
+
+        // Prepend link prefix to absolute paths (skip relative paths from above)
+        let path = if let Some(prefix) = &self.link_prefix {
+            if path.starts_with('/') {
+                format!("{prefix}{path}")
+            } else {
+                path
             }
         } else {
             path
@@ -1269,5 +1299,66 @@ Install with apt.
         let mut renderer = MarkdownRenderer::<HtmlBackend>::new().with_base_path("/a/b");
         let result = renderer.render_markdown("[link](../other.md)");
         assert!(result.html.contains(r#"href="/a/other""#));
+    }
+
+    #[test]
+    fn test_link_prefix_prepends_to_internal_links() {
+        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
+            .with_base_path("/docs/usage")
+            .with_link_prefix("/rw-docs");
+        let result = renderer.render_markdown("[link](./quick-start.md)");
+        assert!(
+            result
+                .html
+                .contains(r#"href="/rw-docs/docs/usage/quick-start""#)
+        );
+    }
+
+    #[test]
+    fn test_link_prefix_skips_external_links() {
+        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
+            .with_base_path("/docs")
+            .with_link_prefix("/rw-docs");
+        let result = renderer.render_markdown("[link](https://example.com)");
+        assert!(result.html.contains(r#"href="https://example.com""#));
+    }
+
+    #[test]
+    fn test_link_prefix_skips_fragment_links() {
+        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
+            .with_base_path("/docs")
+            .with_link_prefix("/rw-docs");
+        let result = renderer.render_markdown("[link](#section)");
+        assert!(result.html.contains(r##"href="#section""##));
+    }
+
+    #[test]
+    fn test_link_prefix_preserves_fragment_on_internal_links() {
+        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
+            .with_base_path("/docs")
+            .with_link_prefix("/rw-docs");
+        let result = renderer.render_markdown("[link](./page.md#section)");
+        assert!(result.html.contains(r#"href="/rw-docs/docs/page#section""#));
+    }
+
+    #[test]
+    fn test_link_prefix_with_trailing_slash() {
+        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
+            .with_base_path("/docs")
+            .with_trailing_slash(true)
+            .with_link_prefix("/rw-docs");
+        let result = renderer.render_markdown("[link](./page.md)");
+        assert!(result.html.contains(r#"href="/rw-docs/docs/page/""#));
+    }
+
+    #[test]
+    fn test_link_prefix_skipped_when_relative_links() {
+        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
+            .with_base_path("/docs/usage")
+            .with_relative_links(true)
+            .with_link_prefix("/rw-docs");
+        let result = renderer.render_markdown("[link](../other.md)");
+        // relative_links converts to relative path, link_prefix does not apply
+        assert!(result.html.contains(r#"href="other""#));
     }
 }

--- a/crates/rw-server/src/lib.rs
+++ b/crates/rw-server/src/lib.rs
@@ -153,6 +153,7 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
         relative_links: false,
         trailing_slash: false,
         static_tabs: false,
+        link_prefix: None,
     };
     let site = Arc::new(Site::new(Arc::clone(&storage), cache, site_config));
 

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -41,6 +41,10 @@ pub struct PageRendererConfig {
     ///
     /// Default: `false`.
     pub static_tabs: bool,
+    /// Prefix prepended to all resolved internal link paths (e.g. `/rw-docs`).
+    ///
+    /// Default: `None` (no prefix).
+    pub link_prefix: Option<String>,
 }
 
 impl Default for PageRendererConfig {
@@ -53,6 +57,7 @@ impl Default for PageRendererConfig {
             relative_links: false,
             trailing_slash: false,
             static_tabs: false,
+            link_prefix: None,
         }
     }
 }
@@ -145,6 +150,7 @@ pub(crate) struct PageRenderer {
     relative_links: bool,
     trailing_slash: bool,
     static_tabs: bool,
+    link_prefix: Option<String>,
 }
 
 impl PageRenderer {
@@ -165,6 +171,7 @@ impl PageRenderer {
             relative_links: config.relative_links,
             trailing_slash: config.trailing_slash,
             static_tabs: config.static_tabs,
+            link_prefix: config.link_prefix,
         }
     }
 
@@ -276,6 +283,10 @@ impl PageRenderer {
             .with_relative_links(self.relative_links)
             .with_trailing_slash(self.trailing_slash)
             .with_directives(directives);
+
+        if let Some(prefix) = &self.link_prefix {
+            renderer = renderer.with_link_prefix(prefix);
+        }
 
         if self.extract_title {
             renderer = renderer.with_title_extraction();

--- a/crates/rw/src/commands/techdocs/build.rs
+++ b/crates/rw/src/commands/techdocs/build.rs
@@ -83,6 +83,7 @@ impl BuildArgs {
                 relative_links: true,
                 trailing_slash: true,
                 static_tabs: true,
+                link_prefix: None,
             },
         );
 


### PR DESCRIPTION
## Summary

- Add `link_prefix` option to `MarkdownRenderer` that prepends a path prefix to all resolved internal link paths (e.g., `/docs/guide` → `/rw-docs/docs/guide`)
- Expose `link_prefix` in `PageRendererConfig` so all consumers (server, techdocs, napi) can use it
- External links, fragment-only links, and protocol-relative links are not affected

## Test plan

- [x] Unit tests for internal link prefixing
- [x] Unit tests for external link skipping
- [x] Unit tests for fragment-only link skipping
- [x] Unit tests for fragment preservation on internal links
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)