### PR TITLE
refactor: replace router onPathChange pub/sub with $effect

### DIFF
--- a/packages/viewer/src/App.svelte
+++ b/packages/viewer/src/App.svelte
@@ -58,11 +58,16 @@
   const liveReload = new LiveReload({ router });
   const ui = new Ui();
 
-  // Side effects on any navigation
-  const unsubPathChange = router.onPathChange(() => {
-    ui.closeMobileMenu();
-    ui.closeTocPopover();
-    navigation.expandOnlyTo(router.path);
+  // Close menus and expand navigation on any path change
+  let previousPath = router.path;
+  $effect(() => {
+    const currentPath = router.path;
+    if (currentPath !== previousPath) {
+      previousPath = currentPath;
+      ui.closeMobileMenu();
+      ui.closeTocPopover();
+      navigation.expandOnlyTo(currentPath);
+    }
   });
 
   // Reload navigation tree when file structure changes
@@ -110,7 +115,6 @@
   onDestroy(() => {
     cleanupRouter?.();
     liveReload.stop();
-    unsubPathChange();
     unsubStructureReload();
   });
 

--- a/packages/viewer/src/state/router.svelte.ts
+++ b/packages/viewer/src/state/router.svelte.ts
@@ -22,7 +22,6 @@ export class Router {
   readonly embedded: boolean;
   private readonly basePath: string;
   private readonly onNavigate?: (path: string) => void;
-  private pathChangeListeners: Set<() => void> = new Set();
 
   constructor(options?: {
     embedded?: boolean;
@@ -43,16 +42,6 @@ export class Router {
     }
   }
 
-  /** Register a callback that fires on path changes. Returns an unsubscribe function. */
-  onPathChange = (callback: () => void): (() => void) => {
-    this.pathChangeListeners.add(callback);
-    return () => this.pathChangeListeners.delete(callback);
-  };
-
-  private notifyPathChange = () => {
-    for (const cb of this.pathChangeListeners) cb();
-  };
-
   /** Prefix an internal path with basePath for use in href attributes. */
   prefixPath = (path: string): string => {
     return this.basePath + path;
@@ -71,7 +60,6 @@ export class Router {
 
     this.path = url.pathname;
     this.hash = url.hash.slice(1);
-    this.notifyPathChange();
   };
 
   /** Initialize router - call once on app mount. Returns cleanup function.
@@ -81,7 +69,6 @@ export class Router {
     const handlePopState = () => {
       this.path = window.location.pathname;
       this.hash = window.location.hash.slice(1);
-      this.notifyPathChange();
     };
 
     const handleClick = (e: MouseEvent) => {

--- a/packages/viewer/src/state/router.test.svelte.ts
+++ b/packages/viewer/src/state/router.test.svelte.ts
@@ -64,27 +64,6 @@ describe("goto", () => {
 
   // Scroll-to-top on navigation is handled by Layout component
   // which scrolls the actual content container element
-
-  it("notifies path change listeners on goto", () => {
-    const router = new Router();
-    const listener = vi.fn();
-    router.onPathChange(listener);
-
-    router.goto("/new-path");
-
-    expect(listener).toHaveBeenCalledOnce();
-  });
-
-  it("does not notify after unsubscribe", () => {
-    const router = new Router();
-    const listener = vi.fn();
-    const unsub = router.onPathChange(listener);
-
-    unsub();
-    router.goto("/new-path");
-
-    expect(listener).not.toHaveBeenCalled();
-  });
 });
 
 describe("initRouter", () => {
@@ -153,21 +132,6 @@ describe("initRouter", () => {
 
       expect(router.path).toBe("/back-path");
       expect(router.hash).toBe("section");
-    });
-
-    it("notifies path change listeners on popstate", () => {
-      const listener = vi.fn();
-      router.onPathChange(listener);
-
-      Object.defineProperty(window, "location", {
-        value: { pathname: "/back-path", hash: "" },
-        writable: true,
-        configurable: true,
-      });
-
-      popstateHandler!({} as PopStateEvent);
-
-      expect(listener).toHaveBeenCalledOnce();
     });
   });
 


### PR DESCRIPTION
## Summary

- Removed manual `pathChangeListeners` pub/sub from `Router` class (`onPathChange`, `notifyPathChange`, listener Set)
- Replaced with a `$effect` in `App.svelte` that reacts to `router.path` changes directly via Svelte 5 reactivity
- Removed 3 tests for the deleted API, all remaining 131 tests pass

The manual listener system was redundant with Svelte 5's reactive `$state` — any `$effect` or `$derived` reading `router.path` already re-runs automatically when it changes. The timing difference (sync callback vs async `$effect`) doesn't matter for these consumers (UI state flips and nav expansion).

## Test plan

- [x] All 131 viewer unit tests pass
- [x] Manual: navigate between pages, verify mobile menu and TOC popover close on navigation
- [x] Manual: verify navigation sidebar expands to current page on link click and browser back/forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)