### PR TITLE
fix(diagrams): apply linkPrefix to C4 diagram URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Embed CSS no longer uses `@layer`, fixing viewer styles being overridden by host app resets (e.g., MUI's CssBaseline)
 - Embedded viewer now sets `font-size: 16px` on its root element, preventing host font-size from breaking em-based typography sizing
+- C4 diagram `$link` URLs now include `linkPrefix` when serving from S3 bundles
 
 ## [0.1.13] - 2026-03-09
 

--- a/crates/rw-diagrams/src/lib.rs
+++ b/crates/rw-diagrams/src/lib.rs
@@ -39,6 +39,6 @@ mod output;
 mod plantuml;
 mod processor;
 
-pub use meta_includes::{EntityInfo, MetaIncludeSource};
+pub use meta_includes::{EntityInfo, LinkConfig, MetaIncludeSource};
 pub use output::{DiagramOutput, RenderedDiagramInfo, TagGenerator};
 pub use processor::DiagramProcessor;

--- a/crates/rw-diagrams/src/meta_includes.rs
+++ b/crates/rw-diagrams/src/meta_includes.rs
@@ -11,13 +11,15 @@ use rw_renderer::relative_path;
 /// When provided, diagram link URLs are transformed to match the renderer's
 /// link mode (relative paths, trailing slashes).
 #[derive(Clone, Debug)]
-pub(crate) struct LinkConfig {
+pub struct LinkConfig {
     /// Base path of the page containing the diagram (e.g., "/domains/billing").
     pub base_path: String,
     /// Convert absolute URLs to relative paths.
     pub relative_links: bool,
     /// Append trailing slash to URLs.
     pub trailing_slash: bool,
+    /// Optional prefix to prepend to absolute URLs (e.g., "/rw-docs").
+    pub link_prefix: Option<String>,
 }
 
 /// Entity metadata for generating `PlantUML` C4 includes.
@@ -44,6 +46,11 @@ pub trait MetaIncludeSource: Send + Sync {
     /// * `entity_type` - One of "domain", "system", "service"
     /// * `name` - Normalized name with underscores (e.g., `payment_gateway`)
     fn get_entity(&self, entity_type: &str, name: &str) -> Option<EntityInfo>;
+}
+
+/// Check if a path matches the meta include pattern (e.g., `systems/sys_*.iuml`).
+pub(crate) fn is_meta_include_pattern(path: &str) -> bool {
+    parse_include_path(path).is_some()
 }
 
 /// Parsed components of a meta include path.
@@ -109,9 +116,11 @@ fn escape_description(desc: &str) -> String {
 
 /// Transform a URL according to link configuration.
 ///
-/// Mirrors the logic of `MarkdownRenderer::resolve_href()`:
+/// Mirrors the logic of `MarkdownRenderer::resolve_href()` (without fragment
+/// handling, since C4 `$link` URLs don't contain fragments):
 /// 1. Add trailing slash if enabled
 /// 2. Convert to relative path if enabled
+/// 3. Prepend link prefix to absolute paths (skipped when relative links enabled)
 fn resolve_link(url: &str, config: &LinkConfig) -> String {
     let mut path = url.to_owned();
 
@@ -126,6 +135,12 @@ fn resolve_link(url: &str, config: &LinkConfig) -> String {
             config.base_path.clone()
         };
         relative_path(&from, &path)
+    } else if let Some(prefix) = &config.link_prefix {
+        if path.starts_with('/') {
+            format!("{prefix}{path}")
+        } else {
+            path
+        }
     } else {
         path
     }
@@ -538,6 +553,7 @@ mod tests {
             base_path: "/overview".to_owned(),
             relative_links: false,
             trailing_slash: true,
+            link_prefix: None,
         };
         let result = render_c4_macro("system", "payment_gateway", &entity, false, Some(&config));
         assert!(result.contains("$link=\"/domains/billing/systems/payment-gateway/\""));
@@ -550,6 +566,7 @@ mod tests {
             base_path: "/domains/payments".to_owned(),
             relative_links: true,
             trailing_slash: false,
+            link_prefix: None,
         };
         let result = render_c4_macro("system", "payment_gateway", &entity, false, Some(&config));
         assert!(result.contains("$link=\"billing/systems/payment-gateway\""));
@@ -562,6 +579,7 @@ mod tests {
             base_path: "/domains/payments".to_owned(),
             relative_links: true,
             trailing_slash: true,
+            link_prefix: None,
         };
         let result = render_c4_macro("system", "payment_gateway", &entity, false, Some(&config));
         assert!(result.contains("$link=\"../billing/systems/payment-gateway/\""));
@@ -578,8 +596,48 @@ mod tests {
             base_path: "/overview".to_owned(),
             relative_links: true,
             trailing_slash: true,
+            link_prefix: None,
         };
         let result = render_c4_macro("system", "virtual", &entity, false, Some(&config));
         assert!(!result.contains("$link"));
+    }
+
+    #[test]
+    fn test_render_with_link_prefix() {
+        let entity = system_entity();
+        let config = LinkConfig {
+            base_path: "/overview".to_owned(),
+            relative_links: false,
+            trailing_slash: false,
+            link_prefix: Some("/rw-docs".to_owned()),
+        };
+        let result = render_c4_macro("system", "payment_gateway", &entity, false, Some(&config));
+        assert!(result.contains("$link=\"/rw-docs/domains/billing/systems/payment-gateway\""));
+    }
+
+    #[test]
+    fn test_render_with_link_prefix_and_trailing_slash() {
+        let entity = system_entity();
+        let config = LinkConfig {
+            base_path: "/overview".to_owned(),
+            relative_links: false,
+            trailing_slash: true,
+            link_prefix: Some("/rw-docs".to_owned()),
+        };
+        let result = render_c4_macro("system", "payment_gateway", &entity, false, Some(&config));
+        assert!(result.contains("$link=\"/rw-docs/domains/billing/systems/payment-gateway/\""));
+    }
+
+    #[test]
+    fn test_render_with_link_prefix_skipped_when_relative() {
+        let entity = system_entity();
+        let config = LinkConfig {
+            base_path: "/domains/payments".to_owned(),
+            relative_links: true,
+            trailing_slash: false,
+            link_prefix: Some("/rw-docs".to_owned()),
+        };
+        let result = render_c4_macro("system", "payment_gateway", &entity, false, Some(&config));
+        assert!(result.contains("$link=\"billing/systems/payment-gateway\""));
     }
 }

--- a/crates/rw-diagrams/src/plantuml.rs
+++ b/crates/rw-diagrams/src/plantuml.rs
@@ -9,7 +9,9 @@ use std::path::PathBuf;
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::meta_includes::{LinkConfig, MetaIncludeSource, resolve_meta_include};
+use crate::meta_includes::{
+    LinkConfig, MetaIncludeSource, is_meta_include_pattern, resolve_meta_include,
+};
 
 static INCLUDE_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?m)^(\s*)!include\s+(.+)$").unwrap());
@@ -98,6 +100,12 @@ pub(crate) fn resolve_includes(
         }
 
         if !resolved {
+            // Skip warning for meta-pattern includes (systems/sys_*.iuml etc.)
+            // when no meta source is available — they'll be resolved at request time.
+            if meta_source.is_none() && is_meta_include_pattern(include_path) {
+                continue;
+            }
+
             let searched_paths: Vec<_> = include_dirs
                 .iter()
                 .map(|d| d.join(include_path).display().to_string())
@@ -455,5 +463,21 @@ mod tests {
         let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
         assert!(!result.warnings.is_empty());
         assert!(result.warnings[0].contains("missing.iuml"));
+    }
+
+    #[test]
+    fn test_meta_pattern_include_no_warning_without_meta_source() {
+        let source = "@startuml\n!include systems/sys_payment_gateway.iuml\n@enduml";
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        assert!(
+            result.warnings.is_empty(),
+            "Meta-pattern includes should not warn when no meta source: {:?}",
+            result.warnings
+        );
+        assert!(
+            result
+                .source
+                .contains("!include systems/sys_payment_gateway.iuml")
+        );
     }
 }

--- a/crates/rw-diagrams/src/processor.rs
+++ b/crates/rw-diagrams/src/processor.rs
@@ -226,19 +226,10 @@ impl DiagramProcessor {
     /// Set link configuration for transforming `$link` URLs in C4 macros.
     ///
     /// When set, diagram include URLs are transformed to match the renderer's
-    /// link mode (relative paths, trailing slashes).
+    /// link mode (relative paths, trailing slashes, link prefix).
     #[must_use]
-    pub fn with_link_config(
-        mut self,
-        base_path: String,
-        relative_links: bool,
-        trailing_slash: bool,
-    ) -> Self {
-        self.config.link_config = Some(LinkConfig {
-            base_path,
-            relative_links,
-            trailing_slash,
-        });
+    pub fn with_link_config(mut self, link_config: LinkConfig) -> Self {
+        self.config.link_config = Some(link_config);
         self
     }
 
@@ -355,8 +346,8 @@ impl CodeBlockProcessor for DiagramProcessor {
         let resolved = resolve_includes(
             source,
             &self.config.include_dirs,
-            self.config.meta_include_source.as_deref(),
-            self.config.link_config.as_ref(),
+            None, // Skip meta includes — resolved at request time with link_prefix
+            None,
             0,
             &mut warnings,
         );
@@ -1065,5 +1056,37 @@ mod tests {
             DiagramProcessor::new("https://kroki.io").timeout(Duration::from_millis(100));
 
         assert!(processor.extracted().is_empty());
+    }
+
+    #[test]
+    fn test_bundle_preserves_meta_includes() {
+        use std::sync::Arc;
+
+        use crate::meta_includes::{EntityInfo, MetaIncludeSource};
+
+        struct TestMetaSource;
+        impl MetaIncludeSource for TestMetaSource {
+            fn get_entity(&self, entity_type: &str, name: &str) -> Option<EntityInfo> {
+                if entity_type == "system" && name == "payment_gateway" {
+                    Some(EntityInfo {
+                        title: "Payment Gateway".to_owned(),
+                        description: Some("Processes payments".to_owned()),
+                        url_path: Some("/domains/billing/systems/payment-gateway".to_owned()),
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+
+        let mut processor = DiagramProcessor::new("https://kroki.io")
+            .with_meta_include_source(Arc::new(TestMetaSource));
+        let source = "@startuml\n!include systems/sys_payment_gateway.iuml\n@enduml";
+        let result = processor.bundle("plantuml", source);
+        // Meta includes should NOT be resolved at bundle time
+        assert!(
+            result.is_none(),
+            "bundle() should not resolve meta includes"
+        );
     }
 }

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use rw_cache::{Cache, CacheBucket, CacheBucketExt};
-use rw_diagrams::{DiagramProcessor, MetaIncludeSource};
+use rw_diagrams::{DiagramProcessor, LinkConfig, MetaIncludeSource};
 use rw_renderer::directive::DirectiveProcessor;
 use rw_renderer::{HtmlBackend, MarkdownRenderer, TabsDirective, TocEntry, escape_html};
 use rw_storage::{Metadata, Storage, StorageError, StorageErrorKind};
@@ -315,12 +315,13 @@ impl PageRenderer {
             processor = processor.with_meta_include_source(source);
         }
 
-        if self.relative_links || self.trailing_slash {
-            processor = processor.with_link_config(
-                format!("/{base_path}"),
-                self.relative_links,
-                self.trailing_slash,
-            );
+        if self.relative_links || self.trailing_slash || self.link_prefix.is_some() {
+            processor = processor.with_link_config(LinkConfig {
+                base_path: format!("/{base_path}"),
+                relative_links: self.relative_links,
+                trailing_slash: self.trailing_slash,
+                link_prefix: self.link_prefix.clone(),
+            });
         }
 
         Some(processor)


### PR DESCRIPTION
## Summary

- Add `link_prefix` to `LinkConfig` so C4 diagram `$link` URLs get the prefix prepended (matching `resolve_href()` behavior)
- Skip meta includes at bundle time (`bundle()` passes `None` for `meta_source`), leaving them as `!include` lines to be resolved at request time when `linkPrefix` is known
- Pass `link_prefix` from `PageRenderer` through to `DiagramProcessor`

## Test plan

- [x] Verify diagram C4 `$link` URLs include the prefix when `linkPrefix` is set
- [x] Verify S3-bundled diagrams preserve meta `!include` lines for request-time resolution
- [x] Verify no warnings for meta-pattern includes at bundle time
- [x] Verify existing behavior unchanged when no `linkPrefix` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)