### PR TITLE
Replace CSS class selectors with ARIA roles in E2E tests

### DIFF
--- a/.claude/rules/playwright.md
+++ b/.claude/rules/playwright.md
@@ -1,0 +1,22 @@
+---
+description: Playwright E2E test conventions
+globs: "**/*.spec.ts"
+---
+
+# Playwright E2E Test Conventions
+
+## Selector Priority Order
+
+Use selectors in this order, from most to least preferred:
+
+1. **Role locators** — `page.getByRole('button', { name: 'Submit' })`, `page.getByRole('navigation', { name: 'Breadcrumb' })`. This includes ARIA roles and names.
+2. **Text/label locators** — `page.getByText()`, `page.getByLabel()`, `page.getByPlaceholder()`
+3. **Test IDs** — `page.getByTestId('viewer-root')` for elements without semantic roles
+4. **CSS/XPath** — last resort, only for structural queries where no semantic alternative exists (e.g., `pre code[class*="language-python"]`)
+
+## Rules
+
+- Never use CSS class names as selectors (e.g., `.layout-sidebar`, `.flex-1`). Classes are styling concerns and break when refactoring.
+- Prefer adding ARIA landmarks (`role`, `aria-label`) to components over adding `data-testid`. This improves both tests and accessibility.
+- Use `data-testid` only for elements that have no meaningful role or text (e.g., layout wrappers, scroll containers).
+- Prefer `locator.evaluate()` over `page.evaluate()` with `querySelector()`. When `page.evaluate()` is unavoidable (e.g., querying multiple elements), use semantic attributes (`aria-label`, `data-testid`) — never CSS classes.

--- a/packages/viewer/e2e/mobile.spec.ts
+++ b/packages/viewer/e2e/mobile.spec.ts
@@ -7,7 +7,7 @@ test.describe("Mobile Navigation", () => {
     await page.goto("/");
 
     // Desktop aside should not be visible on mobile
-    const desktopNav = page.locator("aside").first();
+    const desktopNav = page.getByRole("complementary", { name: "Sidebar" });
     await expect(desktopNav).toBeHidden();
   });
 
@@ -26,7 +26,7 @@ test.describe("Mobile Navigation", () => {
     await page.getByRole("button", { name: "Open menu" }).click();
 
     // Mobile drawer should appear
-    const drawer = page.locator("aside.absolute");
+    const drawer = page.getByRole("complementary", { name: "Mobile navigation" });
     await expect(drawer).toBeVisible();
 
     // Should show navigation items
@@ -40,7 +40,7 @@ test.describe("Mobile Navigation", () => {
     // Open drawer
     await page.getByRole("button", { name: "Open menu" }).click();
 
-    const drawer = page.locator("aside.absolute");
+    const drawer = page.getByRole("complementary", { name: "Mobile navigation" });
     await expect(drawer).toBeVisible();
 
     // Expand Getting Started
@@ -64,7 +64,7 @@ test.describe("Mobile Navigation", () => {
     // Open drawer
     await page.getByRole("button", { name: "Open menu" }).click();
 
-    const drawer = page.locator("aside.absolute");
+    const drawer = page.getByRole("complementary", { name: "Mobile navigation" });
     await expect(drawer).toBeVisible();
 
     // Press escape
@@ -80,7 +80,7 @@ test.describe("Mobile Navigation", () => {
     // Open drawer
     await page.getByRole("button", { name: "Open menu" }).click();
 
-    const drawer = page.locator("aside.absolute");
+    const drawer = page.getByRole("complementary", { name: "Mobile navigation" });
     await expect(drawer).toBeVisible();
 
     // Click outside the drawer on the backdrop overlay
@@ -96,7 +96,7 @@ test.describe("Mobile Navigation", () => {
   test("content is readable on mobile", async ({ page }) => {
     await page.goto("/");
 
-    const article = page.locator("article");
+    const article = page.getByRole("article");
     await expect(article).toBeVisible();
 
     // Content should be readable
@@ -128,7 +128,7 @@ test.describe("Mobile Navigation", () => {
 
     // Open drawer and navigate
     await page.getByRole("button", { name: "Open menu" }).click();
-    const drawer = page.locator("aside.absolute");
+    const drawer = page.getByRole("complementary", { name: "Mobile navigation" });
 
     // Expand Getting Started
     const gsLink = drawer.getByRole("link", { name: "Getting Started" });
@@ -137,15 +137,18 @@ test.describe("Mobile Navigation", () => {
 
     // Verify navigation
     await expect(page).toHaveURL(/\/getting-started\/installation$/);
-    await expect(page.locator("article h1")).toContainText("Installation");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Installation");
 
     // Navigate to another page
     await page.getByRole("button", { name: "Open menu" }).click();
-    await page.locator("aside.absolute").getByRole("link", { name: "API Reference" }).click();
+    await page
+      .getByRole("complementary", { name: "Mobile navigation" })
+      .getByRole("link", { name: "API Reference" })
+      .click();
 
     // Verify second navigation
     await expect(page).toHaveURL(/\/api$/);
-    await expect(page.locator("article h1")).toContainText("API Reference");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("API Reference");
   });
 
   test("drawer panel stays within container bounds when container is shorter than viewport", async ({
@@ -155,26 +158,22 @@ test.describe("Mobile Navigation", () => {
 
     // Simulate embedded mode: constrain the viewer container so it doesn't
     // fill the full viewport (e.g., host app has a footer below).
-    await page.evaluate(() => {
-      const container = document.querySelector(".layout-container") as HTMLElement;
-      container.style.height = "500px";
-      container.style.overflow = "hidden";
+    await page.getByTestId("viewer-root").evaluate((el) => {
+      el.style.height = "500px";
+      el.style.overflow = "hidden";
     });
 
     // Open drawer
     await page.getByRole("button", { name: "Open menu" }).click();
-    const panel = page.locator("aside.absolute > div").first();
+    const drawer = page.getByRole("complementary", { name: "Mobile navigation" });
+    const panel = drawer.getByTestId("mobile-drawer-panel");
     await expect(panel).toBeVisible();
 
     // The panel bottom should not extend past the container bottom
-    const { panelBottom, containerBottom } = await page.evaluate(() => {
-      const p = document.querySelector("aside.absolute > div") as HTMLElement;
-      const c = document.querySelector(".layout-container") as HTMLElement;
-      return {
-        panelBottom: p.getBoundingClientRect().bottom,
-        containerBottom: c.getBoundingClientRect().bottom,
-      };
-    });
+    const [panelBottom, containerBottom] = await Promise.all([
+      panel.evaluate((el) => el.getBoundingClientRect().bottom),
+      page.getByTestId("viewer-root").evaluate((el) => el.getBoundingClientRect().bottom),
+    ]);
 
     expect(panelBottom).toBeLessThanOrEqual(containerBottom);
   });
@@ -185,23 +184,22 @@ test.describe("Mobile Navigation", () => {
     await page.goto("/");
 
     // Constrain the container to simulate embedded mode
-    await page.evaluate(() => {
-      const container = document.querySelector(".layout-container") as HTMLElement;
-      container.style.height = "600px";
-      container.style.overflow = "hidden";
+    await page.getByTestId("viewer-root").evaluate((el) => {
+      el.style.height = "600px";
+      el.style.overflow = "hidden";
     });
 
     // Open drawer and read initial panel height
     await page.getByRole("button", { name: "Open menu" }).click();
-    const panel = page.locator("aside.absolute > div").first();
+    const drawer = page.getByRole("complementary", { name: "Mobile navigation" });
+    const panel = drawer.getByTestId("mobile-drawer-panel");
     await expect(panel).toBeVisible();
 
     const initialHeight = await panel.evaluate((el) => el.getBoundingClientRect().height);
 
     // Shrink the container (NOT the viewport)
-    await page.evaluate(() => {
-      const container = document.querySelector(".layout-container") as HTMLElement;
-      container.style.height = "400px";
+    await page.getByTestId("viewer-root").evaluate((el) => {
+      el.style.height = "400px";
     });
 
     // Panel height should adapt to the smaller container
@@ -215,13 +213,13 @@ test.describe("Mobile Navigation", () => {
     await page.goto("/getting-started/installation");
 
     // Breadcrumbs should be visible
-    const breadcrumbs = page.locator("nav ol");
+    const breadcrumbs = page.getByRole("navigation", { name: "Breadcrumb" });
     await expect(breadcrumbs).toBeVisible();
 
     // Click Home breadcrumb
     await breadcrumbs.getByRole("link", { name: "Home" }).click();
 
     // Should navigate home
-    await expect(page.locator("article")).toContainText("Test Documentation");
+    await expect(page.getByRole("article")).toContainText("Test Documentation");
   });
 });

--- a/packages/viewer/e2e/navigation.spec.ts
+++ b/packages/viewer/e2e/navigation.spec.ts
@@ -5,14 +5,14 @@ test.describe("Navigation", () => {
     await page.goto("/");
 
     // Home page should load and show content
-    await expect(page.locator("article")).toContainText("Test Documentation");
+    await expect(page.getByRole("article")).toContainText("Test Documentation");
   });
 
   test("shows navigation sidebar with top-level sections", async ({ page }) => {
     await page.goto("/");
 
     // Navigation sidebar should be visible
-    const aside = page.locator("aside").first();
+    const aside = page.getByRole("complementary", { name: "Sidebar" });
     await expect(aside).toBeVisible();
 
     // Should show top-level navigation items
@@ -24,7 +24,7 @@ test.describe("Navigation", () => {
   test("expands navigation tree on click", async ({ page }) => {
     await page.goto("/");
 
-    const aside = page.locator("aside").first();
+    const aside = page.getByRole("complementary", { name: "Sidebar" });
 
     // Click the expand button next to Getting Started
     const gettingStartedLink = aside.getByRole("link", { name: "Getting Started" });
@@ -39,7 +39,7 @@ test.describe("Navigation", () => {
   test("collapses expanded navigation on second click", async ({ page }) => {
     await page.goto("/");
 
-    const aside = page.locator("aside").first();
+    const aside = page.getByRole("complementary", { name: "Sidebar" });
 
     // Expand Getting Started section
     const gettingStartedLink = aside.getByRole("link", { name: "Getting Started" });
@@ -59,7 +59,7 @@ test.describe("Navigation", () => {
   test("navigates to page on click", async ({ page }) => {
     await page.goto("/");
 
-    const aside = page.locator("aside").first();
+    const aside = page.getByRole("complementary", { name: "Sidebar" });
 
     // Expand Getting Started section
     const gettingStartedLink = aside.getByRole("link", { name: "Getting Started" });
@@ -73,46 +73,52 @@ test.describe("Navigation", () => {
     await expect(page).toHaveURL(/\/getting-started\/installation$/);
 
     // Page content should load
-    await expect(page.locator("article")).toContainText("Install via npm");
+    await expect(page.getByRole("article")).toContainText("Install via npm");
   });
 
   test("shows breadcrumbs on nested pages", async ({ page }) => {
     await page.goto("/getting-started/installation");
 
     // Breadcrumbs should show path
-    const breadcrumbNav = page.locator("nav ol");
-    await expect(breadcrumbNav).toBeVisible();
+    const breadcrumbs = page.getByRole("navigation", { name: "Breadcrumb" });
+    await expect(breadcrumbs).toBeVisible();
 
     // Check breadcrumb content
-    await expect(breadcrumbNav).toContainText("Home");
-    await expect(breadcrumbNav).toContainText("Getting Started");
+    await expect(breadcrumbs).toContainText("Home");
+    await expect(breadcrumbs).toContainText("Getting Started");
   });
 
   test("breadcrumb links navigate correctly", async ({ page }) => {
     await page.goto("/getting-started/installation");
 
     // Click on Getting Started breadcrumb
-    await page.locator("nav ol").getByRole("link", { name: "Getting Started" }).click();
+    await page
+      .getByRole("navigation", { name: "Breadcrumb" })
+      .getByRole("link", { name: "Getting Started" })
+      .click();
 
     // Should navigate to getting started section
     await expect(page).toHaveURL(/\/getting-started$/);
-    await expect(page.locator("article")).toContainText("This guide will help you get started");
+    await expect(page.getByRole("article")).toContainText("This guide will help you get started");
   });
 
   test("breadcrumb Home link navigates to homepage", async ({ page }) => {
     await page.goto("/getting-started/installation");
 
     // Click on Home breadcrumb
-    await page.locator("nav ol").getByRole("link", { name: "Home" }).click();
+    await page
+      .getByRole("navigation", { name: "Breadcrumb" })
+      .getByRole("link", { name: "Home" })
+      .click();
 
     // Should navigate to home
-    await expect(page.locator("article")).toContainText("Test Documentation");
+    await expect(page.getByRole("article")).toContainText("Test Documentation");
   });
 
   test("highlights active navigation item", async ({ page }) => {
     await page.goto("/");
 
-    const aside = page.locator("aside").first();
+    const aside = page.getByRole("complementary", { name: "Sidebar" });
 
     // Expand and navigate to Installation
     const gettingStartedLink = aside.getByRole("link", { name: "Getting Started" });
@@ -131,7 +137,7 @@ test.describe("Navigation", () => {
   test("deep navigation works (3 levels)", async ({ page }) => {
     await page.goto("/");
 
-    const aside = page.locator("aside").first();
+    const aside = page.getByRole("complementary", { name: "Sidebar" });
 
     // Expand Advanced Topics
     const advancedLink = aside.getByRole("link", { name: "Advanced Topics" });
@@ -148,7 +154,7 @@ test.describe("Navigation", () => {
 
     // Should navigate to deep nested page
     await expect(page).toHaveURL(/\/advanced\/plugins\/custom$/);
-    await expect(page.locator("article")).toContainText(
+    await expect(page.getByRole("article")).toContainText(
       "Step-by-step guide to creating a custom plugin",
     );
   });
@@ -159,10 +165,10 @@ test.describe("Navigation", () => {
     await page.goto("/getting-started/installation");
 
     // Wait for content to load
-    await expect(page.locator("article")).toContainText("Install via npm");
+    await expect(page.getByRole("article")).toContainText("Install via npm");
 
     // Scroll the content area to the bottom
-    const contentArea = page.locator(".flex-1.overflow-y-auto");
+    const contentArea = page.getByTestId("content-scroll-area");
     await contentArea.evaluate((el) => {
       el.scrollTop = el.scrollHeight;
     });
@@ -170,7 +176,7 @@ test.describe("Navigation", () => {
     expect(scrolledTop).toBeGreaterThan(0);
 
     // Click a different page in the navigation
-    const aside = page.locator("aside").first();
+    const aside = page.getByRole("complementary", { name: "Sidebar" });
     await aside.getByRole("link", { name: "Configuration" }).click();
     await expect(page).toHaveURL(/\/getting-started\/configuration$/);
 
@@ -183,7 +189,7 @@ test.describe("Navigation", () => {
     // Navigate directly to a nested page
     await page.goto("/advanced/plugins/custom");
 
-    const aside = page.locator("aside").first();
+    const aside = page.getByRole("complementary", { name: "Sidebar" });
 
     // The path to the current page should be expanded
     await expect(aside.getByRole("link", { name: "Custom Plugin Guide" })).toBeVisible();

--- a/packages/viewer/e2e/page-content.spec.ts
+++ b/packages/viewer/e2e/page-content.spec.ts
@@ -10,12 +10,9 @@ test.describe("ToC sticky behavior", () => {
     const tocHeading = page.getByText("On this page");
     await expect(tocHeading).toBeVisible();
 
-    // Scroll the content area down (the overflow-y-auto wrapper inside .layout-root)
-    await page.evaluate(() => {
-      const scrollContainer = document.querySelector(".layout-root > .overflow-y-auto");
-      if (scrollContainer) {
-        scrollContainer.scrollTop = scrollContainer.scrollHeight;
-      }
+    // Scroll the content area down
+    await page.getByTestId("content-scroll-area").evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
     });
 
     // The TOC should still be visible at the top after scrolling
@@ -30,16 +27,15 @@ test.describe("Embedded Layout", () => {
     await page.goto("/");
 
     // Wait for desktop sidebar to be visible (requires >= 952px container width)
-    const sidebar = page.locator(".layout-sidebar");
+    const sidebar = page.getByRole("complementary", { name: "Sidebar" });
     await expect(sidebar).toBeVisible();
 
     // Simulate embedded mode: constrain the viewer container to be much
     // shorter than the viewport (e.g., host app has a header/footer).
     const containerHeight = 400;
-    await page.evaluate((h) => {
-      const container = document.querySelector(".layout-container") as HTMLElement;
-      container.style.height = `${h}px`;
-      container.style.overflow = "hidden";
+    await page.getByTestId("viewer-root").evaluate((el, h) => {
+      el.style.height = `${h}px`;
+      el.style.overflow = "hidden";
     }, containerHeight);
 
     // The sidebar height should not exceed the container height.
@@ -54,26 +50,24 @@ test.describe("Embedded Layout", () => {
     await page.goto("/");
 
     // Wait for ToC to be visible (requires >= 1224px container width)
-    const tocAside = page.locator(".layout-toc");
+    const tocAside = page.getByRole("complementary", { name: "Page outline" });
     await expect(tocAside).toBeVisible();
 
     // Simulate embedded mode: constrain the viewer container to be much
     // shorter than the viewport (e.g., host app has a header/footer).
     const containerHeight = 400;
-    await page.evaluate((h) => {
-      const container = document.querySelector(".layout-container") as HTMLElement;
-      container.style.height = `${h}px`;
-      container.style.overflow = "hidden";
+    await page.getByTestId("viewer-root").evaluate((el, h) => {
+      el.style.height = `${h}px`;
+      el.style.overflow = "hidden";
     }, containerHeight);
 
     // The ToC sticky wrapper's max-height should not exceed the container
     // height. With the bug, it uses 100vh (~900px) which is much larger
     // than the 400px container.
     await expect(async () => {
-      const maxH = await page.evaluate(() => {
-        const toc = document.querySelector(".layout-toc .sticky") as HTMLElement;
-        return parseFloat(getComputedStyle(toc).maxHeight);
-      });
+      const maxH = await page
+        .getByTestId("toc-sticky-wrapper")
+        .evaluate((el) => parseFloat(getComputedStyle(el).maxHeight));
       expect(maxH).toBeLessThanOrEqual(containerHeight);
     }).toPass({ timeout: 2000 });
   });
@@ -83,7 +77,7 @@ test.describe("Embedded Layout", () => {
   }) => {
     await page.goto("/");
 
-    const sidebar = page.locator(".layout-sidebar");
+    const sidebar = page.getByRole("complementary", { name: "Sidebar" });
     await expect(sidebar).toBeVisible();
 
     // Expand all navigation sections so the sidebar content is tall
@@ -95,8 +89,7 @@ test.describe("Embedded Layout", () => {
     // fixed-height container with overflow hidden. The viewer's own
     // sidebar must remain scrollable within these bounds.
     const containerHeight = 150;
-    await page.evaluate((h) => {
-      const container = document.querySelector(".layout-container") as HTMLElement;
+    await page.getByTestId("viewer-root").evaluate((container, h) => {
       const wrapper = document.createElement("div");
       wrapper.style.height = `${h}px`;
       wrapper.style.overflow = "hidden";
@@ -106,8 +99,7 @@ test.describe("Embedded Layout", () => {
 
     // The sidebar content should overflow and be scrollable
     await expect(async () => {
-      const { isScrollable, canScrollToBottom } = await page.evaluate(() => {
-        const sb = document.querySelector(".layout-sidebar") as HTMLElement;
+      const { isScrollable, canScrollToBottom } = await sidebar.evaluate((sb) => {
         const overflows = sb.scrollHeight > sb.clientHeight;
         sb.scrollTop = sb.scrollHeight;
         return {
@@ -125,11 +117,11 @@ test.describe("Page Content", () => {
   test("renders markdown content with headings", async ({ page }) => {
     await page.goto("/");
 
-    const article = page.locator("article");
+    const article = page.getByRole("article");
     await expect(article).toBeVisible();
 
     // Should have page title (h1)
-    await expect(article.locator("h1")).toContainText("Test Documentation");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Test Documentation");
 
     // Should have section headings (h2)
     await expect(article.locator("#features")).toBeVisible();
@@ -140,7 +132,7 @@ test.describe("Page Content", () => {
   test("renders lists correctly", async ({ page }) => {
     await page.goto("/");
 
-    const article = page.locator("article");
+    const article = page.getByRole("article");
 
     // Should have unordered list with features
     const list = article.locator("ul").first();
@@ -167,7 +159,7 @@ test.describe("Page Content", () => {
   test("renders internal links correctly", async ({ page }) => {
     await page.goto("/");
 
-    const article = page.locator("article");
+    const article = page.getByRole("article");
 
     // Should have internal links
     const gettingStartedLink = article.getByRole("link", { name: "Getting Started" });
@@ -178,13 +170,13 @@ test.describe("Page Content", () => {
 
     // Should navigate to the linked page
     await expect(page).toHaveURL(/\/getting-started$/);
-    await expect(page.locator("article h1")).toContainText("Getting Started");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Getting Started");
   });
 
   test("renders tables correctly", async ({ page }) => {
     await page.goto("/getting-started/configuration");
 
-    const article = page.locator("article");
+    const article = page.getByRole("article");
 
     // Should have a table
     const table = article.locator("table").first();
@@ -201,7 +193,7 @@ test.describe("Page Content", () => {
   test("renders ordered lists correctly", async ({ page }) => {
     await page.goto("/getting-started/configuration");
 
-    const article = page.locator("article");
+    const article = page.getByRole("article");
 
     // Should have ordered list
     const orderedList = article.locator("ol").first();
@@ -245,11 +237,11 @@ test.describe("Page Content", () => {
   test("handles deeply nested pages", async ({ page }) => {
     await page.goto("/advanced/plugins/custom");
 
-    const article = page.locator("article");
+    const article = page.getByRole("article");
     await expect(article).toBeVisible();
 
     // Should show correct content
-    await expect(article.locator("h1")).toContainText("Custom Plugin Guide");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Custom Plugin Guide");
     await expect(article).toContainText("Step 1: Create Plugin Structure");
     await expect(article).toContainText("Step 2: Register Plugin");
   });
@@ -274,7 +266,7 @@ test.describe("Page Content", () => {
   test("internal links with relative paths work", async ({ page }) => {
     await page.goto("/advanced/plugins/custom");
 
-    const article = page.locator("article");
+    const article = page.getByRole("article");
 
     // Click link to installation (uses ../../getting-started/installation.md)
     const installationLink = article.getByRole("link", { name: "Installation" });

--- a/packages/viewer/e2e/toc-popover.spec.ts
+++ b/packages/viewer/e2e/toc-popover.spec.ts
@@ -12,7 +12,7 @@ test.describe("TOC Popover", () => {
     await expect(button).toBeVisible();
 
     // Full TOC sidebar should be hidden at this width
-    const tocSidebar = page.locator(".layout-toc");
+    const tocSidebar = page.getByRole("complementary", { name: "Page outline" });
     await expect(tocSidebar).toBeHidden();
   });
 
@@ -21,7 +21,7 @@ test.describe("TOC Popover", () => {
     await page.setViewportSize({ width: 1400, height: 800 });
     await page.goto("/");
 
-    const tocSidebar = page.locator(".layout-toc");
+    const tocSidebar = page.getByRole("complementary", { name: "Page outline" });
     await expect(tocSidebar).toBeVisible();
 
     const button = page.getByRole("button", { name: "Table of contents" });
@@ -35,7 +35,7 @@ test.describe("TOC Popover", () => {
     await button.click();
 
     // Popover nav should appear with TOC links
-    const popover = page.locator("nav[aria-label='Table of contents']");
+    const popover = page.getByRole("navigation", { name: "Table of contents" });
     await expect(popover).toBeVisible();
 
     // Should contain heading links from the page
@@ -62,7 +62,7 @@ test.describe("TOC Popover", () => {
     const button = page.getByRole("button", { name: "Table of contents" });
     await button.click();
 
-    const popover = page.locator("nav[aria-label='Table of contents']");
+    const popover = page.getByRole("navigation", { name: "Table of contents" });
     await expect(popover).toBeVisible();
 
     await page.keyboard.press("Escape");
@@ -75,11 +75,11 @@ test.describe("TOC Popover", () => {
     const button = page.getByRole("button", { name: "Table of contents" });
     await button.click();
 
-    const popover = page.locator("nav[aria-label='Table of contents']");
+    const popover = page.getByRole("navigation", { name: "Table of contents" });
     await expect(popover).toBeVisible();
 
     // Click on the article content area (outside the popover)
-    await page.locator("article").click();
+    await page.getByRole("article").click();
     await expect(popover).toBeHidden();
   });
 
@@ -89,7 +89,7 @@ test.describe("TOC Popover", () => {
     const button = page.getByRole("button", { name: "Table of contents" });
     await button.click();
 
-    const popover = page.locator("nav[aria-label='Table of contents']");
+    const popover = page.getByRole("navigation", { name: "Table of contents" });
     await popover.getByRole("link", { name: "Code Example" }).click();
 
     // Popover should close after navigation
@@ -105,7 +105,7 @@ test.describe("TOC Popover", () => {
     await page.goto("/getting-started/installation");
 
     // Wait for page content to load
-    await expect(page.locator("article h1")).toContainText("Installation");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Installation");
 
     // Check if TOC popover button is present — it should only render
     // when the page has TOC entries

--- a/packages/viewer/src/components/Breadcrumbs.svelte
+++ b/packages/viewer/src/components/Breadcrumbs.svelte
@@ -11,7 +11,7 @@
   const { router } = getRwContext();
 </script>
 
-<nav class="mb-6 min-h-8">
+<nav aria-label="Breadcrumb" class="mb-6 min-h-8">
   {#if breadcrumbs.length > 0}
     <ol class="flex min-h-8 flex-wrap items-center text-sm text-gray-600 dark:text-neutral-400">
       {#each breadcrumbs as crumb (crumb.path)}

--- a/packages/viewer/src/components/Layout.svelte
+++ b/packages/viewer/src/components/Layout.svelte
@@ -46,7 +46,7 @@
   });
 </script>
 
-<div class="layout-container">
+<div class="layout-container" data-testid="viewer-root">
   <LoadingBar loading={$page.loading} />
   <!-- Mobile Header -->
   <header
@@ -94,6 +94,7 @@
   >
     <!-- Navigation Sidebar (Desktop) -->
     <aside
+      aria-label="Sidebar"
       class="
         layout-sidebar hidden h-full w-[280px] shrink-0 overflow-y-auto border-r border-gray-200
         dark:border-neutral-700
@@ -122,7 +123,11 @@
     </aside>
 
     <!-- Main Content + ToC Container -->
-    <div class="min-w-0 flex-1 overflow-y-auto" bind:this={contentArea}>
+    <div
+      class="min-w-0 flex-1 overflow-y-auto"
+      data-testid="content-scroll-area"
+      bind:this={contentArea}
+    >
       <div class="layout-content mx-auto max-w-6xl px-4 pt-6 pb-12">
         {#if $page.data}
           {#if $page.data.toc.length > 0}
@@ -143,9 +148,12 @@
 
           <!-- Table of Contents Sidebar - reserve space during loading for consistent skeleton layout -->
           {#if $page.loading || ($page.data && $page.data.toc.length > 0)}
-            <aside class="layout-toc hidden w-[240px] shrink-0">
+            <aside aria-label="Page outline" class="layout-toc hidden w-[240px] shrink-0">
               {#if $page.data && $page.data.toc.length > 0}
-                <div class="sticky top-6 max-h-[calc(100cqb-1.5rem)] overflow-y-auto pl-8">
+                <div
+                  class="sticky top-6 max-h-[calc(100cqb-1.5rem)] overflow-y-auto pl-8"
+                  data-testid="toc-sticky-wrapper"
+                >
                   <TocSidebar toc={$page.data.toc} />
                 </div>
               {/if}

--- a/packages/viewer/src/components/MobileDrawer.svelte
+++ b/packages/viewer/src/components/MobileDrawer.svelte
@@ -36,8 +36,11 @@
   ></button>
 
   <!-- Drawer -->
-  <aside class="absolute inset-y-0 left-0 z-50 w-[280px]">
-    <div class="h-[100cqb] overflow-y-auto bg-white shadow-xl dark:bg-neutral-800">
+  <aside aria-label="Mobile navigation" class="absolute inset-y-0 left-0 z-50 w-[280px]">
+    <div
+      data-testid="mobile-drawer-panel"
+      class="h-[100cqb] overflow-y-auto bg-white shadow-xl dark:bg-neutral-800"
+    >
       <div class="p-4">
         <div class="mb-6 flex items-center justify-between">
           <a href={router.prefixPath("/")} class="block">


### PR DESCRIPTION
## Summary
- Add ARIA landmarks (`aria-label`) to layout components: sidebar, mobile drawer, TOC aside, and breadcrumbs nav
- Add `data-testid` attributes (`viewer-root`, `content-scroll-area`) to layout wrappers without semantic roles
- Replace all CSS class selectors (`.layout-sidebar`, `.layout-toc`, `aside.absolute`, etc.) with `getByRole` and `getByTestId` locators
- Add `.claude/rules/playwright.md` to enforce selector priority order for future tests

## Test plan
- [x] All 50 Playwright E2E tests pass
- [x] `make format` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)