### PR TITLE
fix: preserve navigation expansion after page refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed navigation sidebar collapsing after page refresh on inner pages
+
 ## [0.1.10] - 2026-03-01
 
 ### Fixed

--- a/packages/viewer/src/stores/navigation.test.ts
+++ b/packages/viewer/src/stores/navigation.test.ts
@@ -274,5 +274,71 @@ describe("navigation store", () => {
       // State reference should be the same (no update)
       expect(stateAfter).toBe(stateBefore);
     });
+
+    it("re-expands active path after loadScope replaces the tree", async () => {
+      const scopedTree: NavigationTree = {
+        items: [
+          {
+            title: "Billing",
+            path: "/billing",
+            children: [
+              { title: "Payments", path: "/billing/payments" },
+              { title: "Invoices", path: "/billing/invoices" },
+            ],
+          },
+        ],
+      };
+
+      mockFetchNavigation.mockResolvedValue(scopedTree);
+      const navigation = createNavigationStore(mockApiClient);
+
+      // Set active path before tree is loaded (simulates Page.svelte subscription)
+      navigation.expandOnlyTo("/billing/payments");
+
+      // Load navigation (simulates scopeWatcher calling loadScope)
+      await navigation.loadScope("billing");
+
+      const state = get(navigation);
+      // /billing should be expanded (ancestor of active path)
+      expect(state.collapsed.has("/billing")).toBe(false);
+    });
+
+    it("re-expands active path when scope changes after initial load", async () => {
+      const scopedTree: NavigationTree = {
+        items: [
+          {
+            title: "Guide",
+            path: "/guide",
+            children: [
+              { title: "Getting Started", path: "/guide/getting-started" },
+              {
+                title: "Advanced",
+                path: "/guide/advanced",
+                children: [{ title: "Plugins", path: "/guide/advanced/plugins" }],
+              },
+            ],
+          },
+        ],
+      };
+
+      mockFetchNavigation.mockResolvedValueOnce(mockTree).mockResolvedValueOnce(scopedTree);
+      const navigation = createNavigationStore(mockApiClient);
+
+      // Initial load and expand (simulates Layout.svelte)
+      await navigation.load();
+      navigation.expandOnlyTo("/guide/advanced/plugins");
+
+      // Verify expanded
+      expect(get(navigation).collapsed.has("/guide")).toBe(false);
+      expect(get(navigation).collapsed.has("/guide/advanced")).toBe(false);
+
+      // Scope change replaces the tree (simulates scopeWatcher)
+      await navigation.loadScope("guide");
+
+      // Active path should still be expanded in the new tree
+      const state = get(navigation);
+      expect(state.collapsed.has("/guide")).toBe(false);
+      expect(state.collapsed.has("/guide/advanced")).toBe(false);
+    });
   });
 });

--- a/packages/viewer/src/stores/navigation.ts
+++ b/packages/viewer/src/stores/navigation.ts
@@ -58,6 +58,30 @@ export function createNavigationStore(apiClient: ApiClient): NavigationStore {
   // Track in-flight request for cancellation
   let currentController: AbortController | null = null;
 
+  // Remember the last requested expand path so loadScope can restore it
+  // after replacing the tree (which resets all collapsed state).
+  let activePath: string | null = null;
+
+  /** Expand ancestors of `path` in the current tree (no-op if tree is null). */
+  const doExpandTo = (path: string): void => {
+    update((state) => {
+      if (!state.tree) return state;
+
+      const pathsToExpand = getParentPaths(path);
+      // Optimization: skip update if target path is already expanded.
+      const alreadyCorrect = pathsToExpand.every((p) => !state.collapsed.has(p));
+      if (alreadyCorrect) return state;
+
+      // Collapse all parent items
+      const collapsed = new Set(collectParentPaths(state.tree.items));
+      // Expand the path to the current page
+      for (const parentPath of pathsToExpand) {
+        collapsed.delete(parentPath);
+      }
+      return { ...state, collapsed };
+    });
+  };
+
   const loadScope = async (scope: string, options?: { bypassCache?: boolean }): Promise<void> => {
     // Abort any in-flight request
     currentController?.abort();
@@ -82,6 +106,10 @@ export function createNavigationStore(apiClient: ApiClient): NavigationStore {
         collapsed: new Set(allParentPaths),
         currentScope: scope,
       }));
+      // Re-expand to the active path after tree replacement
+      if (activePath) {
+        doExpandTo(activePath);
+      }
     } catch (e) {
       // Silently ignore aborted requests
       if (e instanceof DOMException && e.name === "AbortError") return;
@@ -116,28 +144,13 @@ export function createNavigationStore(apiClient: ApiClient): NavigationStore {
 
     /** Expand only the path to the current page, collapse all others */
     expandOnlyTo(path: string) {
-      update((state) => {
-        if (!state.tree) return state;
-
-        const pathsToExpand = getParentPaths(path);
-        // Optimization: skip update if target path is already expanded.
-        // This handles clicks on the current page or its children.
-        // For navigation to different branches, the full re-collapse happens below.
-        const alreadyCorrect = pathsToExpand.every((p) => !state.collapsed.has(p));
-        if (alreadyCorrect) return state;
-
-        // Collapse all parent items
-        const collapsed = new Set(collectParentPaths(state.tree.items));
-        // Expand the path to the current page
-        for (const parentPath of pathsToExpand) {
-          collapsed.delete(parentPath);
-        }
-        return { ...state, collapsed };
-      });
+      activePath = path;
+      doExpandTo(path);
     },
 
     /** Reset store to initial state (for testing) */
     _reset() {
+      activePath = null;
       set({ ...initialState, collapsed: new Set() });
     },
   };


### PR DESCRIPTION
## Summary

- Fixed navigation sidebar collapsing after page refresh on inner pages (#152)
- Root cause: loadScope resets all collapsed state when replacing the tree, but when scopeWatcher triggers a second loadScope that races with the initial load, the expand intent is lost
- Store the active path from expandOnlyTo and automatically re-expand after any loadScope completes

## Test plan

- [x] Unit tests added for race condition scenarios
- [x] All 131 frontend tests pass
- [x] Manual: navigate to an inner page, refresh — sidebar should stay expanded

Closes #152