### PR TITLE
chore: configure Renovate for Yarn v4

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
   ],
   "ignorePaths": [
     ".github/workflows/release.yml"
+  ],
+  "postUpdateOptions": [
+    "yarnDedupeHighest"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `yarnDedupeHighest` post-update option so Renovate runs `yarn dedupe --strategy highest` after dependency updates, keeping the lock file clean after the npm → Yarn v4 migration

## Test plan
- [ ] Verify Renovate opens a dependency update PR and the lock file has no duplicate resolutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)