### PR TITLE
Collapse breadcrumb overflow into ellipsis dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed sidebar, table of contents, mobile drawer, and loading bar overflowing container bounds when viewer is embedded in a smaller host element
+- Long breadcrumb trails progressively collapse middle items into a "..." dropdown, showing as many items as fit
 
 ## [0.1.11] - 2026-03-04
 

--- a/packages/viewer/e2e/breadcrumb-overflow.spec.ts
+++ b/packages/viewer/e2e/breadcrumb-overflow.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+test.describe("Breadcrumb Overflow", () => {
+  // Deep page with 5 breadcrumbs: Home > Advanced Topics > Plugin Development > Custom Extensions Development > Getting Started With Extensions
+  const deepPage = "/advanced/plugins/custom-extensions/getting-started-guide";
+
+  async function openEllipsisDropdown(page: Page): Promise<{
+    breadcrumbs: Locator;
+    ellipsisButton: Locator;
+  }> {
+    await page.setViewportSize({ width: 400, height: 800 });
+    await page.goto(deepPage);
+
+    const breadcrumbs = page.getByRole("navigation", { name: "Breadcrumb" });
+    const ellipsisButton = breadcrumbs.getByRole("button", {
+      name: "Show hidden breadcrumbs",
+    });
+    await expect(ellipsisButton).toBeVisible();
+    await ellipsisButton.click();
+
+    return { breadcrumbs, ellipsisButton };
+  }
+
+  test("collapses middle breadcrumbs into ellipsis when container is narrow", async ({ page }) => {
+    // Start wide so all breadcrumbs are visible
+    await page.goto(deepPage);
+
+    const breadcrumbs = page.getByRole("navigation", { name: "Breadcrumb" });
+    await expect(breadcrumbs).toBeVisible();
+    await expect(breadcrumbs.getByRole("link", { name: "Home" })).toBeVisible();
+    await expect(
+      breadcrumbs.getByRole("link", { name: "Custom Extensions Development" }),
+    ).toBeVisible();
+
+    // Ellipsis should not be present at full width
+    await expect(breadcrumbs.getByRole("button", { name: "Show hidden breadcrumbs" })).toBeHidden();
+
+    // Shrink viewport to trigger overflow
+    await page.setViewportSize({ width: 400, height: 800 });
+
+    // Ellipsis button should appear
+    const ellipsisButton = breadcrumbs.getByRole("button", {
+      name: "Show hidden breadcrumbs",
+    });
+    await expect(ellipsisButton).toBeVisible();
+
+    // First and last breadcrumbs should always remain visible
+    await expect(breadcrumbs.getByRole("link", { name: "Home" })).toBeVisible();
+    await expect(
+      breadcrumbs.getByRole("link", { name: "Custom Extensions Development" }),
+    ).toBeVisible();
+  });
+
+  test("opens dropdown with hidden breadcrumbs on ellipsis click", async ({ page }) => {
+    await openEllipsisDropdown(page);
+
+    // Dropdown should show hidden middle items
+    const dropdown = page.getByRole("menu", { name: "Hidden breadcrumbs" });
+    await expect(dropdown.getByRole("menuitem", { name: "Advanced Topics" })).toBeVisible();
+  });
+
+  test("navigates when clicking a hidden breadcrumb in dropdown", async ({ page }) => {
+    await openEllipsisDropdown(page);
+
+    // Click the hidden breadcrumb
+    const dropdown = page.getByRole("menu", { name: "Hidden breadcrumbs" });
+    await dropdown.getByRole("menuitem", { name: "Advanced Topics" }).click();
+
+    await expect(page).toHaveURL(/\/advanced$/);
+  });
+
+  test("closes dropdown on Escape key", async ({ page }) => {
+    const { ellipsisButton } = await openEllipsisDropdown(page);
+    await expect(ellipsisButton).toHaveAttribute("aria-expanded", "true");
+
+    await page.keyboard.press("Escape");
+
+    await expect(ellipsisButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("closes dropdown on click outside", async ({ page }) => {
+    const { ellipsisButton } = await openEllipsisDropdown(page);
+    await expect(ellipsisButton).toHaveAttribute("aria-expanded", "true");
+
+    // Click outside
+    await page.getByRole("article").click();
+
+    await expect(ellipsisButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("shows all breadcrumbs without ellipsis when they fit", async ({ page }) => {
+    // 3 short breadcrumbs on a wide viewport should all fit
+    await page.goto("/advanced/plugins/custom");
+
+    const breadcrumbs = page.getByRole("navigation", { name: "Breadcrumb" });
+    await expect(breadcrumbs).toBeVisible();
+
+    await expect(breadcrumbs.getByRole("link", { name: "Home" })).toBeVisible();
+    await expect(breadcrumbs.getByRole("link", { name: "Advanced Topics" })).toBeVisible();
+    await expect(breadcrumbs.getByRole("link", { name: "Plugin Development" })).toBeVisible();
+
+    await expect(breadcrumbs.getByRole("button", { name: "Show hidden breadcrumbs" })).toBeHidden();
+  });
+});

--- a/packages/viewer/e2e/fixtures/docs/advanced/plugins/custom-extensions/getting-started-guide.md
+++ b/packages/viewer/e2e/fixtures/docs/advanced/plugins/custom-extensions/getting-started-guide.md
@@ -1,0 +1,3 @@
+# Getting Started With Extensions
+
+A comprehensive guide to getting started with custom extensions development.

--- a/packages/viewer/e2e/fixtures/docs/advanced/plugins/custom-extensions/index.md
+++ b/packages/viewer/e2e/fixtures/docs/advanced/plugins/custom-extensions/index.md
@@ -1,0 +1,3 @@
+# Custom Extensions Development
+
+Guide to developing custom extensions.

--- a/packages/viewer/src/components/Breadcrumbs.svelte
+++ b/packages/viewer/src/components/Breadcrumbs.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getRwContext } from "../lib/context";
+  import { dismissible } from "../lib/dismissible";
   import type { Breadcrumb } from "../types";
 
   interface Props {
@@ -9,29 +10,231 @@
   let { breadcrumbs }: Props = $props();
 
   const { router } = getRwContext();
+
+  let navEl: HTMLElement | undefined = $state();
+  let olEl: HTMLOListElement | undefined = $state();
+  let wrapperEl: HTMLDivElement | undefined = $state();
+  let open = $state(false);
+  let hiddenCount = $state(0);
+  // Plain variables (not $state) — only read inside imperative measurement functions.
+  // Measurement is two-pass: first pass computes hiddenCount with ellipsisWidth=0,
+  // then a second pass (via $effect) measures the rendered ellipsis and recomputes.
+  // The nav's overflow-hidden clips any momentary extra item during the first frame.
+  let itemWidths: number[] = [];
+  let itemWidthsTotal = 0;
+  let ellipsisWidth = 0;
+  let lastContainerWidth = 0;
+  let rafId = 0;
+
+  let firstCrumb = $derived(breadcrumbs.length > 0 ? breadcrumbs[0] : null);
+  let lastCrumb = $derived(breadcrumbs.length > 1 ? breadcrumbs[breadcrumbs.length - 1] : null);
+  let hiddenCrumbs = $derived(breadcrumbs.length > 2 ? breadcrumbs.slice(1, 1 + hiddenCount) : []);
+  let visibleMiddleCrumbs = $derived(
+    breadcrumbs.length > 2 ? breadcrumbs.slice(1 + hiddenCount, breadcrumbs.length - 1) : [],
+  );
+
+  function close() {
+    open = false;
+  }
+
+  function toggle() {
+    open = !open;
+  }
+
+  $effect(() => dismissible(open, wrapperEl, close));
+
+  function computeHiddenCount(force = false) {
+    if (!navEl || itemWidths.length === 0) return;
+
+    const containerWidth = navEl.clientWidth;
+    if (!force && containerWidth === lastContainerWidth) return;
+    lastContainerWidth = containerWidth;
+
+    if (itemWidthsTotal <= containerWidth) {
+      hiddenCount = 0;
+      return;
+    }
+
+    const middleCount = breadcrumbs.length - 2;
+    let runningTotal = itemWidthsTotal;
+
+    for (let i = 0; i < middleCount; i++) {
+      const middleIndex = i + 1;
+      if (i === 0) {
+        runningTotal = runningTotal - itemWidths[middleIndex] + ellipsisWidth;
+      } else {
+        runningTotal -= itemWidths[middleIndex];
+      }
+
+      if (runningTotal <= containerWidth) {
+        hiddenCount = i + 1;
+        return;
+      }
+    }
+
+    hiddenCount = middleCount;
+  }
+
+  function measureItemWidths() {
+    if (!navEl || !olEl || breadcrumbs.length <= 2) {
+      itemWidths = [];
+      itemWidthsTotal = 0;
+      hiddenCount = 0;
+      return;
+    }
+
+    hiddenCount = 0;
+    ellipsisWidth = 0;
+    lastContainerWidth = 0;
+
+    cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(() => {
+      if (!olEl) return;
+      const children = olEl.children;
+      itemWidths = [];
+      itemWidthsTotal = 0;
+      for (let i = 0; i < children.length; i++) {
+        const w = (children[i] as HTMLElement).offsetWidth;
+        itemWidths.push(w);
+        itemWidthsTotal += w;
+      }
+      computeHiddenCount(true);
+    });
+  }
+
+  function measureEllipsis() {
+    if (!olEl) return;
+    const ellipsisLi = olEl.children[1] as HTMLElement | undefined;
+    if (!ellipsisLi) return;
+    ellipsisWidth = ellipsisLi.offsetWidth;
+    lastContainerWidth = 0;
+    computeHiddenCount(true);
+  }
+
+  $effect(() => {
+    if (hiddenCount > 0 && ellipsisWidth === 0) {
+      requestAnimationFrame(measureEllipsis);
+    }
+  });
+
+  $effect(() => {
+    void breadcrumbs;
+    close();
+    measureItemWidths();
+  });
+
+  $effect(() => {
+    if (!navEl) return;
+
+    const observer = new ResizeObserver(() => {
+      computeHiddenCount();
+    });
+
+    observer.observe(navEl);
+    return () => observer.disconnect();
+  });
 </script>
 
-<nav aria-label="Breadcrumb" class="mb-6 min-h-8">
-  {#if breadcrumbs.length > 0}
-    <ol class="flex min-h-8 flex-wrap items-center text-sm text-gray-600 dark:text-neutral-400">
-      {#each breadcrumbs as crumb (crumb.path)}
-        <li
-          class="
-            after:mx-2 after:text-gray-400 after:content-['/']
-            last:after:content-none
-            dark:after:text-neutral-500
-          "
-        >
+<div class="relative mb-6 min-h-8" bind:this={wrapperEl}>
+  <nav aria-label="Breadcrumb" class="min-h-8 overflow-hidden" bind:this={navEl}>
+    {#if breadcrumbs.length > 0}
+      <ol
+        class="
+          flex min-w-fit min-h-8 items-center text-sm whitespace-nowrap text-gray-600
+          dark:text-neutral-400
+        "
+        bind:this={olEl}
+      >
+        {#if firstCrumb}
+          <li
+            class={breadcrumbs.length > 1
+              ? "after:mx-2 after:text-gray-400 after:content-['/'] dark:after:text-neutral-500"
+              : ""}
+          >
+            <a
+              href={router.prefixPath(firstCrumb.path)}
+              class="hover:text-gray-700 hover:underline dark:hover:text-neutral-300"
+            >
+              {firstCrumb.title}
+            </a>
+          </li>
+        {/if}
+
+        {#if hiddenCount > 0}
+          <li
+            class="after:mx-2 after:text-gray-400 after:content-['/'] dark:after:text-neutral-500"
+          >
+            <button
+              onclick={toggle}
+              class="
+                cursor-pointer
+                hover:text-gray-700 hover:underline
+                dark:hover:text-neutral-300
+              "
+              aria-label="Show hidden breadcrumbs"
+              aria-expanded={open}
+            >
+              &hellip;
+            </button>
+          </li>
+        {/if}
+
+        {#each visibleMiddleCrumbs as crumb (crumb.path)}
+          <li
+            class="after:mx-2 after:text-gray-400 after:content-['/'] dark:after:text-neutral-500"
+          >
+            <a
+              href={router.prefixPath(crumb.path)}
+              class="hover:text-gray-700 hover:underline dark:hover:text-neutral-300"
+            >
+              {crumb.title}
+            </a>
+          </li>
+        {/each}
+
+        {#if lastCrumb}
+          <li>
+            <a
+              href={router.prefixPath(lastCrumb.path)}
+              class="hover:text-gray-700 hover:underline dark:hover:text-neutral-300"
+            >
+              {lastCrumb.title}
+            </a>
+          </li>
+        {/if}
+      </ol>
+    {:else}
+      <div class="h-8"></div>
+    {/if}
+  </nav>
+
+  {#if open && hiddenCount > 0}
+    <ul
+      role="menu"
+      aria-label="Hidden breadcrumbs"
+      class="
+        absolute top-full left-0 z-40 mt-1 min-w-48 overflow-y-auto rounded-lg border
+        border-gray-200 bg-white py-1 shadow-lg
+        dark:border-neutral-600 dark:bg-neutral-800
+      "
+    >
+      {#each hiddenCrumbs as crumb (crumb.path)}
+        <li role="none">
           <a
             href={router.prefixPath(crumb.path)}
-            class="hover:text-gray-700 hover:underline dark:hover:text-neutral-300"
+            role="menuitem"
+            class="
+              block px-3 py-1.5 text-sm text-gray-600
+              hover:bg-gray-100 hover:text-gray-700
+              dark:text-neutral-400
+              dark:hover:bg-neutral-700 dark:hover:text-neutral-300
+            "
+            onclick={close}
           >
             {crumb.title}
           </a>
         </li>
       {/each}
-    </ol>
-  {:else}
-    <div class="h-8"></div>
+    </ul>
   {/if}
-</nav>
+</div>

--- a/packages/viewer/src/components/TocPopover.svelte
+++ b/packages/viewer/src/components/TocPopover.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getRwContext } from "../lib/context";
+  import { dismissible } from "../lib/dismissible";
   import TocSidebar from "./TocSidebar.svelte";
   import type { TocEntry } from "../types";
 
@@ -13,29 +14,7 @@
 
   let popoverEl: HTMLDivElement | undefined = $state();
 
-  function handleClickOutside(event: MouseEvent) {
-    if (popoverEl && !popoverEl.contains(event.target as Node)) {
-      ui.closeTocPopover();
-    }
-  }
-
-  $effect(() => {
-    if ($ui.tocPopoverOpen) {
-      document.addEventListener("click", handleClickOutside, true);
-      return () => document.removeEventListener("click", handleClickOutside, true);
-    }
-  });
-
-  $effect(() => {
-    if (!$ui.tocPopoverOpen) return;
-    function handleKeydown(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        ui.closeTocPopover();
-      }
-    }
-    window.addEventListener("keydown", handleKeydown);
-    return () => window.removeEventListener("keydown", handleKeydown);
-  });
+  $effect(() => dismissible($ui.tocPopoverOpen, popoverEl, ui.closeTocPopover));
 </script>
 
 <div class="relative" bind:this={popoverEl}>

--- a/packages/viewer/src/lib/dismissible.ts
+++ b/packages/viewer/src/lib/dismissible.ts
@@ -1,0 +1,32 @@
+/**
+ * Manages click-outside and Escape key dismissal for popovers/dropdowns.
+ * Registers listeners only while open, and cleans up automatically via $effect return.
+ *
+ * Usage in a Svelte 5 component:
+ *   $effect(() => dismissible(isOpen, containerEl, closeFunction));
+ */
+export function dismissible(
+  isOpen: boolean,
+  containerEl: HTMLElement | undefined,
+  close: () => void,
+): (() => void) | undefined {
+  if (!isOpen) return;
+
+  function handleClick(event: MouseEvent) {
+    if (containerEl && !containerEl.contains(event.target as Node)) {
+      close();
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") close();
+  }
+
+  document.addEventListener("click", handleClick, true);
+  window.addEventListener("keydown", handleKeydown);
+
+  return () => {
+    document.removeEventListener("click", handleClick, true);
+    window.removeEventListener("keydown", handleKeydown);
+  };
+}


### PR DESCRIPTION
## Summary

- Long breadcrumb trails progressively collapse middle items into a "..." dropdown — shows as many items as fit instead of hiding all at once
- First and last breadcrumb items are always visible; hidden middle items shown in a dropdown popover on click
- Uses `ResizeObserver` to detect overflow and recalculate visible items on container resize
- Dropdown has proper ARIA menu roles for accessibility
- Extracted a shared dismissible utility (click-outside + Escape) reused by both breadcrumb dropdown and TOC popover

## Test plan

- [x] Verified at 1440px: all breadcrumbs visible, no ellipsis
- [x] Verified at 1100px: middle items progressively collapse into "...", dropdown shows hidden items on click
- [x] Click outside closes dropdown
- [x] Escape key closes dropdown
- [x] Clicking dropdown link navigates and closes dropdown
- [x] Resizing wider restores collapsed items
- [x] All 56 E2E tests pass (navigation, mobile, breadcrumb overflow, TOC popover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)