### PR TITLE
Fix scroll-to-top on page navigation

### DIFF
--- a/packages/viewer/e2e/navigation.spec.ts
+++ b/packages/viewer/e2e/navigation.spec.ts
@@ -153,6 +153,32 @@ test.describe("Navigation", () => {
     );
   });
 
+  test("scrolls to top when navigating to a different page", async ({ page }) => {
+    // Use a small viewport so page content requires scrolling
+    await page.setViewportSize({ width: 1280, height: 200 });
+    await page.goto("/getting-started/installation");
+
+    // Wait for content to load
+    await expect(page.locator("article")).toContainText("Install via npm");
+
+    // Scroll the content area to the bottom
+    const contentArea = page.locator(".flex-1.overflow-y-auto");
+    await contentArea.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    const scrolledTop = await contentArea.evaluate((el) => el.scrollTop);
+    expect(scrolledTop).toBeGreaterThan(0);
+
+    // Click a different page in the navigation
+    const aside = page.locator("aside").first();
+    await aside.getByRole("link", { name: "Configuration" }).click();
+    await expect(page).toHaveURL(/\/getting-started\/configuration$/);
+
+    // Content area should be scrolled to top
+    const newScrollTop = await contentArea.evaluate((el) => el.scrollTop);
+    expect(newScrollTop).toBe(0);
+  });
+
   test("auto-expands navigation to current page", async ({ page }) => {
     // Navigate directly to a nested page
     await page.goto("/advanced/plugins/custom");

--- a/packages/viewer/src/components/Layout.svelte
+++ b/packages/viewer/src/components/Layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, untrack } from "svelte";
   import type { Snippet } from "svelte";
   import { get } from "svelte/store";
   import { getRwContext } from "../lib/context";
@@ -17,7 +17,10 @@
   let { children }: Props = $props();
 
   const { router, navigation, page, ui } = getRwContext();
+  const routerPath = router.path;
   const homeHref = router.prefixPath("/");
+
+  let contentArea: HTMLElement;
 
   onMount(async () => {
     await navigation.load();
@@ -25,6 +28,14 @@
     const currentPath = get(router.path);
     if (currentPath !== "/") {
       navigation.expandOnlyTo(currentPath);
+    }
+  });
+
+  // Scroll content area to top when navigating to a new page (without hash)
+  $effect(() => {
+    void $routerPath;
+    if (!untrack(() => get(router.hash)) && contentArea) {
+      contentArea.scrollTop = 0;
     }
   });
 
@@ -111,7 +122,7 @@
     </aside>
 
     <!-- Main Content + ToC Container -->
-    <div class="min-w-0 flex-1 overflow-y-auto">
+    <div class="min-w-0 flex-1 overflow-y-auto" bind:this={contentArea}>
       <div class="layout-content mx-auto max-w-6xl px-4 pt-6 pb-12">
         {#if $page.data}
           {#if $page.data.toc.length > 0}

--- a/packages/viewer/src/stores/router.test.ts
+++ b/packages/viewer/src/stores/router.test.ts
@@ -28,7 +28,6 @@ describe("goto", () => {
       configurable: true,
     });
     vi.spyOn(window.history, "pushState").mockImplementation(() => {});
-    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -64,19 +63,8 @@ describe("goto", () => {
     expect(get(router.hash)).toBe("");
   });
 
-  it("scrolls to top when no hash", () => {
-    const router = createRouter();
-    router.goto("/new-path");
-
-    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
-  });
-
-  it("does not scroll when hash is present", () => {
-    const router = createRouter();
-    router.goto("/new-path#section");
-
-    expect(window.scrollTo).not.toHaveBeenCalled();
-  });
+  // Scroll-to-top on navigation is handled by Layout component
+  // which scrolls the actual content container element
 });
 
 describe("initRouter", () => {
@@ -99,7 +87,6 @@ describe("initRouter", () => {
       if (event === "click") clickHandler = handler as (e: MouseEvent) => void;
     });
     vi.spyOn(window.history, "pushState").mockImplementation(() => {});
-    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
 
     router = createRouter();
     cleanup = router.initRouter();
@@ -338,7 +325,6 @@ describe("embedded mode", () => {
       configurable: true,
     });
     vi.spyOn(window.history, "pushState").mockImplementation(() => {});
-    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -389,13 +375,6 @@ describe("embedded mode", () => {
 
     expect(window.history.pushState).not.toHaveBeenCalled();
     expect(get(router.path)).toBe("/guide");
-  });
-
-  it("goto does not scroll to top in embedded mode", () => {
-    const router = createRouter({ embedded: true });
-    router.goto("/guide");
-
-    expect(window.scrollTo).not.toHaveBeenCalled();
   });
 
   it("goto calls onNavigate callback in embedded mode", () => {
@@ -507,7 +486,6 @@ describe("basePath", () => {
       configurable: true,
     });
     vi.spyOn(window.history, "pushState").mockImplementation(() => {});
-    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/packages/viewer/src/stores/router.ts
+++ b/packages/viewer/src/stores/router.ts
@@ -69,11 +69,8 @@ export function createRouter(options?: {
     path.set(url.pathname);
     hash.set(url.hash.slice(1));
 
-    // If there's a hash, scrolling will be handled by the page component
-    // Otherwise scroll to top
-    if (!url.hash && !embedded) {
-      window.scrollTo(0, 0);
-    }
+    // Scroll-to-top on navigation is handled by Layout component
+    // which scrolls the actual content container element
   }
 
   /** Initialize router - call once on app mount. Returns cleanup function.


### PR DESCRIPTION
## Summary

- Scroll to top of the content area (not `window`) when navigating between pages, fixing scroll behavior in embedded mode
- Use `untrack()` to read hash without subscribing, so the effect only fires on path changes — not on TOC clicks
- Add e2e test verifying scroll position resets on navigation

## Test plan

- [x] Unit tests pass (`make test`)
- [x] E2e test covers scroll-to-top on navigation
- [x] Manual: navigate between pages and verify content scrolls to top
- [x] Manual: click TOC links and verify page does NOT scroll to top
- [x] Manual: verify in embedded mode (`--embedded`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)