### PR TITLE
fix(ci): build linux-x64-gnu in manylinux2014 container with smoke tests

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -4,24 +4,24 @@ on:
   workflow_call:
     inputs:
       plan:
-        required: true
+        required: false
         type: string
 
 jobs:
   build-native:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
             os: macos-14
-            build-flags: ""
+            build: npm -w @rwdocs/core run build -- --target aarch64-apple-darwin
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            build-flags: "--use-napi-cross"
+            os: ubuntu-22.04
+            build: npm -w @rwdocs/core run build -- --target x86_64-unknown-linux-gnu
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            use-zigbuild: true
-            build-flags: "-x"
+            build: npm -w @rwdocs/core run build -- --target x86_64-unknown-linux-musl -x
     name: Build native - ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,15 +32,17 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install zig
-        if: ${{ matrix.use-zigbuild }}
-        uses: mlugg/setup-zig@v2
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - uses: mlugg/setup-zig@v2
+        if: ${{ contains(matrix.target, 'musl') }}
         with:
           version: 0.14.1
 
       - name: Install cargo-zigbuild
-        if: ${{ matrix.use-zigbuild }}
         uses: taiki-e/install-action@v2
+        if: ${{ contains(matrix.target, 'musl') }}
         with:
           tool: cargo-zigbuild
 
@@ -53,10 +55,7 @@ jobs:
         run: npm ci
 
       - name: Build native addon
-        run: |
-          npm -w @rwdocs/core run build -- ${{ matrix.build-flags }}
-        env:
-          NAPI_RS_TARGET: ${{ matrix.target }}
+        run: ${{ matrix.build }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -64,6 +63,34 @@ jobs:
           name: npm-native-${{ matrix.target }}
           path: packages/core/*.node
           if-no-files-found: error
+
+  test-native:
+    name: Test native - ${{ matrix.target }}
+    needs: build-native
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            image: node:22-slim
+          - target: x86_64-unknown-linux-musl
+            image: node:22-alpine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-native-${{ matrix.target }}
+          path: packages/core/
+
+      - name: Test binding
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ matrix.image }}
+          options: -v ${{ github.workspace }}:/workspace -w /workspace
+          run: node -e "const c = require('./packages/core'); console.log('OK', Object.keys(c))"
 
   build-viewer:
     name: Build viewer library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,7 @@ jobs:
           name: playwright-report
           path: packages/viewer/playwright-report/
           retention-days: 7
+
+  native-bindings:
+    name: Native bindings
+    uses: ./.github/workflows/build-npm.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `@rwdocs/core` linux-x64-gnu binary segfault on Debian 12 by building on Ubuntu 22.04 (glibc 2.35)
+
 ## [0.1.16] - 2026-03-10
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Build `@rwdocs/core` linux-x64-gnu on `ubuntu-22.04` (glibc 2.35) instead of `ubuntu-latest` (glibc 2.39), fixing the segfault on Debian 12
- Pass `--target` explicitly to napi build — `NAPI_RS_TARGET` env var was never read by `@napi-rs/cli`, so musl builds were silently producing gnu binaries
- Add smoke tests that load native bindings inside target Docker containers (`node:22-slim` for gnu, `node:22-alpine` for musl)
- Run native binding build + smoke tests on every PR via CI, not just during release
- Simplify workflow structure following napi-rs package template patterns

## Context

v0.1.16 attempted to fix glibc compatibility using `--use-napi-cross`, which caused a segfault. The manylinux2014 Docker container approach also failed because `aws-lc-sys` (from S3/TLS deps) requires `-fuse-ld=lld` which the container's GCC doesn't support. Pinning `ubuntu-22.04` is the simplest reliable fix.

The smoke tests would have caught both the original glibc error and the segfault before release.

Supersedes #204.

## Test plan

- [x] All three native builds pass (macOS, linux-gnu, linux-musl)
- [x] Smoke test passes: `node:22-slim` (Debian 12) loads `@rwdocs/core`
- [x] Smoke test passes: `node:22-alpine` loads `@rwdocs/core`
- [ ] Verify on real `node:22-bookworm-slim` Docker image after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)