### PR TITLE
feat: replace basePath/scopePath with sectionRef in mount API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Cross-section link annotation — all internal links now include `data-section-ref` and `data-section-path` attributes on the rendered `<a>` element, enabling host applications to resolve entity page URLs at runtime. Works for both markdown links and diagram links (PlantUML `$link` URLs rendered via Kroki)
+- `resolveSectionRefs` option for `mountRw()` — host applications can provide a resolver that maps section refs to base URLs, enabling cross-entity link navigation in Backstage and other embedded contexts
+- `sectionRef` field on navigation items, scope info, and breadcrumbs in both server API and `@rwdocs/core` responses
 
 ### Changed
 
 - Section metadata field renamed from `type` to `kind` to align with Backstage and Kubernetes conventions — `type` is still accepted in YAML for backward compatibility
-- API responses now use a nested `section: { kind, name }` object (was flat `sectionType` field) on navigation items, scope info, and `@rwdocs/core` responses
+- API responses now use a nested `section: { kind, name }` object (was flat `sectionType`/`sectionKind` fields) and `sectionRef` string (e.g., `domain:default/billing`) on navigation items, scope info, and breadcrumbs
 - Embedded viewer (`mountRw()`) now uses flow layout — content takes its natural height and the parent page controls scrolling, instead of filling a fixed container with internal scroll
+- `mountRw()` API simplified — `basePath` and `scopePath` options replaced by a single `sectionRef` string; the viewer derives path mappings at runtime using `resolveSectionRefs` and the navigation API
 - Navigation API and `@rwdocs/core` `getNavigation()` now accept `sectionRef` (e.g., `"domain:default/billing"`) instead of a filesystem `scope` path — page responses return `sectionRef` instead of `navigationScope`
 
 ### Removed
 
 - `rw techdocs build` and `rw techdocs publish` commands — use native Backstage plugins ([rwdocs/backstage-plugins](https://github.com/rwdocs/backstage-plugins)) instead
-- `linkPrefix` option from `@rwdocs/core` `createSite()` config
+- `linkPrefix` option from `@rwdocs/core` `createSite()` config — use `resolveSectionRefs` in `mountRw()` for link URL construction in embedded mode
 
 ## [0.1.17] - 2026-03-10
 

--- a/crates/rw-site/src/lib.rs
+++ b/crates/rw-site/src/lib.rs
@@ -34,6 +34,7 @@ pub(crate) mod site_state;
 
 pub use page::{BreadcrumbItem, PageRenderResult, PageRendererConfig, RenderError};
 pub use rw_sections::Section;
+pub use rw_sections::Sections;
 pub use site::Site;
 pub use site_state::{NavItem, Navigation, ScopeInfo};
 

--- a/crates/rw-site/src/site.rs
+++ b/crates/rw-site/src/site.rs
@@ -189,6 +189,13 @@ impl Site {
         nav
     }
 
+    /// Get the current sections map.
+    #[must_use]
+    pub fn sections(&self) -> Arc<Sections> {
+        let snapshot = self.reload_if_needed();
+        Arc::clone(&snapshot.sections)
+    }
+
     /// Get the section ref string for the section a page belongs to.
     ///
     /// Reloads site if needed and returns the ref (e.g., `"domain:default/billing"`)

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -40,7 +40,7 @@ export interface PageMetaResponse {
   description?: string
   kind?: string
   vars?: any
-  sectionRef?: string
+  sectionRef: string
 }
 
 export interface PageResponse {

--- a/packages/viewer/src/App.svelte
+++ b/packages/viewer/src/App.svelte
@@ -20,24 +20,27 @@
     embedded?: boolean;
     /** Initial path to navigate to. Defaults to current window path. */
     initialPath?: string;
-    /** Path prefix for link hrefs (e.g. "/rw-docs"). */
-    basePath?: string;
-    /** Called when the user navigates to a new path (embedded mode only). */
-    onNavigate?: (path: string) => void;
+    /** Section ref for this entity (e.g. "system:default/payment-gateway"). */
+    sectionRef?: string;
+    /** Called when the user navigates (embedded mode only). Receives the full href. */
+    onNavigate?: (href: string) => void;
     /** Custom fetch function (e.g. Backstage authenticated fetch). */
     fetchFn?: typeof fetch;
     /** Called during mount with the router's goto function, for external navigation control. */
     exposeGoto?: (goto: (path: string) => void) => void;
+    /** Resolve section refs to base URLs for cross-entity navigation. */
+    resolveSectionRefs?: (refs: string[]) => Promise<Record<string, string>>;
   }
 
   let {
     apiBaseUrl = "/api",
     embedded = false,
     initialPath,
-    basePath,
+    sectionRef,
     onNavigate,
     fetchFn,
     exposeGoto,
+    resolveSectionRefs,
   }: Props = $props();
 
   const apiClient = createApiClient(
@@ -47,7 +50,6 @@
   const router = new Router({
     embedded: untrack(() => embedded),
     initialPath: untrack(() => initialPath),
-    basePath: untrack(() => basePath),
     onNavigate: untrack(() => onNavigate),
   });
 
@@ -55,6 +57,13 @@
   untrack(() => exposeGoto)?.(router.goto);
   const page = new PageState(apiClient, { embedded: untrack(() => embedded) });
   const navigation = new Navigation(apiClient);
+
+  // Configure section ref resolution for nav items and breadcrumbs
+  const resolverFn = untrack(() => resolveSectionRefs);
+  if (resolverFn) {
+    navigation.setSectionRefResolver(resolverFn);
+    page.setSectionRefResolver(resolverFn);
+  }
   const liveReload = new LiveReload({ router });
   const ui = new Ui();
 
@@ -69,16 +78,29 @@
     }
   });
 
+  const currentSectionRef = untrack(() => sectionRef);
+
   // Reload navigation tree when file structure changes
   const unsubStructureReload = liveReload.onStructureReload(async () => {
-    await navigation.load({ bypassCache: true });
+    await navigation.load({
+      bypassCache: true,
+      sectionRef: currentSectionRef,
+    });
     const currentPath = router.path;
     if (currentPath !== "/") {
       navigation.expandOnlyTo(currentPath);
     }
   });
 
-  setRwContext({ apiClient, router, page, navigation, liveReload, ui });
+  setRwContext({
+    apiClient,
+    router,
+    page,
+    navigation,
+    liveReload,
+    ui,
+    resolveSectionRefs: untrack(() => resolveSectionRefs),
+  });
 
   const defaultConfig: ConfigResponse = {
     liveReloadEnabled: false,
@@ -89,14 +111,30 @@
   $effect(() => {
     const cleanupRouter = router.initRouter(rootElement);
 
-    // Load navigation tree, fetch config, start live reload
     (async () => {
-      await navigation.load();
+      // Load navigation — pass sectionRef for scoped loading in embedded mode
+      await navigation.load(currentSectionRef ? { sectionRef: currentSectionRef } : undefined);
+
+      // Extract scopePath from navigation response (embedded mode with sectionRef)
+      if (navigation.tree?.scope?.path) {
+        router.setScopePath(navigation.tree.scope.path);
+      }
+
       const currentPath = router.path;
       if (currentPath !== "/") {
         navigation.expandOnlyTo(currentPath);
       }
 
+      // Set own base URL from the resolved nav tree scope (embedded mode).
+      // resolveNavTree already resolves the scope ref, so we reuse it here
+      // instead of calling the resolver a second time.
+      if (currentSectionRef && navigation.tree?.scope?.href) {
+        router.setBasePath(navigation.tree.scope.href);
+      } else if (embedded) {
+        router.setBasePath("");
+      }
+
+      // Fetch config and start live reload
       let config = defaultConfig;
       try {
         config = await apiClient.fetchConfig();

--- a/packages/viewer/src/components/Breadcrumbs.svelte
+++ b/packages/viewer/src/components/Breadcrumbs.svelte
@@ -159,7 +159,7 @@
               : ""}
           >
             <a
-              href={router.prefixPath(firstCrumb.path)}
+              href={firstCrumb.href ?? router.prefixPath(firstCrumb.path)}
               class="hover:text-gray-700 hover:underline dark:hover:text-neutral-300"
             >
               {firstCrumb.title}
@@ -191,7 +191,7 @@
             class="after:mx-2 after:text-gray-400 after:content-['/'] dark:after:text-neutral-500"
           >
             <a
-              href={router.prefixPath(crumb.path)}
+              href={crumb.href ?? router.prefixPath(crumb.path)}
               class="hover:text-gray-700 hover:underline dark:hover:text-neutral-300"
             >
               {crumb.title}
@@ -202,7 +202,7 @@
         {#if lastCrumb}
           <li>
             <a
-              href={router.prefixPath(lastCrumb.path)}
+              href={lastCrumb.href ?? router.prefixPath(lastCrumb.path)}
               class="hover:text-gray-700 hover:underline dark:hover:text-neutral-300"
             >
               {lastCrumb.title}
@@ -228,7 +228,7 @@
       {#each hiddenCrumbs as crumb (crumb.path)}
         <li role="none">
           <a
-            href={router.prefixPath(crumb.path)}
+            href={crumb.href ?? router.prefixPath(crumb.path)}
             role="menuitem"
             class="
               block px-3 py-1.5 text-sm text-gray-600

--- a/packages/viewer/src/components/NavItem.svelte
+++ b/packages/viewer/src/components/NavItem.svelte
@@ -58,7 +58,7 @@
     {/if}
 
     <a
-      href={router.prefixPath(item.path)}
+      href={item.href ?? router.prefixPath(item.path)}
       class="
         flex-1 rounded-sm p-1.5 text-sm transition-colors
         {isActive

--- a/packages/viewer/src/components/NavigationSidebar.svelte
+++ b/packages/viewer/src/components/NavigationSidebar.svelte
@@ -7,7 +7,7 @@
   let backLink = $derived.by(() => {
     const tree = navigation.tree;
     if (!tree?.scope) return null;
-    return tree.parentScope ?? { path: "/", title: "Home" };
+    return tree.parentScope ?? { path: "/", title: "Home", href: undefined };
   });
 </script>
 
@@ -20,7 +20,7 @@
     {#if navigation.tree.scope && backLink}
       <div class="mb-5">
         <a
-          href={router.prefixPath(backLink.path)}
+          href={backLink.href ?? router.prefixPath(backLink.path)}
           class="
             mb-2 flex items-center text-sm text-gray-500
             hover:text-blue-600

--- a/packages/viewer/src/components/PageContent.svelte
+++ b/packages/viewer/src/components/PageContent.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { getRwContext } from "../lib/context";
   import { initializeTabs } from "../lib/tabs";
+  import { rewriteSectionRefLinks } from "../lib/sectionRefs";
   import { LOADING_SHOW_DELAY } from "../lib/constants";
   import LoadingSkeleton from "./LoadingSkeleton.svelte";
 
-  const { page, router } = getRwContext();
+  const ctx = getRwContext();
+  const { page, router } = ctx;
 
   let articleRef: HTMLElement | undefined = $state();
   let showSkeleton = $state(false);
@@ -26,6 +28,20 @@
     if (page.data && articleRef) {
       return initializeTabs(articleRef);
     }
+  });
+
+  // Rewrite section ref links when content changes (embedded mode with resolver).
+  // If the user navigates away during the async resolver call, Svelte replaces
+  // the DOM element, so stale writes land on a detached node and are harmless.
+  $effect(() => {
+    if (!page.data || !articleRef || !ctx.resolveSectionRefs) return;
+    rewriteSectionRefLinks(articleRef, ctx.resolveSectionRefs, () => router.getBasePath()).catch(
+      (e) => {
+        if (import.meta.env.DEV) {
+          console.warn("[PageContent] Failed to rewrite section ref links:", e);
+        }
+      },
+    );
   });
 
   // Scroll to hash target when content loads or hash changes (skip in embedded mode

--- a/packages/viewer/src/embed.ts
+++ b/packages/viewer/src/embed.ts
@@ -9,15 +9,23 @@ export interface MountOptions {
   embedded?: boolean;
   /** Initial path to navigate to. */
   initialPath?: string;
-  /** Path prefix for link hrefs (e.g. "/rw-docs"). Links will use this prefix so that
-   *  Cmd+Click, right-click → Open in new tab, and hover previews show correct URLs. */
-  basePath?: string;
+  /** Section ref for this entity (e.g. "system:default/payment-gateway").
+   *  Used to load scoped navigation and to resolve the viewer's own base URL via `resolveSectionRefs`. */
+  sectionRef: string;
   /** Custom fetch function (e.g. Backstage authenticated fetch). */
   fetchFn?: typeof fetch;
-  /** Called when the user navigates to a new path (embedded mode only). */
-  onNavigate?: (path: string) => void;
+  /** Called when the user navigates (embedded mode only).
+   *  Receives the full href — for same-section navigation this is basePath + internal path,
+   *  for cross-section navigation this is the resolved catalog URL.
+   *  Use this to drive React Router or equivalent in the host application. */
+  onNavigate?: (href: string) => void;
   /** Color scheme: 'light', 'dark', or 'auto' (OS preference). Defaults to 'auto'. */
   colorScheme?: "light" | "dark" | "auto";
+  /** Resolve section refs to base URLs for cross-entity navigation.
+   *  Called at startup with the viewer's own `sectionRef` to set the base URL, and after
+   *  each page render with unique ref strings (e.g., "system:default/payment-gateway").
+   *  Returns a map of ref → base URL. */
+  resolveSectionRefs?: (refs: string[]) => Promise<Record<string, string>>;
 }
 
 export interface RwInstance {
@@ -73,9 +81,10 @@ export function mountRw(target: HTMLElement, options: MountOptions): RwInstance 
       apiBaseUrl: options.apiBaseUrl,
       embedded: options.embedded ?? true,
       initialPath: options.initialPath,
-      basePath: options.basePath,
+      sectionRef: options.sectionRef,
       fetchFn: options.fetchFn,
       onNavigate: options.onNavigate,
+      resolveSectionRefs: options.resolveSectionRefs,
       exposeGoto: (goto: (path: string) => void) => {
         gotoFn = goto;
       },

--- a/packages/viewer/src/lib/context.ts
+++ b/packages/viewer/src/lib/context.ts
@@ -13,6 +13,7 @@ export interface RwContext {
   navigation: Navigation;
   liveReload: LiveReload;
   ui: Ui;
+  resolveSectionRefs?: (refs: string[]) => Promise<Record<string, string>>;
 }
 
 const RW_KEY = Symbol("rw");

--- a/packages/viewer/src/lib/sectionRefs.test.ts
+++ b/packages/viewer/src/lib/sectionRefs.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  rewriteSectionRefLinks,
+  sectionRefString,
+  resolveNavTree,
+  resolveBreadcrumbs,
+} from "./sectionRefs";
+import type { NavigationTree, Breadcrumb } from "../types";
+
+function createContainer(html: string): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  return el;
+}
+
+describe("sectionRefString", () => {
+  it("builds ref string from section info", () => {
+    expect(sectionRefString({ kind: "domain", name: "billing" })).toBe("domain:default/billing");
+  });
+});
+
+describe("rewriteSectionRefLinks", () => {
+  it("rewrites links with resolved section refs", async () => {
+    const container = createContainer(
+      '<a href="/domains/billing/api" data-section-ref="domain:default/billing" data-section-path="api">Billing API</a>',
+    );
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "/catalog/default/domain/billing/docs",
+    });
+
+    await rewriteSectionRefLinks(container, resolver, () => "");
+
+    const link = container.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("/catalog/default/domain/billing/docs/api");
+    expect(resolver).toHaveBeenCalledWith(["domain:default/billing"]);
+  });
+
+  it("falls back to basePath for unresolved refs", async () => {
+    const container = createContainer(
+      '<a href="/domains/billing" data-section-ref="domain:default/billing" data-section-path="">Billing</a>',
+    );
+    const resolver = vi.fn().mockResolvedValue({});
+
+    await rewriteSectionRefLinks(
+      container,
+      resolver,
+      () => "/catalog/default/system/my-service/docs",
+    );
+
+    const link = container.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("/catalog/default/system/my-service/docs");
+  });
+
+  it("deduplicates refs before calling resolver", async () => {
+    const container = createContainer(
+      '<a href="/a" data-section-ref="domain:default/billing" data-section-path="a">A</a>' +
+        '<a href="/b" data-section-ref="domain:default/billing" data-section-path="b">B</a>',
+    );
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "/catalog/default/domain/billing/docs",
+    });
+
+    await rewriteSectionRefLinks(container, resolver, () => "");
+
+    expect(resolver).toHaveBeenCalledWith(["domain:default/billing"]);
+    const links = container.querySelectorAll("a");
+    expect(links[0].getAttribute("href")).toBe("/catalog/default/domain/billing/docs/a");
+    expect(links[1].getAttribute("href")).toBe("/catalog/default/domain/billing/docs/b");
+  });
+
+  it("handles links with no section-path", async () => {
+    const container = createContainer(
+      '<a href="/domains/billing" data-section-ref="domain:default/billing">Billing</a>',
+    );
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "/catalog/default/domain/billing/docs",
+    });
+
+    await rewriteSectionRefLinks(container, resolver, () => "");
+
+    const link = container.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("/catalog/default/domain/billing/docs");
+  });
+
+  it("skips container with no section-ref links", async () => {
+    const container = createContainer('<a href="/about">About</a>');
+    const resolver = vi.fn();
+
+    await rewriteSectionRefLinks(container, resolver, () => "");
+
+    expect(resolver).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveNavTree", () => {
+  it("rewrites nav item paths with resolved refs", async () => {
+    const tree: NavigationTree = {
+      items: [
+        {
+          title: "Billing",
+          path: "/domains/billing",
+          section: { kind: "domain", name: "billing" },
+          children: [
+            { title: "API", path: "/domains/billing/api" },
+            {
+              title: "Payments",
+              path: "/domains/billing/systems/payments",
+              section: { kind: "system", name: "payments" },
+            },
+          ],
+        },
+        { title: "Guide", path: "/guide" },
+      ],
+    };
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "/catalog/default/domain/billing/docs",
+      "system:default/payments": "/catalog/default/system/payments/docs",
+    });
+
+    const result = await resolveNavTree(tree, resolver);
+
+    expect(result.items[0].href).toBe("/catalog/default/domain/billing/docs");
+    expect(result.items[0].path).toBe("/domains/billing"); // path preserved for keying/active state
+    expect(result.items[0].children![0].href).toBeUndefined(); // no section, no href
+    expect(result.items[0].children![0].path).toBe("/domains/billing/api");
+    expect(result.items[0].children![1].href).toBe("/catalog/default/system/payments/docs");
+    expect(result.items[1].href).toBeUndefined(); // no section, no href
+    expect(result.items[1].path).toBe("/guide");
+  });
+
+  it("rewrites scope and parentScope paths", async () => {
+    const tree: NavigationTree = {
+      items: [],
+      scope: {
+        path: "/domains/billing",
+        title: "Billing",
+        section: { kind: "domain", name: "billing" },
+      },
+      parentScope: {
+        path: "/",
+        title: "Home",
+        section: { kind: "root", name: "home" },
+      },
+    };
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "/catalog/default/domain/billing/docs",
+    });
+
+    const result = await resolveNavTree(tree, resolver);
+
+    expect(result.scope!.href).toBe("/catalog/default/domain/billing/docs");
+    expect(result.scope!.path).toBe("/domains/billing"); // path preserved
+    expect(result.parentScope!.href).toBeUndefined(); // unresolved, no href
+    expect(result.parentScope!.path).toBe("/"); // path preserved
+  });
+
+  it("skips resolver when no sections exist", async () => {
+    const tree: NavigationTree = {
+      items: [{ title: "Guide", path: "/guide" }],
+    };
+    const resolver = vi.fn();
+
+    const result = await resolveNavTree(tree, resolver);
+
+    expect(resolver).not.toHaveBeenCalled();
+    expect(result).toBe(tree); // same reference, no changes
+  });
+
+  it("synthesizes root parentScope for top-level sections", async () => {
+    const tree: NavigationTree = {
+      items: [{ title: "Overview", path: "/domains/billing/overview" }],
+      scope: {
+        path: "/domains/billing",
+        title: "Billing",
+        section: { kind: "domain", name: "billing" },
+      },
+      // No parentScope — this is a top-level section
+    };
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "/catalog/default/domain/billing/docs",
+      "section:default/root": "/catalog/default/system/my-service/docs",
+    });
+
+    const result = await resolveNavTree(tree, resolver);
+
+    expect(result.parentScope).toBeDefined();
+    expect(result.parentScope!.title).toBe("Home");
+    expect(result.parentScope!.href).toBe("/catalog/default/system/my-service/docs");
+    expect(resolver).toHaveBeenCalledWith(expect.arrayContaining(["section:default/root"]));
+  });
+
+  it("keeps original path for unresolved nav refs", async () => {
+    const tree: NavigationTree = {
+      items: [
+        {
+          title: "Billing",
+          path: "/domains/billing",
+          section: { kind: "domain", name: "billing" },
+        },
+      ],
+    };
+    const resolver = vi.fn().mockResolvedValue({});
+
+    const result = await resolveNavTree(tree, resolver);
+
+    expect(result.items[0].href).toBeUndefined(); // unresolved, no href
+    expect(result.items[0].path).toBe("/domains/billing"); // path preserved
+  });
+});
+
+describe("resolveBreadcrumbs", () => {
+  it("sets href on breadcrumbs with resolved refs", async () => {
+    const breadcrumbs: Breadcrumb[] = [
+      { title: "Home", path: "/" },
+      { title: "Billing", path: "/domains/billing", section: { kind: "domain", name: "billing" } },
+      { title: "API", path: "/domains/billing/api" },
+    ];
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "/catalog/default/domain/billing/docs",
+    });
+
+    const result = await resolveBreadcrumbs(breadcrumbs, resolver);
+
+    expect(result[0].path).toBe("/"); // no section, unchanged
+    expect(result[0].href).toBeUndefined();
+    expect(result[1].href).toBe("/catalog/default/domain/billing/docs");
+    expect(result[1].path).toBe("/domains/billing"); // path preserved
+    expect(result[2].path).toBe("/domains/billing/api"); // no section, unchanged
+    expect(result[2].href).toBeUndefined();
+  });
+
+  it("skips resolver when no breadcrumbs have sections", async () => {
+    const breadcrumbs: Breadcrumb[] = [
+      { title: "Home", path: "/" },
+      { title: "Guide", path: "/guide" },
+    ];
+    const resolver = vi.fn();
+
+    const result = await resolveBreadcrumbs(breadcrumbs, resolver);
+
+    expect(resolver).not.toHaveBeenCalled();
+    expect(result).toBe(breadcrumbs);
+  });
+});

--- a/packages/viewer/src/lib/sectionRefs.ts
+++ b/packages/viewer/src/lib/sectionRefs.ts
@@ -1,0 +1,136 @@
+import type { SectionInfo, ScopeInfo, NavItem, Breadcrumb, NavigationTree } from "../types";
+
+export type SectionRefResolver = (refs: string[]) => Promise<Record<string, string>>;
+
+/**
+ * Build a ref string from section info (e.g., "domain:default/billing").
+ * Namespace is always "default" — the backend does not expose namespace yet.
+ */
+export function sectionRefString(section: SectionInfo): string {
+  return `${section.kind}:default/${section.name}`;
+}
+
+/**
+ * Rewrite href attributes on links with data-section-ref in rendered HTML content.
+ *
+ * Collects unique refs, calls the resolver once, then rewrites each link's
+ * href to the resolved base URL + section path.
+ */
+export async function rewriteSectionRefLinks(
+  container: HTMLElement,
+  resolver: SectionRefResolver,
+  getBasePath: () => string,
+): Promise<void> {
+  const links = container.querySelectorAll<HTMLElement>("a[data-section-ref]");
+  if (links.length === 0) return;
+
+  const refsSet = new Set<string>();
+  for (const link of links) {
+    refsSet.add(link.getAttribute("data-section-ref")!);
+  }
+
+  const resolved = await resolver([...refsSet]);
+
+  for (const link of links) {
+    const ref = link.getAttribute("data-section-ref")!;
+    const sectionPath = link.getAttribute("data-section-path") ?? "";
+    const baseUrl = resolved[ref] ?? getBasePath();
+    link.setAttribute("href", sectionPath ? `${baseUrl}/${sectionPath}` : baseUrl);
+  }
+}
+
+/** Collect all unique section ref strings from a navigation tree. */
+function collectNavRefs(items: NavItem[]): Set<string> {
+  const refs = new Set<string>();
+  for (const item of items) {
+    if (item.section) {
+      refs.add(sectionRefString(item.section));
+    }
+    if (item.children) {
+      for (const ref of collectNavRefs(item.children)) {
+        refs.add(ref);
+      }
+    }
+  }
+  return refs;
+}
+
+/** Rewrite paths in a navigation tree using resolved section refs. */
+function rewriteNavItems(items: NavItem[], resolved: Record<string, string>): NavItem[] {
+  return items.map((item) => {
+    const ref = item.section ? sectionRefString(item.section) : undefined;
+    const href = ref ? resolved[ref] : undefined;
+    return {
+      ...item,
+      href,
+      children: item.children ? rewriteNavItems(item.children, resolved) : undefined,
+    };
+  });
+}
+
+/**
+ * Resolve section refs in a navigation tree and rewrite all paths.
+ * Returns a new tree with rewritten paths.
+ */
+export async function resolveNavTree(
+  tree: NavigationTree,
+  resolver: SectionRefResolver,
+): Promise<NavigationTree> {
+  // For top-level sections (scope exists but no parentScope), synthesize a
+  // root parentScope so the resolver can map it to the source entity URL.
+  const effectiveParentScope: ScopeInfo | undefined =
+    tree.parentScope ??
+    (tree.scope
+      ? { path: "/", title: "Home", section: { kind: "section", name: "root" } }
+      : undefined);
+
+  const refs = collectNavRefs(tree.items);
+  const scopeRef = tree.scope ? sectionRefString(tree.scope.section) : undefined;
+  const parentScopeRef = effectiveParentScope
+    ? sectionRefString(effectiveParentScope.section)
+    : undefined;
+  if (scopeRef) refs.add(scopeRef);
+  if (parentScopeRef) refs.add(parentScopeRef);
+  if (refs.size === 0) return tree;
+
+  const resolved = await resolver([...refs]);
+
+  return {
+    items: rewriteNavItems(tree.items, resolved),
+    scope: tree.scope
+      ? {
+          ...tree.scope,
+          href: resolved[scopeRef!],
+        }
+      : undefined,
+    parentScope: effectiveParentScope
+      ? {
+          ...effectiveParentScope,
+          href: resolved[parentScopeRef!],
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Resolve section refs in breadcrumbs and rewrite paths.
+ * Returns new breadcrumb array with rewritten paths.
+ */
+export async function resolveBreadcrumbs(
+  breadcrumbs: Breadcrumb[],
+  resolver: SectionRefResolver,
+): Promise<Breadcrumb[]> {
+  const refs = new Set<string>();
+  for (const bc of breadcrumbs) {
+    if (bc.section) refs.add(sectionRefString(bc.section));
+  }
+  if (refs.size === 0) return breadcrumbs;
+
+  const resolved = await resolver([...refs]);
+
+  return breadcrumbs.map((bc) => {
+    if (!bc.section) return bc;
+    const ref = sectionRefString(bc.section);
+    return { ...bc, href: resolved[ref] };
+  });
+}

--- a/packages/viewer/src/pages/Home.svelte
+++ b/packages/viewer/src/pages/Home.svelte
@@ -3,11 +3,15 @@
   import { watchPageSection } from "../lib/sectionWatcher.svelte";
   import PageContent from "../components/PageContent.svelte";
 
-  const { page, navigation, liveReload } = getRwContext();
+  const { router, page, navigation, liveReload } = getRwContext();
 
   watchPageSection(page, navigation);
 
   $effect(() => {
+    // In embedded mode, wait for scope/basePath resolution before loading.
+    // The path may change once the section scope is known (e.g., "/" → "/domains/billing"),
+    // which would unmount Home and mount Page instead — avoid a wasted fetch.
+    if (router.embedded && !router.resolved) return;
     page.load("");
     return liveReload.onReload(() => {
       page.load("", { bypassCache: true });

--- a/packages/viewer/src/pages/Page.svelte
+++ b/packages/viewer/src/pages/Page.svelte
@@ -6,8 +6,12 @@
 
   const { router, page, navigation, liveReload } = getRwContext();
 
-  // Load page when path changes
+  // Load page when path changes.
+  // In embedded mode, wait for scope/basePath resolution — the initial path
+  // may not yet include the section prefix, so loading now would fetch the
+  // wrong page.
   $effect(() => {
+    if (router.embedded && !router.resolved) return;
     const currentPath = router.path;
     const apiPath = extractDocPath(currentPath);
     page.load(apiPath);

--- a/packages/viewer/src/state/navigation.svelte.ts
+++ b/packages/viewer/src/state/navigation.svelte.ts
@@ -1,5 +1,7 @@
 import type { NavigationTree, NavItem } from "../types";
 import type { ApiClient } from "../api/client";
+import type { SectionRefResolver } from "../lib/sectionRefs";
+import { resolveNavTree } from "../lib/sectionRefs";
 
 /** Collect all paths with children from the navigation tree */
 export function collectParentPaths(items: NavItem[]): string[] {
@@ -36,13 +38,19 @@ export class Navigation {
   private apiClient: ApiClient;
   private currentController: AbortController | null = null;
   private activePath: string | null = null;
+  private sectionRefResolver?: SectionRefResolver;
 
   constructor(apiClient: ApiClient) {
     this.apiClient = apiClient;
   }
 
-  load = async (options?: { bypassCache?: boolean }): Promise<void> => {
-    return this.loadSection(undefined, options);
+  /** Configure section ref resolution for nav item path rewriting. */
+  setSectionRefResolver(resolver: SectionRefResolver) {
+    this.sectionRefResolver = resolver;
+  }
+
+  load = async (options?: { bypassCache?: boolean; sectionRef?: string }): Promise<void> => {
+    return this.loadSection(options?.sectionRef, options);
   };
 
   loadSection = async (
@@ -64,8 +72,13 @@ export class Navigation {
       });
       if (controller.signal.aborted) return;
 
-      const allParentPaths = collectParentPaths(tree.items);
-      this.tree = tree;
+      const resolvedTree = this.sectionRefResolver
+        ? await resolveNavTree(tree, this.sectionRefResolver)
+        : tree;
+      if (controller.signal.aborted) return;
+
+      const allParentPaths = collectParentPaths(resolvedTree.items);
+      this.tree = resolvedTree;
       this.loading = false;
       this.collapsed = new Set(allParentPaths);
       this.currentSectionRef = sectionRef;

--- a/packages/viewer/src/state/navigation.test.svelte.ts
+++ b/packages/viewer/src/state/navigation.test.svelte.ts
@@ -145,6 +145,18 @@ describe("navigation store", () => {
       );
     });
 
+    it("forwards sectionRef to fetchNavigation", async () => {
+      mockFetchNavigation.mockResolvedValue(mockTree);
+      const navigation = new Navigation(mockApiClient);
+
+      await navigation.load({ sectionRef: "domain:default/billing" });
+
+      expect(mockFetchNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({ sectionRef: "domain:default/billing" }),
+      );
+      expect(navigation.currentSectionRef).toBe("domain:default/billing");
+    });
+
     it("aborts previous request when new load starts", async () => {
       let firstResolve: (value: NavigationTree) => void;
       const firstPromise = new Promise<NavigationTree>((resolve) => {

--- a/packages/viewer/src/state/page.svelte.ts
+++ b/packages/viewer/src/state/page.svelte.ts
@@ -1,6 +1,8 @@
 import type { PageResponse } from "../types";
 import type { ApiClient } from "../api/client";
 import { NotFoundError } from "../api/client";
+import type { SectionRefResolver } from "../lib/sectionRefs";
+import { resolveBreadcrumbs } from "../lib/sectionRefs";
 
 export class Page {
   data = $state.raw<PageResponse | null>(null);
@@ -11,10 +13,16 @@ export class Page {
   private apiClient: ApiClient;
   private embedded: boolean;
   private abortController: AbortController | null = null;
+  private sectionRefResolver?: SectionRefResolver;
 
   constructor(apiClient: ApiClient, options?: { embedded?: boolean }) {
     this.apiClient = apiClient;
     this.embedded = options?.embedded ?? false;
+  }
+
+  /** Configure section ref resolution for breadcrumb path rewriting. */
+  setSectionRefResolver(resolver: SectionRefResolver) {
+    this.sectionRefResolver = resolver;
   }
 
   load = async (path: string, options?: { bypassCache?: boolean; silent?: boolean }) => {
@@ -22,6 +30,7 @@ export class Page {
       this.abortController.abort();
     }
     this.abortController = new AbortController();
+    const signal = this.abortController.signal;
 
     if (!options?.silent) {
       this.loading = true;
@@ -30,10 +39,18 @@ export class Page {
     }
 
     try {
-      const data = await this.apiClient.fetchPage(path, {
+      let data = await this.apiClient.fetchPage(path, {
         bypassCache: options?.bypassCache,
-        signal: this.abortController.signal,
+        signal,
       });
+      if (signal.aborted) return;
+      if (this.sectionRefResolver) {
+        data = {
+          ...data,
+          breadcrumbs: await resolveBreadcrumbs(data.breadcrumbs, this.sectionRefResolver),
+        };
+        if (signal.aborted) return;
+      }
       this.data = data;
       this.loading = false;
       this.error = null;
@@ -58,7 +75,9 @@ export class Page {
         this.notFound = false;
       }
     } finally {
-      this.abortController = null;
+      if (this.abortController?.signal === signal) {
+        this.abortController = null;
+      }
     }
   };
 

--- a/packages/viewer/src/state/page.test.svelte.ts
+++ b/packages/viewer/src/state/page.test.svelte.ts
@@ -291,6 +291,56 @@ describe("page store", () => {
       expect(page.data).toEqual(updatedResponse);
       expect(page.loading).toBe(false);
     });
+
+    it("does not crash when concurrent load nullifies abortController before abort check", async () => {
+      const page = new Page(mockApiClient);
+
+      const responseWithBreadcrumbs: PageResponse = {
+        ...mockPageResponse,
+        breadcrumbs: [{ title: "API", path: "/", section: { kind: "component", name: "api" } }],
+      };
+
+      // The bug: load1 fetches page, then awaits resolveBreadcrumbs. While
+      // load1 is suspended, load2 starts, completes, and its finally block
+      // sets this.abortController = null. Load1 resumes and reads
+      // this.abortController.signal.aborted → TypeError: null.
+
+      // We use the resolver to suspend load1 after fetchPage succeeds.
+      // While load1 is suspended in resolveBreadcrumbs, we start and
+      // complete load2, which nullifies abortController.
+
+      let resolveResolver!: (v: Record<string, string>) => void;
+      const resolver = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<Record<string, string>>((r) => {
+              resolveResolver = r;
+            }),
+        )
+        .mockResolvedValue({ "component:default/api": "/docs/api" });
+      page.setSectionRefResolver(resolver);
+
+      // load1: fetchPage resolves immediately, then hangs on resolveBreadcrumbs
+      mockFetchPage.mockResolvedValueOnce(responseWithBreadcrumbs);
+      const load1 = page.load("");
+
+      // Yield to let load1 reach resolveBreadcrumbs (fetchPage resolved)
+      await vi.waitFor(() => expect(resolver).toHaveBeenCalledTimes(1));
+
+      // load2: starts, aborts load1's controller, creates new one
+      mockFetchPage.mockResolvedValueOnce(responseWithBreadcrumbs);
+      const load2 = page.load("domains/billing");
+      await load2; // completes → finally sets this.abortController = null
+
+      // Now resume load1's resolveBreadcrumbs — it will hit
+      // this.abortController.signal.aborted where this.abortController is null.
+      // The TypeError gets caught by the generic catch block and sets page.error,
+      // so we assert error stays null (load1 should bail out, not crash).
+      resolveResolver({ "component:default/api": "/docs/api" });
+      await load1;
+      expect(page.error).toBeNull();
+    });
   });
 
   describe("clear", () => {

--- a/packages/viewer/src/state/router.svelte.ts
+++ b/packages/viewer/src/state/router.svelte.ts
@@ -33,22 +33,25 @@ function decodeHash(encoded: string): string {
 export class Router {
   path = $state("/");
   hash = $state("");
+  resolved = $state(false);
   readonly embedded: boolean;
-  private readonly basePath: string;
+  private basePath = $state("");
+  private scopePath = $state("");
   private readonly onNavigate?: (path: string) => void;
+  private pendingGotos: string[] = [];
+  private scopeApplied = false;
 
   constructor(options?: {
     embedded?: boolean;
     initialPath?: string;
-    basePath?: string;
     onNavigate?: (path: string) => void;
   }) {
     this.embedded = options?.embedded ?? false;
-    this.basePath = options?.basePath ?? "";
     this.onNavigate = options?.onNavigate;
 
     if (this.embedded) {
-      this.path = options?.initialPath?.split("#")[0] ?? "/";
+      const raw = options?.initialPath?.split("#")[0] ?? "/";
+      this.path = raw;
       this.hash = decodeHash(options?.initialPath?.split("#")[1] ?? "");
     } else {
       this.path = window.location.pathname;
@@ -56,20 +59,70 @@ export class Router {
     }
   }
 
+  getBasePath(): string {
+    return this.basePath;
+  }
+
+  setBasePath(value: string): void {
+    this.basePath = value;
+    this.resolved = true;
+
+    // Replay pending gotos
+    const pending = this.pendingGotos.splice(0);
+    for (const path of pending) {
+      this.goto(path);
+    }
+  }
+
+  getScopePath(): string {
+    return this.scopePath;
+  }
+
+  setScopePath(value: string): void {
+    this.scopePath = value;
+
+    // Apply scope to current path once (embedded mode only)
+    if (this.embedded && !this.scopeApplied) {
+      this.scopeApplied = true;
+      this.path = this.addScope(this.path);
+    }
+  }
+
+  /** Strip scopePath prefix from an internal path for URL construction. */
+  private stripScope(path: string): string {
+    if (!this.scopePath) return path;
+    if (path === this.scopePath) return "/";
+    if (path.startsWith(this.scopePath + "/")) return path.slice(this.scopePath.length);
+    return path;
+  }
+
+  /** Add scopePath prefix to a URL path for internal/API use. */
+  private addScope(path: string): string {
+    if (!this.scopePath) return path;
+    if (path === "/") return this.scopePath;
+    return this.scopePath + path;
+  }
+
   /** Prefix an internal path with basePath for use in href attributes. */
   prefixPath = (path: string): string => {
-    return this.basePath + path;
+    return this.basePath + this.stripScope(path);
   };
 
   /** Navigate to a path programmatically */
   goto = (newPath: string) => {
+    // Queue navigation until basePath is resolved in embedded mode
+    if (!this.resolved && this.embedded) {
+      this.pendingGotos.push(newPath);
+      return;
+    }
+
     const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost";
     const url = new URL(newPath, origin);
 
     if (!this.embedded) {
       window.history.pushState({}, "", newPath);
     } else if (this.onNavigate) {
-      this.onNavigate(newPath);
+      this.onNavigate(this.basePath + this.stripScope(newPath));
     }
 
     this.path = url.pathname;
@@ -100,10 +153,20 @@ export class Router {
       if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
       if (isExternalLink(href, anchor)) return;
 
-      const internalPath =
-        this.basePath && href.startsWith(this.basePath)
-          ? href.slice(this.basePath.length) || "/"
-          : href;
+      // Not yet resolved in embedded mode — ignore clicks
+      if (this.embedded && !this.resolved) return;
+
+      // Cross-section link — let host handle routing via onNavigate
+      if (this.basePath && !href.startsWith(this.basePath)) {
+        if (this.onNavigate) {
+          e.preventDefault();
+          this.onNavigate(href);
+        }
+        return;
+      }
+
+      const urlPath = this.basePath ? href.slice(this.basePath.length) || "/" : href;
+      const internalPath = this.addScope(urlPath);
 
       e.preventDefault();
       this.goto(internalPath);

--- a/packages/viewer/src/state/router.test.svelte.ts
+++ b/packages/viewer/src/state/router.test.svelte.ts
@@ -469,6 +469,7 @@ describe("embedded mode", () => {
 
   it("goto does not call pushState in embedded mode", () => {
     const router = new Router({ embedded: true });
+    router.setBasePath("");
     router.goto("/guide");
 
     expect(window.history.pushState).not.toHaveBeenCalled();
@@ -478,10 +479,21 @@ describe("embedded mode", () => {
   it("goto calls onNavigate callback in embedded mode", () => {
     const onNavigate = vi.fn();
     const router = new Router({ embedded: true, onNavigate });
+    router.setBasePath("");
     router.goto("/guide");
 
     expect(onNavigate).toHaveBeenCalledWith("/guide");
     expect(window.history.pushState).not.toHaveBeenCalled();
+  });
+
+  it("goto calls onNavigate with basePath-prefixed path", () => {
+    const onNavigate = vi.fn();
+    const router = new Router({ embedded: true, onNavigate });
+    router.setBasePath("/rw-docs");
+    router.goto("/guide");
+
+    expect(onNavigate).toHaveBeenCalledWith("/rw-docs/guide");
+    expect(router.path).toBe("/guide");
   });
 
   it("goto does not call onNavigate in normal mode", () => {
@@ -596,19 +608,22 @@ describe("basePath", () => {
   });
 
   it("prefixPath prepends basePath to path", () => {
-    const router = new Router({ embedded: true, basePath: "/rw-docs" });
+    const router = new Router({ embedded: true });
+    router.setBasePath("/rw-docs");
     expect(router.prefixPath("/docs/guide")).toBe("/rw-docs/docs/guide");
   });
 
   it("prefixPath handles root path", () => {
-    const router = new Router({ embedded: true, basePath: "/rw-docs" });
+    const router = new Router({ embedded: true });
+    router.setBasePath("/rw-docs");
     expect(router.prefixPath("/")).toBe("/rw-docs/");
   });
 
   it("click handler strips basePath from href before navigating", () => {
     const onNavigate = vi.fn();
     const rootElement = document.createElement("div");
-    const router = new Router({ embedded: true, basePath: "/rw-docs", onNavigate });
+    const router = new Router({ embedded: true, onNavigate });
+    router.setBasePath("/rw-docs");
     const cleanup = router.initRouter(rootElement);
 
     const anchor = document.createElement("a");
@@ -623,7 +638,7 @@ describe("basePath", () => {
     rootElement.dispatchEvent(event);
 
     expect(event.preventDefault).toHaveBeenCalled();
-    expect(onNavigate).toHaveBeenCalledWith("/docs/guide");
+    expect(onNavigate).toHaveBeenCalledWith("/rw-docs/docs/guide");
     expect(router.path).toBe("/docs/guide");
 
     cleanup();
@@ -632,7 +647,8 @@ describe("basePath", () => {
   it("click handler handles root basePath href", () => {
     const onNavigate = vi.fn();
     const rootElement = document.createElement("div");
-    const router = new Router({ embedded: true, basePath: "/rw-docs", onNavigate });
+    const router = new Router({ embedded: true, onNavigate });
+    router.setBasePath("/rw-docs");
     const cleanup = router.initRouter(rootElement);
 
     const anchor = document.createElement("a");
@@ -645,9 +661,222 @@ describe("basePath", () => {
 
     rootElement.dispatchEvent(event);
 
-    expect(onNavigate).toHaveBeenCalledWith("/");
+    expect(onNavigate).toHaveBeenCalledWith("/rw-docs/");
     expect(router.path).toBe("/");
 
     cleanup();
+  });
+
+  it("click handler intercepts cross-section links and calls onNavigate with href", () => {
+    const onNavigate = vi.fn();
+    const rootElement = document.createElement("div");
+    const router = new Router({ embedded: true, onNavigate });
+    router.setBasePath("/catalog/default/domain/billing/docs");
+    const cleanup = router.initRouter(rootElement);
+
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "/catalog/default/system/payment-gateway/docs");
+    rootElement.appendChild(anchor);
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    vi.spyOn(event, "preventDefault");
+    Object.defineProperty(event, "target", { value: anchor });
+
+    rootElement.dispatchEvent(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(onNavigate).toHaveBeenCalledWith("/catalog/default/system/payment-gateway/docs");
+    // Internal path should NOT change — viewer is navigating away
+    expect(router.path).toBe("/");
+
+    cleanup();
+  });
+
+  it("click handler falls through on cross-section links when no onNavigate", () => {
+    const rootElement = document.createElement("div");
+    const router = new Router({ embedded: true });
+    router.setBasePath("/catalog/default/domain/billing/docs");
+    const cleanup = router.initRouter(rootElement);
+
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "/catalog/default/system/payment-gateway/docs");
+    rootElement.appendChild(anchor);
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    vi.spyOn(event, "preventDefault");
+    Object.defineProperty(event, "target", { value: anchor });
+
+    rootElement.dispatchEvent(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+});
+
+describe("scopePath", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      value: { origin: "http://localhost:3000", pathname: "/", hash: "" },
+      writable: true,
+      configurable: true,
+    });
+    vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prefixPath strips scopePath before prepending basePath", () => {
+    const router = new Router({ embedded: true });
+    router.setBasePath("/catalog/default/system/payment-gateway/docs");
+    router.setScopePath("/domains/billing/systems/payment-gateway");
+    expect(router.prefixPath("/domains/billing/systems/payment-gateway/usecases/get-cards")).toBe(
+      "/catalog/default/system/payment-gateway/docs/usecases/get-cards",
+    );
+  });
+
+  it("prefixPath handles scope root path", () => {
+    const router = new Router({ embedded: true });
+    router.setBasePath("/catalog/default/system/payment-gateway/docs");
+    router.setScopePath("/domains/billing/systems/payment-gateway");
+    expect(router.prefixPath("/domains/billing/systems/payment-gateway")).toBe(
+      "/catalog/default/system/payment-gateway/docs/",
+    );
+  });
+
+  it("prefixPath leaves paths outside scope unchanged", () => {
+    const router = new Router({ embedded: true });
+    router.setBasePath("/catalog/default/system/payment-gateway/docs");
+    router.setScopePath("/domains/billing/systems/payment-gateway");
+    expect(router.prefixPath("/other/path")).toBe(
+      "/catalog/default/system/payment-gateway/docs/other/path",
+    );
+  });
+
+  it("initialPath is scope-relative and gets scope prefix added", () => {
+    const router = new Router({
+      embedded: true,
+      initialPath: "/usecases/get-cards",
+    });
+    router.setScopePath("/domains/billing/systems/payment-gateway");
+    expect(router.path).toBe("/domains/billing/systems/payment-gateway/usecases/get-cards");
+  });
+
+  it("initialPath root maps to scopePath", () => {
+    const router = new Router({
+      embedded: true,
+      initialPath: "/",
+    });
+    router.setScopePath("/domains/billing/systems/payment-gateway");
+    expect(router.path).toBe("/domains/billing/systems/payment-gateway");
+  });
+
+  it("goto calls onNavigate with scope-stripped href", () => {
+    const onNavigate = vi.fn();
+    const router = new Router({ embedded: true, onNavigate });
+    router.setBasePath("/catalog/default/system/payment-gateway/docs");
+    router.setScopePath("/domains/billing/systems/payment-gateway");
+    router.goto("/domains/billing/systems/payment-gateway/usecases/get-cards");
+
+    expect(onNavigate).toHaveBeenCalledWith(
+      "/catalog/default/system/payment-gateway/docs/usecases/get-cards",
+    );
+    expect(router.path).toBe("/domains/billing/systems/payment-gateway/usecases/get-cards");
+  });
+
+  it("click handler adds scope prefix when converting URL to internal path", () => {
+    const onNavigate = vi.fn();
+    const rootElement = document.createElement("div");
+    const router = new Router({ embedded: true, onNavigate });
+    router.setBasePath("/catalog/default/system/payment-gateway/docs");
+    router.setScopePath("/domains/billing/systems/payment-gateway");
+    const cleanup = router.initRouter(rootElement);
+
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "/catalog/default/system/payment-gateway/docs/usecases/get-cards");
+    rootElement.appendChild(anchor);
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    vi.spyOn(event, "preventDefault");
+    Object.defineProperty(event, "target", { value: anchor });
+
+    rootElement.dispatchEvent(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(router.path).toBe("/domains/billing/systems/payment-gateway/usecases/get-cards");
+    expect(onNavigate).toHaveBeenCalledWith(
+      "/catalog/default/system/payment-gateway/docs/usecases/get-cards",
+    );
+
+    cleanup();
+  });
+});
+
+describe("two-phase initialization", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      value: { origin: "http://localhost:3000", pathname: "/", hash: "" },
+      writable: true,
+      configurable: true,
+    });
+    vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("basePath starts empty and can be set", () => {
+    const router = new Router({ embedded: true });
+    expect(router.getBasePath()).toBe("");
+    router.setBasePath("/catalog/default/domain/billing/docs");
+    expect(router.getBasePath()).toBe("/catalog/default/domain/billing/docs");
+  });
+
+  it("scopePath starts empty and can be set", () => {
+    const router = new Router({ embedded: true });
+    expect(router.getScopePath()).toBe("");
+    router.setScopePath("/domains/billing");
+    expect(router.getScopePath()).toBe("/domains/billing");
+  });
+
+  it("resolved is false until basePath is set", () => {
+    const router = new Router({ embedded: true });
+    expect(router.resolved).toBe(false);
+    router.setBasePath("/docs");
+    expect(router.resolved).toBe(true);
+  });
+
+  it("prefixPath uses basePath after resolution", () => {
+    const router = new Router({ embedded: true });
+    router.setScopePath("/domains/billing");
+    router.setBasePath("/catalog/default/domain/billing/docs");
+    expect(router.prefixPath("/domains/billing/api")).toBe(
+      "/catalog/default/domain/billing/docs/api",
+    );
+  });
+
+  it("setScopePath adjusts current path with addScope", () => {
+    const router = new Router({ embedded: true, initialPath: "/api/overview" });
+    expect(router.path).toBe("/api/overview");
+    router.setScopePath("/domains/billing");
+    expect(router.path).toBe("/domains/billing/api/overview");
+  });
+
+  it("setScopePath adjusts root initialPath", () => {
+    const router = new Router({ embedded: true, initialPath: "/" });
+    router.setScopePath("/domains/billing");
+    expect(router.path).toBe("/domains/billing");
+  });
+
+  it("goto queues navigation before resolution, replays after", () => {
+    const onNavigate = vi.fn();
+    const router = new Router({ embedded: true, onNavigate });
+    router.goto("/some/path");
+    expect(onNavigate).not.toHaveBeenCalled();
+    router.setBasePath("/docs");
+    expect(onNavigate).toHaveBeenCalledWith("/docs/some/path");
   });
 });


### PR DESCRIPTION
## Summary

- Replace `basePath` and `scopePath` options in `mountRw()` with a single `sectionRef` string (e.g. `"domain:default/billing"`) — the viewer derives path mappings at runtime using `resolveSectionRefs` and the navigation API
- Server navigation endpoint accepts `sectionRef` query param, resolving it to a filesystem scope path internally
- Router uses two-phase init: load navigation, extract scope path, resolve base URL via `resolveSectionRefs`
- Add `resolveSectionRefs` callback for cross-entity link navigation in embedded contexts
- Add `sectionRefs` utility module with parsing, nav tree resolution, breadcrumb resolution, and link rewriting

## Test plan

- [x] `make test` passes
- [x] `make lint` passes clean
- [x] Embedded mode with `sectionRef` loads scoped navigation and resolves cross-section links
- [x] Non-embedded mode (`rw serve`) works without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)