### PR TITLE
Move breadcrumbs and TOC button into mobile header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Viewer layout now uses container queries instead of viewport breakpoints, adapting to actual available space when embedded in host applications
+- Mobile header now shows breadcrumbs and table of contents button instead of the logo
 
 ### Fixed
 
@@ -22,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Long breadcrumb trails progressively collapse middle items into a "..." dropdown, showing as many items as fit
 - Embed library CSS is now scoped under `[data-rw-viewer]` to prevent style leaks into host pages
 - Embed library no longer bundles font files, reducing CSS bundle size by 96%
+- Clicking a heading in the mobile "On this page" menu no longer scrolls the heading behind the sticky header
+- Scrolling back to top after using mobile table of contents no longer hides the page title behind the mobile header
 
 ## [0.1.11] - 2026-03-04
 

--- a/packages/viewer/e2e/mobile.spec.ts
+++ b/packages/viewer/e2e/mobile.spec.ts
@@ -222,4 +222,67 @@ test.describe("Mobile Navigation", () => {
     // Should navigate home
     await expect(page.getByRole("article")).toContainText("Test Documentation");
   });
+
+  test("shows breadcrumbs in mobile header, not in content area", async ({ page }) => {
+    await page.goto("/getting-started/installation");
+
+    const header = page.locator("header");
+    const headerBreadcrumbs = header.getByRole("navigation", { name: "Breadcrumb" });
+    await expect(headerBreadcrumbs).toBeVisible();
+
+    // Desktop breadcrumbs in the content area should be hidden
+    const desktopBreadcrumbs = page.locator(".layout-desktop-breadcrumbs");
+    await expect(desktopBreadcrumbs).toBeHidden();
+  });
+
+  test("shows TOC button in mobile header", async ({ page }) => {
+    await page.goto("/");
+
+    const header = page.locator("header");
+    const tocButton = header.getByRole("button", { name: "Table of contents" });
+    await expect(tocButton).toBeVisible();
+
+    // Content area TOC popover should be hidden on mobile
+    const contentTocPopover = page.locator(".layout-toc-popover");
+    await expect(contentTocPopover).toBeHidden();
+  });
+
+  test("mobile header TOC button opens popover and navigates to heading", async ({ page }) => {
+    await page.goto("/");
+
+    const header = page.locator("header");
+    const tocButton = header.getByRole("button", { name: "Table of contents" });
+    await tocButton.click();
+
+    // Popover should appear with TOC links
+    const popover = page.getByRole("navigation", { name: "Table of contents" });
+    await expect(popover).toBeVisible();
+
+    // Click a heading link
+    await popover.getByRole("link", { name: "Code Example" }).click();
+
+    // Popover should close after navigation
+    await expect(popover).toBeHidden();
+
+    // Target heading should be visible (not behind the sticky header)
+    const heading = page.locator("#code-example");
+    await expect(heading).toBeInViewport();
+  });
+
+  test("heading is not hidden behind mobile header after TOC navigation", async ({ page }) => {
+    await page.goto("/");
+
+    // Open TOC and click a heading
+    const header = page.locator("header");
+    await header.getByRole("button", { name: "Table of contents" }).click();
+    const popover = page.getByRole("navigation", { name: "Table of contents" });
+    await popover.getByRole("link", { name: "Code Example" }).click();
+
+    // The heading's top should be below the mobile header's bottom
+    const headerBox = await header.boundingBox();
+    const headingBox = await page.locator("#code-example").boundingBox();
+    expect(headerBox).not.toBeNull();
+    expect(headingBox).not.toBeNull();
+    expect(headingBox!.y).toBeGreaterThanOrEqual(headerBox!.y + headerBox!.height - 1);
+  });
 });

--- a/packages/viewer/src/App.svelte
+++ b/packages/viewer/src/App.svelte
@@ -65,7 +65,6 @@
     if (currentPath !== previousPath) {
       previousPath = currentPath;
       ui.closeMobileMenu();
-      ui.closeTocPopover();
       navigation.expandOnlyTo(currentPath);
     }
   });

--- a/packages/viewer/src/components/Breadcrumbs.svelte
+++ b/packages/viewer/src/components/Breadcrumbs.svelte
@@ -5,9 +5,10 @@
 
   interface Props {
     breadcrumbs: Breadcrumb[];
+    compact?: boolean;
   }
 
-  let { breadcrumbs }: Props = $props();
+  let { breadcrumbs, compact = false }: Props = $props();
 
   const { router } = getRwContext();
 
@@ -127,7 +128,13 @@
     if (!navEl) return;
 
     const observer = new ResizeObserver(() => {
-      computeHiddenCount();
+      // Re-measure item widths when transitioning from hidden (display:none)
+      // to visible — all widths will be zero from the initial measurement.
+      if (itemWidthsTotal === 0 && breadcrumbs.length > 2) {
+        measureItemWidths();
+      } else {
+        computeHiddenCount();
+      }
     });
 
     observer.observe(navEl);
@@ -135,7 +142,7 @@
   });
 </script>
 
-<div class="relative mb-6 min-h-8" bind:this={wrapperEl}>
+<div class={compact ? "relative min-h-8" : "relative mb-6 min-h-8"} bind:this={wrapperEl}>
   <nav aria-label="Breadcrumb" class="min-h-8 overflow-hidden" bind:this={navEl}>
     {#if breadcrumbs.length > 0}
       <ol

--- a/packages/viewer/src/components/IconButton.svelte
+++ b/packages/viewer/src/components/IconButton.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    onclick: () => void;
+    "aria-label": string;
+    "aria-expanded"?: boolean;
+    active?: boolean;
+    class?: string;
+    children: Snippet;
+  }
+
+  let {
+    onclick,
+    "aria-label": ariaLabel,
+    "aria-expanded": ariaExpanded,
+    active = false,
+    class: extraClass = "",
+    children,
+  }: Props = $props();
+</script>
+
+<button
+  {onclick}
+  class="
+    flex size-8 cursor-pointer items-center justify-center rounded-sm border border-gray-200
+    bg-white text-gray-500
+    hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700
+    focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-500
+    active:bg-gray-100
+    dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-400
+    dark:hover:border-neutral-500 dark:hover:bg-neutral-700 dark:hover:text-neutral-300
+    dark:active:bg-neutral-600
+    {extraClass}
+  "
+  class:border-gray-300={active}
+  class:dark:border-neutral-500={active}
+  aria-label={ariaLabel}
+  aria-expanded={ariaExpanded}
+>
+  {@render children()}
+</button>

--- a/packages/viewer/src/components/Layout.svelte
+++ b/packages/viewer/src/components/Layout.svelte
@@ -7,6 +7,7 @@
   import TocPopover from "./TocPopover.svelte";
   import Breadcrumbs from "./Breadcrumbs.svelte";
   import MobileDrawer from "./MobileDrawer.svelte";
+  import IconButton from "./IconButton.svelte";
   import LoadingBar from "./LoadingBar.svelte";
 
   interface Props {
@@ -35,36 +36,25 @@
   <header
     class="
       layout-mobile-header sticky top-0 z-30 flex items-center border-b border-gray-200 bg-white
-      px-4 py-3
+      px-4 py-2
       dark:border-neutral-700 dark:bg-neutral-800
     "
   >
-    <button
-      onclick={ui.openMobileMenu}
-      class="
-        -ml-2 cursor-pointer p-2 text-gray-500
-        hover:text-gray-700
-        dark:text-neutral-400
-        dark:hover:text-neutral-300
-      "
-      aria-label="Open menu"
-    >
-      <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M4 6h16M4 12h16M4 18h16"
-        />
+    <IconButton onclick={ui.openMobileMenu} aria-label="Open menu" class="mr-2 shrink-0">
+      <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
       </svg>
-    </button>
-    <a href={homeHref} class="ml-3">
-      <span class="text-lg font-semibold uppercase"
-        ><span class="text-gray-900 dark:text-neutral-100">R</span><span
-          class="text-gray-400 dark:text-neutral-500">W</span
-        ></span
-      >
-    </a>
+    </IconButton>
+    {#if page.data}
+      <div class="min-w-0 flex-1">
+        <Breadcrumbs breadcrumbs={page.data.breadcrumbs} compact />
+      </div>
+      {#if page.data.toc.length > 0}
+        <div class="ml-2 shrink-0">
+          <TocPopover toc={page.data.toc} />
+        </div>
+      {/if}
+    {/if}
   </header>
 
   <!-- Mobile Drawer -->
@@ -118,7 +108,9 @@
               <TocPopover toc={page.data.toc} />
             </div>
           {/if}
-          <Breadcrumbs breadcrumbs={page.data.breadcrumbs} />
+          <div class="layout-desktop-breadcrumbs">
+            <Breadcrumbs breadcrumbs={page.data.breadcrumbs} />
+          </div>
         {:else if page.loading}
           <!-- Reserve breadcrumb space during first load (matches Breadcrumbs nav mb-6 + h-8) -->
           <div class="mb-6 h-8"></div>
@@ -155,7 +147,16 @@
     container-type: size;
     position: relative;
     height: 100%;
-    overflow: hidden;
+    overflow: clip;
+  }
+
+  /* Hide desktop breadcrumbs and content TOC popover on mobile —
+     they live in the mobile header instead. */
+  .layout-desktop-breadcrumbs {
+    display: none;
+  }
+  .layout-toc-popover {
+    display: none;
   }
 
   /* 952px = sidebar (280px) + comfortable content area (~672px) */
@@ -172,6 +173,12 @@
     .layout-content {
       padding-left: 2rem;
       padding-right: 2rem;
+    }
+    .layout-desktop-breadcrumbs {
+      display: block;
+    }
+    .layout-toc-popover {
+      display: block;
     }
   }
 

--- a/packages/viewer/src/components/TocPopover.svelte
+++ b/packages/viewer/src/components/TocPopover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getRwContext } from "../lib/context";
   import { dismissible } from "../lib/dismissible";
+  import IconButton from "./IconButton.svelte";
   import TocSidebar from "./TocSidebar.svelte";
   import type { TocEntry } from "../types";
 
@@ -10,28 +11,30 @@
 
   let { toc }: Props = $props();
 
-  const { ui } = getRwContext();
+  const { router } = getRwContext();
 
+  let open = $state(false);
   let popoverEl: HTMLDivElement | undefined = $state();
 
-  $effect(() => dismissible(ui.tocPopoverOpen, popoverEl, ui.closeTocPopover));
+  function toggle() {
+    open = !open;
+  }
+
+  function close() {
+    open = false;
+  }
+
+  // Close on navigation
+  $effect(() => {
+    void router.path;
+    close();
+  });
+
+  $effect(() => dismissible(open, popoverEl, close));
 </script>
 
 <div class="relative" bind:this={popoverEl}>
-  <button
-    onclick={ui.toggleTocPopover}
-    class="
-      flex size-8 cursor-pointer items-center justify-center rounded-sm border border-gray-200
-      bg-white text-gray-500
-      hover:border-gray-300 hover:text-gray-700
-      dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-400
-      dark:hover:border-neutral-500 dark:hover:text-neutral-300
-    "
-    class:border-gray-300={ui.tocPopoverOpen}
-    class:dark:border-neutral-500={ui.tocPopoverOpen}
-    aria-label="Table of contents"
-    aria-expanded={ui.tocPopoverOpen}
-  >
+  <IconButton onclick={toggle} aria-label="Table of contents" aria-expanded={open} active={open}>
     <svg
       class="size-4"
       fill="currentColor"
@@ -44,9 +47,9 @@
       <circle cx="3" cy="12" r="1.5" stroke="none" />
       <circle cx="3" cy="18" r="1.5" stroke="none" />
     </svg>
-  </button>
+  </IconButton>
 
-  {#if ui.tocPopoverOpen}
+  {#if open}
     <nav
       class="
         absolute top-full right-0 z-40 mt-2 max-h-[min(24rem,calc(100cqb-5rem))] w-64
@@ -55,7 +58,7 @@
       "
       aria-label="Table of contents"
     >
-      <TocSidebar {toc} onnavigate={ui.closeTocPopover} />
+      <TocSidebar {toc} onnavigate={close} />
     </nav>
   {/if}
 </div>

--- a/packages/viewer/src/state/ui.svelte.ts
+++ b/packages/viewer/src/state/ui.svelte.ts
@@ -1,6 +1,5 @@
 export class Ui {
   mobileMenuOpen = $state(false);
-  tocPopoverOpen = $state(false);
 
   openMobileMenu = () => {
     this.mobileMenuOpen = true;
@@ -8,13 +7,5 @@ export class Ui {
 
   closeMobileMenu = () => {
     this.mobileMenuOpen = false;
-  };
-
-  toggleTocPopover = () => {
-    this.tocPopoverOpen = !this.tocPopoverOpen;
-  };
-
-  closeTocPopover = () => {
-    this.tocPopoverOpen = false;
   };
 }

--- a/packages/viewer/src/state/ui.test.svelte.ts
+++ b/packages/viewer/src/state/ui.test.svelte.ts
@@ -45,27 +45,4 @@ describe("ui store", () => {
     expect(ui1.mobileMenuOpen).toBe(true);
     expect(ui2.mobileMenuOpen).toBe(false);
   });
-
-  it("starts with tocPopoverOpen false", () => {
-    const ui = new Ui();
-    expect(ui.tocPopoverOpen).toBe(false);
-  });
-
-  it("toggleTocPopover toggles tocPopoverOpen", () => {
-    const ui = new Ui();
-    ui.toggleTocPopover();
-    expect(ui.tocPopoverOpen).toBe(true);
-
-    ui.toggleTocPopover();
-    expect(ui.tocPopoverOpen).toBe(false);
-  });
-
-  it("closeTocPopover closes tocPopoverOpen", () => {
-    const ui = new Ui();
-    ui.toggleTocPopover();
-    expect(ui.tocPopoverOpen).toBe(true);
-
-    ui.closeTocPopover();
-    expect(ui.tocPopoverOpen).toBe(false);
-  });
 });

--- a/packages/viewer/src/styles/content.css
+++ b/packages/viewer/src/styles/content.css
@@ -1,7 +1,10 @@
 @layer components {
-  /* Offset heading anchors so they align with the sticky TOC button (top-6 = 1.5rem) */
+  /* Offset heading anchors so they don't sit flush against the top of the
+     scroll area.  The content area scrolls independently below the mobile
+     header, so only a small breathing-room offset is needed (matching the
+     floating TOC button position on mid-width viewports: top-6 = 1.5rem). */
   .prose :where(h1, h2, h3, h4, h5, h6)[id] {
-    scroll-margin-top: 1.5rem;
+    scroll-margin-top: var(--scroll-anchor-offset, 1.5rem);
   }
 
   /* Remove backticks from inline code (typography plugin default) */


### PR DESCRIPTION
## Summary

- Replaces the RW logo in the mobile header with breadcrumbs and the TOC popover button, so users get location context and table of contents access without scrolling
- At desktop widths (>=952px), breadcrumbs and TOC popover remain in the content area as before
- Refactors TocPopover to use local open state instead of shared `ui.tocPopoverOpen`, preventing interference between the two instances

## Test plan

- [x] All 27 e2e tests pass (breadcrumb-overflow, mobile, toc-popover)
- [x] All 128 unit tests pass
- [x] Verified at 450px (mobile), 1050px (tablet), 1300px (desktop)
- [x] Manual: verify TOC popover opens/closes correctly from mobile header
- [x] Manual: verify breadcrumb ellipsis dropdown works in mobile header

🤖 Generated with [Claude Code](https://claude.com/claude-code)