### PR TITLE
fix: use container queries for viewer layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--embedded` flag for `rw serve` to preview docs inside a Backstage-like shell during development
 
+### Changed
+
+- Viewer layout now uses container queries instead of viewport breakpoints, adapting to actual available space when embedded in host applications
+
+### Fixed
+
+- Fixed sidebar, table of contents, mobile drawer, and loading bar overflowing container bounds when viewer is embedded in a smaller host element
+
 ## [0.1.11] - 2026-03-04
 
 ### Added

--- a/packages/viewer/e2e/mobile.spec.ts
+++ b/packages/viewer/e2e/mobile.spec.ts
@@ -26,7 +26,7 @@ test.describe("Mobile Navigation", () => {
     await page.getByRole("button", { name: "Open menu" }).click();
 
     // Mobile drawer should appear
-    const drawer = page.locator("aside.fixed");
+    const drawer = page.locator("aside.absolute");
     await expect(drawer).toBeVisible();
 
     // Should show navigation items
@@ -40,7 +40,7 @@ test.describe("Mobile Navigation", () => {
     // Open drawer
     await page.getByRole("button", { name: "Open menu" }).click();
 
-    const drawer = page.locator("aside.fixed");
+    const drawer = page.locator("aside.absolute");
     await expect(drawer).toBeVisible();
 
     // Expand Getting Started
@@ -64,7 +64,7 @@ test.describe("Mobile Navigation", () => {
     // Open drawer
     await page.getByRole("button", { name: "Open menu" }).click();
 
-    const drawer = page.locator("aside.fixed");
+    const drawer = page.locator("aside.absolute");
     await expect(drawer).toBeVisible();
 
     // Press escape
@@ -80,7 +80,7 @@ test.describe("Mobile Navigation", () => {
     // Open drawer
     await page.getByRole("button", { name: "Open menu" }).click();
 
-    const drawer = page.locator("aside.fixed");
+    const drawer = page.locator("aside.absolute");
     await expect(drawer).toBeVisible();
 
     // Click outside the drawer on the backdrop overlay
@@ -128,7 +128,7 @@ test.describe("Mobile Navigation", () => {
 
     // Open drawer and navigate
     await page.getByRole("button", { name: "Open menu" }).click();
-    const drawer = page.locator("aside.fixed");
+    const drawer = page.locator("aside.absolute");
 
     // Expand Getting Started
     const gsLink = drawer.getByRole("link", { name: "Getting Started" });
@@ -141,11 +141,74 @@ test.describe("Mobile Navigation", () => {
 
     // Navigate to another page
     await page.getByRole("button", { name: "Open menu" }).click();
-    await page.locator("aside.fixed").getByRole("link", { name: "API Reference" }).click();
+    await page.locator("aside.absolute").getByRole("link", { name: "API Reference" }).click();
 
     // Verify second navigation
     await expect(page).toHaveURL(/\/api$/);
     await expect(page.locator("article h1")).toContainText("API Reference");
+  });
+
+  test("drawer panel stays within container bounds when container is shorter than viewport", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Simulate embedded mode: constrain the viewer container so it doesn't
+    // fill the full viewport (e.g., host app has a footer below).
+    await page.evaluate(() => {
+      const container = document.querySelector(".layout-container") as HTMLElement;
+      container.style.height = "500px";
+      container.style.overflow = "hidden";
+    });
+
+    // Open drawer
+    await page.getByRole("button", { name: "Open menu" }).click();
+    const panel = page.locator("aside.absolute > div").first();
+    await expect(panel).toBeVisible();
+
+    // The panel bottom should not extend past the container bottom
+    const { panelBottom, containerBottom } = await page.evaluate(() => {
+      const p = document.querySelector("aside.absolute > div") as HTMLElement;
+      const c = document.querySelector(".layout-container") as HTMLElement;
+      return {
+        panelBottom: p.getBoundingClientRect().bottom,
+        containerBottom: c.getBoundingClientRect().bottom,
+      };
+    });
+
+    expect(panelBottom).toBeLessThanOrEqual(containerBottom);
+  });
+
+  test("drawer panel height updates when container resizes without viewport change", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Constrain the container to simulate embedded mode
+    await page.evaluate(() => {
+      const container = document.querySelector(".layout-container") as HTMLElement;
+      container.style.height = "600px";
+      container.style.overflow = "hidden";
+    });
+
+    // Open drawer and read initial panel height
+    await page.getByRole("button", { name: "Open menu" }).click();
+    const panel = page.locator("aside.absolute > div").first();
+    await expect(panel).toBeVisible();
+
+    const initialHeight = await panel.evaluate((el) => el.getBoundingClientRect().height);
+
+    // Shrink the container (NOT the viewport)
+    await page.evaluate(() => {
+      const container = document.querySelector(".layout-container") as HTMLElement;
+      container.style.height = "400px";
+    });
+
+    // Panel height should adapt to the smaller container
+    await expect(async () => {
+      const newHeight = await panel.evaluate((el) => el.getBoundingClientRect().height);
+      expect(newHeight).toBeLessThan(initialHeight);
+    }).toPass({ timeout: 2000 });
   });
 
   test("breadcrumbs work on mobile", async ({ page }) => {

--- a/packages/viewer/e2e/page-content.spec.ts
+++ b/packages/viewer/e2e/page-content.spec.ts
@@ -1,5 +1,126 @@
 import { test, expect } from "@playwright/test";
 
+test.describe("ToC sticky behavior", () => {
+  test.use({ viewport: { width: 1400, height: 400 } });
+
+  test("ToC stays visible at top when content is scrolled down", async ({ page }) => {
+    await page.goto("/");
+
+    // Wait for TOC to be visible
+    const tocHeading = page.getByText("On this page");
+    await expect(tocHeading).toBeVisible();
+
+    // Scroll the content area down (the overflow-y-auto wrapper inside .layout-root)
+    await page.evaluate(() => {
+      const scrollContainer = document.querySelector(".layout-root > .overflow-y-auto");
+      if (scrollContainer) {
+        scrollContainer.scrollTop = scrollContainer.scrollHeight;
+      }
+    });
+
+    // The TOC should still be visible at the top after scrolling
+    await expect(tocHeading).toBeInViewport();
+  });
+});
+
+test.describe("Embedded Layout", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("sidebar height is bounded by container, not viewport", async ({ page }) => {
+    await page.goto("/");
+
+    // Wait for desktop sidebar to be visible (requires >= 952px container width)
+    const sidebar = page.locator(".layout-sidebar");
+    await expect(sidebar).toBeVisible();
+
+    // Simulate embedded mode: constrain the viewer container to be much
+    // shorter than the viewport (e.g., host app has a header/footer).
+    const containerHeight = 400;
+    await page.evaluate((h) => {
+      const container = document.querySelector(".layout-container") as HTMLElement;
+      container.style.height = `${h}px`;
+      container.style.overflow = "hidden";
+    }, containerHeight);
+
+    // The sidebar height should not exceed the container height.
+    // With the bug, it uses h-screen (100vh = 900px) which overflows
+    // the 400px container.
+    const sidebarHeight = await sidebar.evaluate((el) => el.getBoundingClientRect().height);
+
+    expect(sidebarHeight).toBeLessThanOrEqual(containerHeight);
+  });
+
+  test("ToC max-height is bounded by container, not viewport", async ({ page }) => {
+    await page.goto("/");
+
+    // Wait for ToC to be visible (requires >= 1224px container width)
+    const tocAside = page.locator(".layout-toc");
+    await expect(tocAside).toBeVisible();
+
+    // Simulate embedded mode: constrain the viewer container to be much
+    // shorter than the viewport (e.g., host app has a header/footer).
+    const containerHeight = 400;
+    await page.evaluate((h) => {
+      const container = document.querySelector(".layout-container") as HTMLElement;
+      container.style.height = `${h}px`;
+      container.style.overflow = "hidden";
+    }, containerHeight);
+
+    // The ToC sticky wrapper's max-height should not exceed the container
+    // height. With the bug, it uses 100vh (~900px) which is much larger
+    // than the 400px container.
+    await expect(async () => {
+      const maxH = await page.evaluate(() => {
+        const toc = document.querySelector(".layout-toc .sticky") as HTMLElement;
+        return parseFloat(getComputedStyle(toc).maxHeight);
+      });
+      expect(maxH).toBeLessThanOrEqual(containerHeight);
+    }).toPass({ timeout: 2000 });
+  });
+
+  test("sidebar navigation is scrollable when container is shorter than content", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const sidebar = page.locator(".layout-sidebar");
+    await expect(sidebar).toBeVisible();
+
+    // Expand all navigation sections so the sidebar content is tall
+    for (const toggle of await sidebar.locator("button").all()) {
+      await toggle.click();
+    }
+
+    // Simulate embedded mode: the host app wraps the viewer in a
+    // fixed-height container with overflow hidden. The viewer's own
+    // sidebar must remain scrollable within these bounds.
+    const containerHeight = 150;
+    await page.evaluate((h) => {
+      const container = document.querySelector(".layout-container") as HTMLElement;
+      const wrapper = document.createElement("div");
+      wrapper.style.height = `${h}px`;
+      wrapper.style.overflow = "hidden";
+      container.parentElement!.insertBefore(wrapper, container);
+      wrapper.appendChild(container);
+    }, containerHeight);
+
+    // The sidebar content should overflow and be scrollable
+    await expect(async () => {
+      const { isScrollable, canScrollToBottom } = await page.evaluate(() => {
+        const sb = document.querySelector(".layout-sidebar") as HTMLElement;
+        const overflows = sb.scrollHeight > sb.clientHeight;
+        sb.scrollTop = sb.scrollHeight;
+        return {
+          isScrollable: overflows,
+          canScrollToBottom: sb.scrollTop > 0,
+        };
+      });
+      expect(isScrollable).toBe(true);
+      expect(canScrollToBottom).toBe(true);
+    }).toPass({ timeout: 2000 });
+  });
+});
+
 test.describe("Page Content", () => {
   test("renders markdown content with headings", async ({ page }) => {
     await page.goto("/");

--- a/packages/viewer/eslint.config.js
+++ b/packages/viewer/eslint.config.js
@@ -15,6 +15,7 @@ export default defineConfig([
       },
     },
     rules: {
+      "better-tailwindcss/no-unknown-classes": ["error", { ignore: ["layout-*"] }],
       "better-tailwindcss/enforce-consistent-line-wrapping": [
         "warn",
         { printWidth: 100, strictness: "loose", preferSingleLine: true },

--- a/packages/viewer/src/App.svelte
+++ b/packages/viewer/src/App.svelte
@@ -104,7 +104,7 @@
   let route = $derived(getRoute($path));
 </script>
 
-<div bind:this={rootElement}>
+<div bind:this={rootElement} class="h-full">
   <Layout>
     {#if route === "home"}
       <Home />

--- a/packages/viewer/src/components/Layout.svelte
+++ b/packages/viewer/src/components/Layout.svelte
@@ -28,106 +28,147 @@
   });
 </script>
 
-<LoadingBar loading={$page.loading} />
-
-<!-- Mobile Header -->
-<header
-  class="
-    sticky top-0 z-30 flex items-center border-b border-gray-200 bg-white px-4 py-3
-    md:hidden
-    dark:border-neutral-700 dark:bg-neutral-800
-  "
->
-  <button
-    onclick={ui.openMobileMenu}
+<div class="layout-container">
+  <LoadingBar loading={$page.loading} />
+  <!-- Mobile Header -->
+  <header
     class="
-      -ml-2 cursor-pointer p-2 text-gray-500
-      hover:text-gray-700
-      dark:text-neutral-400
-      dark:hover:text-neutral-300
+      layout-mobile-header sticky top-0 z-30 flex items-center border-b border-gray-200 bg-white
+      px-4 py-3
+      dark:border-neutral-700 dark:bg-neutral-800
     "
-    aria-label="Open menu"
   >
-    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M4 6h16M4 12h16M4 18h16"
-      />
-    </svg>
-  </button>
-  <a href={homeHref} class="ml-3">
-    <span class="text-lg font-semibold uppercase"
-      ><span class="text-gray-900 dark:text-neutral-100">R</span><span
-        class="text-gray-400 dark:text-neutral-500">W</span
-      ></span
+    <button
+      onclick={ui.openMobileMenu}
+      class="
+        -ml-2 cursor-pointer p-2 text-gray-500
+        hover:text-gray-700
+        dark:text-neutral-400
+        dark:hover:text-neutral-300
+      "
+      aria-label="Open menu"
     >
-  </a>
-</header>
+      <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 6h16M4 12h16M4 18h16"
+        />
+      </svg>
+    </button>
+    <a href={homeHref} class="ml-3">
+      <span class="text-lg font-semibold uppercase"
+        ><span class="text-gray-900 dark:text-neutral-100">R</span><span
+          class="text-gray-400 dark:text-neutral-500">W</span
+        ></span
+      >
+    </a>
+  </header>
 
-<!-- Mobile Drawer -->
-<MobileDrawer />
-
-<div
-  class="flex min-h-screen flex-col bg-white text-gray-900 md:flex-row dark:bg-neutral-800 dark:text-neutral-100"
->
-  <!-- Navigation Sidebar (Desktop) -->
-  <aside
+  <!-- Mobile Drawer -->
+  <MobileDrawer />
+  <div
     class="
-      sticky top-0 hidden h-screen w-[280px] shrink-0 overflow-y-auto border-r border-gray-200
-      md:block
-      dark:border-neutral-700
+      layout-root flex h-full flex-col bg-white text-gray-900
+      dark:bg-neutral-800 dark:text-neutral-100
     "
   >
-    <div class="px-4 pt-6 pb-4">
-      <a href={homeHref} class="mb-5 block pl-[6px]">
-        <span class="text-xl font-semibold uppercase"
-          ><span class="text-gray-900 dark:text-neutral-100">R</span><span
-            class="text-gray-400 dark:text-neutral-500">W</span
-          ></span
-        >
-      </a>
-      {#if $navigation.error}
-        <div
-          class="
-            mb-4 rounded-sm border border-red-200 bg-red-50 p-3 text-sm text-red-700
-            dark:border-red-800 dark:bg-red-950 dark:text-red-300
-          "
-        >
-          Failed to load navigation: {$navigation.error}
-        </div>
-      {/if}
-      <NavigationSidebar />
-    </div>
-  </aside>
-
-  <!-- Main Content + ToC Container -->
-  <div class="flex-1">
-    <div class="mx-auto max-w-6xl px-4 pt-6 pb-12 md:px-8">
-      {#if $page.data}
-        <Breadcrumbs breadcrumbs={$page.data.breadcrumbs} />
-      {:else if $page.loading}
-        <!-- Reserve breadcrumb space during first load (matches Breadcrumbs mb-6) -->
-        <div class="mb-6"></div>
-      {/if}
-      <div class="flex">
-        <!-- Main Content -->
-        <main class="min-w-0 flex-1">
-          {@render children()}
-        </main>
-
-        <!-- Table of Contents Sidebar - reserve space during loading for consistent skeleton layout -->
-        {#if $page.loading || ($page.data && $page.data.toc.length > 0)}
-          <aside class="hidden w-[240px] shrink-0 lg:block">
-            {#if $page.data && $page.data.toc.length > 0}
-              <div class="sticky top-6 max-h-[calc(100vh-1.5rem)] overflow-y-auto pl-8">
-                <TocSidebar toc={$page.data.toc} />
-              </div>
-            {/if}
-          </aside>
+    <!-- Navigation Sidebar (Desktop) -->
+    <aside
+      class="
+        layout-sidebar hidden h-full w-[280px] shrink-0 overflow-y-auto border-r border-gray-200
+        dark:border-neutral-700
+      "
+    >
+      <div class="px-4 pt-6 pb-4">
+        <a href={homeHref} class="mb-5 block pl-[6px]">
+          <span class="text-xl font-semibold uppercase"
+            ><span class="text-gray-900 dark:text-neutral-100">R</span><span
+              class="text-gray-400 dark:text-neutral-500">W</span
+            ></span
+          >
+        </a>
+        {#if $navigation.error}
+          <div
+            class="
+              mb-4 rounded-sm border border-red-200 bg-red-50 p-3 text-sm text-red-700
+              dark:border-red-800 dark:bg-red-950 dark:text-red-300
+            "
+          >
+            Failed to load navigation: {$navigation.error}
+          </div>
         {/if}
+        <NavigationSidebar />
+      </div>
+    </aside>
+
+    <!-- Main Content + ToC Container -->
+    <div class="min-w-0 flex-1 overflow-y-auto">
+      <div class="layout-content mx-auto max-w-6xl px-4 pt-6 pb-12">
+        {#if $page.data}
+          <Breadcrumbs breadcrumbs={$page.data.breadcrumbs} />
+        {:else if $page.loading}
+          <!-- Reserve breadcrumb space during first load (matches Breadcrumbs mb-6) -->
+          <div class="mb-6"></div>
+        {/if}
+        <div class="flex">
+          <!-- Main Content -->
+          <main class="min-w-0 flex-1">
+            {@render children()}
+          </main>
+
+          <!-- Table of Contents Sidebar - reserve space during loading for consistent skeleton layout -->
+          {#if $page.loading || ($page.data && $page.data.toc.length > 0)}
+            <aside class="layout-toc hidden w-[240px] shrink-0">
+              {#if $page.data && $page.data.toc.length > 0}
+                <div
+                  class="
+                    sticky top-6 max-h-[calc(100cqb-1.5rem)] overflow-y-auto pl-8
+                  "
+                >
+                  <TocSidebar toc={$page.data.toc} />
+                </div>
+              {/if}
+            </aside>
+          {/if}
+        </div>
       </div>
     </div>
   </div>
 </div>
+
+<style>
+  /* Use container queries instead of viewport breakpoints so the layout
+     adapts to actual available space (important when embedded in a host app). */
+  .layout-container {
+    container-type: size;
+    position: relative;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  /* 952px = sidebar (280px) + comfortable content area (~672px) */
+  @container (min-width: 952px) {
+    .layout-mobile-header {
+      display: none;
+    }
+    .layout-root {
+      flex-direction: row;
+    }
+    .layout-sidebar {
+      display: block;
+    }
+    .layout-content {
+      padding-left: 2rem;
+      padding-right: 2rem;
+    }
+  }
+
+  /* 1224px = sidebar (280px) + content (~704px) + TOC (240px) */
+  @container (min-width: 1224px) {
+    .layout-toc {
+      display: block;
+    }
+  }
+</style>

--- a/packages/viewer/src/components/LoadingBar.svelte
+++ b/packages/viewer/src/components/LoadingBar.svelte
@@ -34,7 +34,7 @@
 
 {#if animationState !== "idle"}
   <div
-    class="fixed inset-x-0 top-0 z-50 h-0.5 overflow-hidden"
+    class="absolute inset-x-0 top-0 z-50 h-0.5 overflow-hidden"
     role="progressbar"
     aria-label="Page loading"
     aria-busy={animationState === "running"}

--- a/packages/viewer/src/components/MobileDrawer.svelte
+++ b/packages/viewer/src/components/MobileDrawer.svelte
@@ -30,56 +30,52 @@
   <!-- Backdrop -->
   <button
     type="button"
-    class="fixed inset-0 z-40 cursor-pointer border-none bg-black/50 md:hidden"
+    class="absolute inset-0 z-40 cursor-pointer border-none bg-black/50"
     onclick={ui.closeMobileMenu}
     aria-label="Close menu"
   ></button>
 
   <!-- Drawer -->
-  <aside
-    class="
-      fixed inset-y-0 left-0 z-50 w-[280px] overflow-y-auto bg-white shadow-xl
-      md:hidden
-      dark:bg-neutral-800
-    "
-  >
-    <div class="p-4">
-      <div class="mb-6 flex items-center justify-between">
-        <a href={router.prefixPath("/")} class="block">
-          <span class="text-xl font-semibold text-gray-900 dark:text-neutral-100">RW</span>
-        </a>
-        <button
-          onclick={ui.closeMobileMenu}
-          class="
-            -mr-2 cursor-pointer p-2 text-gray-500
-            hover:text-gray-700
-            dark:text-neutral-400
-            dark:hover:text-neutral-300
-          "
-          aria-label="Close menu"
-        >
-          <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <!-- svelte-ignore component_name_lowercase -->
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
-      </div>
-      {#if $navigation.error}
-        <div
-          class="
-            mb-4 rounded-sm border border-red-200 bg-red-50 p-3 text-sm text-red-700
-            dark:border-red-800 dark:bg-red-950 dark:text-red-300
-          "
-        >
-          Failed to load navigation: {$navigation.error}
+  <aside class="absolute inset-y-0 left-0 z-50 w-[280px]">
+    <div class="h-[100cqb] overflow-y-auto bg-white shadow-xl dark:bg-neutral-800">
+      <div class="p-4">
+        <div class="mb-6 flex items-center justify-between">
+          <a href={router.prefixPath("/")} class="block">
+            <span class="text-xl font-semibold text-gray-900 dark:text-neutral-100">RW</span>
+          </a>
+          <button
+            onclick={ui.closeMobileMenu}
+            class="
+              -mr-2 cursor-pointer p-2 text-gray-500
+              hover:text-gray-700
+              dark:text-neutral-400
+              dark:hover:text-neutral-300
+            "
+            aria-label="Close menu"
+          >
+            <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <!-- svelte-ignore component_name_lowercase -->
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
         </div>
-      {/if}
-      <NavigationSidebar />
+        {#if $navigation.error}
+          <div
+            class="
+              mb-4 rounded-sm border border-red-200 bg-red-50 p-3 text-sm text-red-700
+              dark:border-red-800 dark:bg-red-950 dark:text-red-300
+            "
+          >
+            Failed to load navigation: {$navigation.error}
+          </div>
+        {/if}
+        <NavigationSidebar />
+      </div>
     </div>
   </aside>
 {/if}


### PR DESCRIPTION
## Summary

Replace viewport-based Tailwind breakpoints with CSS container queries in the viewer layout, matching the TechDocs approach. This fixes layout issues when the viewer is embedded in a host application where the available space is narrower than the viewport.

## Changes

- **Container queries for layout breakpoints** — sidebar shows at 952px container width, ToC at 1224px (matching TechDocs breakpoints)
- **Mobile header synced with sidebar** — moved inside the layout container so it toggles with the same container query, eliminating a dead zone where neither sidebar nor mobile header was visible
- **Mobile drawer scoped to container** — changed from `fixed` to `absolute` positioning so it stays within the viewer boundary and doesn't cover the host app UI
- **Mobile drawer height** — uses ResizeObserver on the container (instead of window resize) to keep the drawer panel correctly sized
- **Stale ResizeObserver guard** — MobileDrawer checks if `panelRef` still exists before updating height, preventing errors after unmount
- **Sidebar scrollable** — sidebar now scrolls when the container is shorter than the nav content
- **ToC and loading bar scoped to container** — max-height and position use container dimensions instead of viewport
- **Container ref passed as prop** — MobileDrawer receives the container element as a prop instead of DOM lookup

## Before

- ToC overflowed outside viewport in embedded mode
- Content area too narrow when both sidebar and ToC showed
- Gap between sidebar hiding and mobile header appearing in embedded mode
- Mobile drawer covered entire viewport including host app sidebar/header
- Long navigation lists clipped at the bottom in embedded mode

## After

- Layout adapts to actual available container space
- ToC automatically hides when container is too narrow
- Sidebar and mobile header toggle together at the same breakpoint
- Mobile drawer stays within the viewer area
- All navigation items scrollable and fully visible in embedded mode