### PR TITLE
fix(embed): strip @layer from embed CSS and add font-size reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Embed CSS no longer uses `@layer`, fixing viewer styles being overridden by host app resets (e.g., MUI's CssBaseline)
+- Embedded viewer now sets `font-size: 16px` on its root element, preventing host font-size from breaking em-based typography sizing
+
 ## [0.1.13] - 2026-03-09
 
 ### Added

--- a/packages/viewer/src/app.css
+++ b/packages/viewer/src/app.css
@@ -52,6 +52,7 @@
   }
 
   body {
+    font-size: 16px;
     @apply bg-white text-gray-900 antialiased dark:bg-neutral-800 dark:text-neutral-100;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/packages/viewer/vite.lib.config.ts
+++ b/packages/viewer/vite.lib.config.ts
@@ -22,7 +22,65 @@ function hasScope(selector: Selector): boolean {
   return selector.some((c) => c.type === "attribute" && c.name === "data-rw-viewer");
 }
 
-/** Scope all CSS selectors in emitted assets under [data-rw-viewer]. */
+/**
+ * Strip `@layer <name> { ... }` wrappers, keeping inner rules.
+ * Un-layered CSS beats layered CSS regardless of specificity, which is
+ * needed so the viewer's scoped rules beat host resets like MUI's CssBaseline.
+ *
+ * This is done as string operations instead of lightningcss's Rule visitor because:
+ * - The Rule visitor has a serialization bug with var() values that breaks on
+ *   Tailwind's CSS output (https://github.com/parcel-bundler/lightningcss/issues/1081)
+ * - @layer is a built-in at-rule that cannot be intercepted via customAtRules
+ *   (https://github.com/parcel-bundler/lightningcss/discussions/945)
+ */
+function stripLayers(css: string): string {
+  // NOTE: Brace tracking does not handle braces inside CSS string literals
+  // (e.g., content: "{") or comments. This is fine because the input is
+  // Tailwind-generated CSS which does not contain such patterns.
+  const out: string[] = [];
+  let i = 0;
+  let runStart = 0;
+  const len = css.length;
+
+  while (i < len) {
+    if (css.startsWith("@layer ", i)) {
+      if (runStart < i) out.push(css.slice(runStart, i));
+
+      const braceIdx = css.indexOf("{", i);
+      if (braceIdx === -1) break;
+
+      // @layer declaration (ordering) like `@layer a, b;` — strip entirely
+      const semiIdx = css.indexOf(";", i);
+      if (semiIdx !== -1 && semiIdx < braceIdx) {
+        i = semiIdx + 1;
+        while (i < len && (css[i] === " " || css[i] === "\n" || css[i] === "\r")) i++;
+        runStart = i;
+        continue;
+      }
+      // @layer block — unwrap, keeping inner rules
+      i = braceIdx + 1;
+      const innerStart = i;
+      let depth = 1;
+      while (i < len && depth > 0) {
+        if (css[i] === "{") depth++;
+        else if (css[i] === "}") depth--;
+        if (depth > 0) i++;
+      }
+      out.push(css.slice(innerStart, i));
+      if (i < len) i++;
+      runStart = i;
+      continue;
+    }
+    i++;
+  }
+
+  if (runStart < len) out.push(css.slice(runStart, len));
+  return out.join("");
+}
+
+/**
+ * Scope all CSS selectors under [data-rw-viewer] and strip @layer wrappers.
+ */
 function scopeCss(): Plugin {
   let outDir: string;
   return {
@@ -46,7 +104,7 @@ function scopeCss(): Plugin {
           },
         },
       });
-      await writeFile(cssPath, result.code);
+      await writeFile(cssPath, stripLayers(result.code.toString()));
     },
   };
 }


### PR DESCRIPTION
## Summary

- Strip `@layer` wrappers from the embed CSS build output so the viewer's scoped styles beat un-layered host resets (e.g., MUI's CssBaseline)
- Add `font-size: 16px` on the viewer root to prevent host font-size (MUI's `0.875rem`) from breaking em-based typography sizing

## Context

Un-layered CSS always beats layered CSS in the cascade, regardless of specificity. Tailwind v4 wraps its output in `@layer` blocks, which meant any un-layered host styles (like MUI's CssBaseline in Backstage) would override the viewer. The `stripLayers` function unwraps these blocks while keeping the rules inside. Layer stripping uses string operations due to a lightningcss Rule visitor bug ([#1081](https://github.com/parcel-bundler/lightningcss/issues/1081)).

With this change, the Backstage plugin can delete its `RwDocsViewer.css` overrides entirely — just `import "@rwdocs/viewer/embed.css"` is sufficient.

## Test plan

- [x] `npm run build:lib` produces embed.css with zero `@layer` declarations
- [x] `font-size: 16px` present on `[data-rw-viewer]` in embed.css
- [x] 132 unit tests pass
- [x] Verify in Backstage: viewer renders correctly without `RwDocsViewer.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)