### PR TITLE
feat: add explicit S3 credentials to @rwdocs/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `accessKeyId` and `secretAccessKey` options for `@rwdocs/core` S3 config to pass AWS credentials explicitly instead of relying on environment variables
+
 ## [0.1.14] - 2026-03-10
 
 ### Fixed

--- a/crates/rw-napi/src/lib.rs
+++ b/crates/rw-napi/src/lib.rs
@@ -89,12 +89,21 @@ pub fn create_site(config: SiteConfig) -> Result<RwSite> {
         PageRendererConfig,
         Arc<dyn Cache>,
     ) = if let Some(s3) = config.s3 {
+        if s3.access_key_id.is_some() != s3.secret_access_key.is_some() {
+            return Err(napi::Error::new(
+                napi::Status::InvalidArg,
+                "s3.accessKeyId and s3.secretAccessKey must be provided together",
+            ));
+        }
+
         let s3_config = S3Config {
             bucket: s3.bucket,
             prefix: s3.entity,
             region: s3.region.unwrap_or_else(|| "us-east-1".to_owned()),
             endpoint: s3.endpoint,
             bucket_root_path: s3.bucket_root_path,
+            access_key_id: s3.access_key_id,
+            secret_access_key: s3.secret_access_key,
         };
         let storage = S3Storage::new(s3_config).map_err(|e| {
             napi::Error::from_reason(format!("Failed to create S3 storage: {e}"))

--- a/crates/rw-napi/src/types.rs
+++ b/crates/rw-napi/src/types.rs
@@ -26,6 +26,10 @@ pub struct S3Config {
     pub endpoint: Option<String>,
     #[napi(js_name = "bucketRootPath")]
     pub bucket_root_path: Option<String>,
+    #[napi(js_name = "accessKeyId")]
+    pub access_key_id: Option<String>,
+    #[napi(js_name = "secretAccessKey")]
+    pub secret_access_key: Option<String>,
 }
 
 #[napi(object)]

--- a/crates/rw-storage-s3/src/s3.rs
+++ b/crates/rw-storage-s3/src/s3.rs
@@ -1,9 +1,11 @@
 //! Shared S3 client utilities.
 
+use std::fmt;
+
 use aws_sdk_s3::Client;
 
 /// S3 bucket configuration shared by storage and publisher.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct S3Config {
     /// S3 bucket name.
     pub bucket: String,
@@ -15,6 +17,27 @@ pub struct S3Config {
     pub endpoint: Option<String>,
     /// Optional prefix path within the bucket.
     pub bucket_root_path: Option<String>,
+    /// Optional AWS access key ID for explicit credentials.
+    pub access_key_id: Option<String>,
+    /// Optional AWS secret access key for explicit credentials.
+    pub secret_access_key: Option<String>,
+}
+
+impl fmt::Debug for S3Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("S3Config")
+            .field("bucket", &self.bucket)
+            .field("prefix", &self.prefix)
+            .field("region", &self.region)
+            .field("endpoint", &self.endpoint)
+            .field("bucket_root_path", &self.bucket_root_path)
+            .field("access_key_id", &self.access_key_id)
+            .field(
+                "secret_access_key",
+                &self.secret_access_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 /// Build an S3 client from connection configuration.
@@ -24,6 +47,19 @@ pub async fn build_client(config: &S3Config) -> Client {
 
     if let Some(endpoint) = &config.endpoint {
         loader = loader.endpoint_url(endpoint);
+    }
+
+    if let (Some(access_key_id), Some(secret_access_key)) =
+        (&config.access_key_id, &config.secret_access_key)
+    {
+        let credentials = aws_sdk_s3::config::Credentials::new(
+            access_key_id,
+            secret_access_key,
+            None, // session token
+            None, // expiry
+            "rw", // provider name
+        );
+        loader = loader.credentials_provider(credentials);
     }
 
     let sdk_config = loader.load().await;

--- a/crates/rw-techdocs/src/publisher.rs
+++ b/crates/rw-techdocs/src/publisher.rs
@@ -136,6 +136,8 @@ mod tests {
             endpoint: None,
             region: "us-east-1".to_owned(),
             bucket_root_path: None,
+            access_key_id: None,
+            secret_access_key: None,
         };
         assert_eq!(
             s3::build_key(&config, "index.html"),
@@ -151,6 +153,8 @@ mod tests {
             endpoint: None,
             region: "us-east-1".to_owned(),
             bucket_root_path: Some("techdocs".to_owned()),
+            access_key_id: None,
+            secret_access_key: None,
         };
         assert_eq!(
             s3::build_key(&config, "index.html"),

--- a/crates/rw/src/commands/mod.rs
+++ b/crates/rw/src/commands/mod.rs
@@ -45,6 +45,8 @@ impl S3Args {
             region: self.region,
             endpoint: self.endpoint,
             bucket_root_path: self.bucket_root_path,
+            access_key_id: None,
+            secret_access_key: None,
         }
     }
 }

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -55,6 +55,8 @@ export interface S3Config {
   region?: string
   endpoint?: string
   bucketRootPath?: string
+  accessKeyId?: string
+  secretAccessKey?: string
 }
 
 export interface ScopeInfoResponse {


### PR DESCRIPTION
## Summary

- Added optional `accessKeyId` and `secretAccessKey` fields to `S3Config` in `rw-storage-s3`, enabling explicit AWS credentials instead of relying solely on the SDK default credential chain
- Exposed the new fields in `@rwdocs/core`'s `createSite()` via napi bindings, with validation that both must be provided together
- Updated TypeScript declarations in `packages/core/index.d.ts`

## Test plan

- [ ] Verify `createSite({ s3: { bucket, entity, accessKeyId, secretAccessKey } })` authenticates with explicit credentials
- [ ] Verify omitting both fields still uses the default AWS credential chain
- [ ] Verify providing only one of `accessKeyId`/`secretAccessKey` returns a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)