### PR TITLE
refactor: replace flat section fields with nested Section object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Section metadata field renamed from `type` to `kind` to align with Backstage and Kubernetes conventions — `type` is still accepted in YAML for backward compatibility
-- API responses now use `kind` (was `type`) and `sectionKind` (was `sectionType`)
+- API responses now use a nested `section: { kind, name }` object (was flat `sectionType` field) on navigation items, scope info, and `@rwdocs/core` responses
 - Embedded viewer (`mountRw()`) now uses flow layout — content takes its natural height and the parent page controls scrolling, instead of filling a fixed container with internal scroll
 
 ### Removed

--- a/crates/rw-napi/src/lib.rs
+++ b/crates/rw-napi/src/lib.rs
@@ -18,7 +18,7 @@ use rw_storage_s3::{S3Config, S3Storage};
 
 use crate::types::{
     BreadcrumbResponse, DiagramsConfig, NavItemResponse, NavigationResponse, PageMetaResponse,
-    PageResponse, ScopeInfoResponse, SiteConfig, TocEntryResponse,
+    PageResponse, ScopeInfoResponse, SectionResponse, SiteConfig, TocEntryResponse,
 };
 
 fn apply_diagrams_config(
@@ -48,7 +48,7 @@ fn convert_nav_item(item: NavItem) -> NavItemResponse {
     NavItemResponse {
         title: item.title,
         path: to_url_path(&item.path),
-        section_kind: item.section_kind,
+        section: item.section.map(SectionResponse::from),
         children: if item.children.is_empty() {
             None
         } else {
@@ -59,10 +59,9 @@ fn convert_nav_item(item: NavItem) -> NavItemResponse {
 
 fn convert_scope_info(info: ScopeInfo) -> ScopeInfoResponse {
     ScopeInfoResponse {
-        // ScopeInfo.path already has leading slash
         path: info.path,
         title: info.title,
-        section_kind: info.section_kind,
+        section: info.section.into(),
     }
 }
 
@@ -267,13 +266,13 @@ mod tests {
         let item = NavItem {
             title: "Getting Started".to_owned(),
             path: "guide/start".to_owned(),
-            section_kind: None,
+            section: None,
             children: vec![],
         };
         let result = convert_nav_item(item);
         assert_eq!(result.title, "Getting Started");
         assert_eq!(result.path, "/guide/start");
-        assert_eq!(result.section_kind, None);
+        assert!(result.section.is_none());
         assert!(result.children.is_none());
     }
 
@@ -282,7 +281,7 @@ mod tests {
         let item = NavItem {
             title: "Home".to_owned(),
             path: String::new(),
-            section_kind: None,
+            section: None,
             children: vec![],
         };
         let result = convert_nav_item(item);
@@ -294,16 +293,19 @@ mod tests {
         let item = NavItem {
             title: "Guides".to_owned(),
             path: "guides".to_owned(),
-            section_kind: Some("guide".to_owned()),
+            section: Some(rw_site::Section {
+                kind: "guide".to_owned(),
+                name: "guides".to_owned(),
+            }),
             children: vec![NavItem {
                 title: "Setup".to_owned(),
                 path: "guides/setup".to_owned(),
-                section_kind: None,
+                section: None,
                 children: vec![],
             }],
         };
         let result = convert_nav_item(item);
-        assert_eq!(result.section_kind.as_deref(), Some("guide"));
+        assert_eq!(result.section.as_ref().unwrap().kind, "guide");
         let children = result.children.as_ref().expect("should have children");
         assert_eq!(children.len(), 1);
         assert_eq!(children[0].path, "/guides/setup");
@@ -351,11 +353,15 @@ mod tests {
         let info = ScopeInfo {
             path: "/domains".to_owned(),
             title: "Domains".to_owned(),
-            section_kind: "domain".to_owned(),
+            section: rw_site::Section {
+                kind: "domain".to_owned(),
+                name: "domains".to_owned(),
+            },
         };
         let result = convert_scope_info(info);
         assert_eq!(result.path, "/domains");
         assert_eq!(result.title, "Domains");
-        assert_eq!(result.section_kind, "domain");
+        assert_eq!(result.section.kind, "domain");
+        assert_eq!(result.section.name, "domains");
     }
 }

--- a/crates/rw-napi/src/types.rs
+++ b/crates/rw-napi/src/types.rs
@@ -1,4 +1,5 @@
 use napi_derive::napi;
+use rw_site::Section;
 use serde_json::Value;
 
 #[napi(object)]
@@ -33,11 +34,25 @@ pub struct S3Config {
 }
 
 #[napi(object)]
+pub struct SectionResponse {
+    pub kind: String,
+    pub name: String,
+}
+
+impl From<Section> for SectionResponse {
+    fn from(s: Section) -> Self {
+        Self {
+            kind: s.kind,
+            name: s.name,
+        }
+    }
+}
+
+#[napi(object)]
 pub struct NavItemResponse {
     pub title: String,
     pub path: String,
-    #[napi(js_name = "sectionKind")]
-    pub section_kind: Option<String>,
+    pub section: Option<SectionResponse>,
     pub children: Option<Vec<NavItemResponse>>,
 }
 
@@ -45,8 +60,7 @@ pub struct NavItemResponse {
 pub struct ScopeInfoResponse {
     pub path: String,
     pub title: String,
-    #[napi(js_name = "kind")]
-    pub section_kind: String,
+    pub section: SectionResponse,
 }
 
 #[napi(object)]

--- a/crates/rw-server/src/handlers/mod.rs
+++ b/crates/rw-server/src/handlers/mod.rs
@@ -1,8 +1,27 @@
 //! HTTP request handlers.
 
+use rw_site::Section;
+use serde::Serialize;
+
 pub(crate) mod config;
 pub(crate) mod navigation;
 pub(crate) mod pages;
+
+/// Section identity for JSON response.
+#[derive(Serialize)]
+pub(crate) struct SectionResponse {
+    kind: String,
+    name: String,
+}
+
+impl From<Section> for SectionResponse {
+    fn from(s: Section) -> Self {
+        Self {
+            kind: s.kind,
+            name: s.name,
+        }
+    }
+}
 
 /// Convert internal path (without leading slash) to URL path (with leading slash).
 ///

--- a/crates/rw-server/src/handlers/navigation.rs
+++ b/crates/rw-server/src/handlers/navigation.rs
@@ -9,7 +9,7 @@ use axum::extract::{Query, State};
 use rw_site::{NavItem, ScopeInfo};
 use serde::{Deserialize, Serialize};
 
-use crate::handlers::to_url_path;
+use crate::handlers::{SectionResponse, to_url_path};
 use crate::state::AppState;
 
 /// Query parameters for GET /api/navigation.
@@ -40,18 +40,16 @@ struct ScopeInfoResponse {
     path: String,
     /// Display title.
     title: String,
-    /// Section kind.
-    #[serde(rename = "kind")]
-    section_kind: String,
+    /// Section identity.
+    section: SectionResponse,
 }
 
 impl From<ScopeInfo> for ScopeInfoResponse {
     fn from(info: ScopeInfo) -> Self {
         Self {
-            // ScopeInfo.path already has leading slash
             path: info.path,
             title: info.title,
-            section_kind: info.section_kind,
+            section: info.section.into(),
         }
     }
 }
@@ -63,9 +61,9 @@ struct NavItemResponse {
     title: String,
     /// Link target path (with leading slash for frontend).
     path: String,
-    /// Section kind if this item is a section root.
-    #[serde(rename = "sectionKind", skip_serializing_if = "Option::is_none")]
-    section_kind: Option<String>,
+    /// Section identity if this item's path matches a section.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    section: Option<SectionResponse>,
     /// Child navigation items.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     children: Vec<NavItemResponse>,
@@ -76,7 +74,7 @@ impl From<NavItem> for NavItemResponse {
         Self {
             title: item.title,
             path: to_url_path(&item.path),
-            section_kind: item.section_kind,
+            section: item.section.map(SectionResponse::from),
             children: item
                 .children
                 .into_iter()
@@ -120,7 +118,7 @@ mod tests {
         let nav_item = NavItem {
             title: "Guide".to_owned(),
             path: "guide".to_owned(),
-            section_kind: None,
+            section: None,
             children: vec![],
         };
         // Convert to NavItemResponse which adds leading slash
@@ -147,7 +145,10 @@ mod tests {
             scope: Some(ScopeInfoResponse {
                 path: "/domains/billing".to_owned(),
                 title: "Billing".to_owned(),
-                section_kind: "domain".to_owned(),
+                section: SectionResponse {
+                    kind: "domain".to_owned(),
+                    name: "billing".to_owned(),
+                },
             }),
             parent_scope: None,
         };
@@ -156,7 +157,8 @@ mod tests {
 
         assert_eq!(json["scope"]["path"], "/domains/billing");
         assert_eq!(json["scope"]["title"], "Billing");
-        assert_eq!(json["scope"]["kind"], "domain");
+        assert_eq!(json["scope"]["section"]["kind"], "domain");
+        assert_eq!(json["scope"]["section"]["name"], "billing");
         assert!(json.get("parentScope").is_none());
     }
 }

--- a/crates/rw-site/src/lib.rs
+++ b/crates/rw-site/src/lib.rs
@@ -34,7 +34,7 @@ pub(crate) mod site_state;
 
 pub use page::{BreadcrumbItem, PageRenderResult, PageRendererConfig, RenderError};
 pub use site::Site;
-pub use site_state::{NavItem, Navigation, ScopeInfo};
+pub use site_state::{NavItem, Navigation, ScopeInfo, Section};
 
 // Re-export TocEntry from rw-renderer for convenience
 pub use rw_renderer::TocEntry;

--- a/crates/rw-site/src/site_state.rs
+++ b/crates/rw-site/src/site_state.rs
@@ -19,6 +19,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::page::{BreadcrumbItem, Page};
 
+/// Section identity for API responses.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct Section {
+    /// Section kind (e.g., `"component"`, `"domain"`).
+    pub kind: String,
+    /// Section name — last path segment (e.g., `"billing"`).
+    pub name: String,
+}
+
+/// Extract the last segment of a URL path as the section name.
+fn section_name(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
 /// Navigation item with children for UI tree.
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct NavItem {
@@ -26,9 +40,9 @@ pub struct NavItem {
     pub title: String,
     /// Link target path.
     pub path: String,
-    /// Section kind if this item is a section root.
+    /// Section identity if this item's path matches a section.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub section_kind: Option<String>,
+    pub section: Option<Section>,
     /// Child navigation items.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<NavItem>,
@@ -50,6 +64,15 @@ pub struct SectionInfo {
     pub description: Option<String>,
 }
 
+impl From<&SectionInfo> for Section {
+    fn from(info: &SectionInfo) -> Self {
+        Self {
+            kind: info.section_kind.clone(),
+            name: section_name(&info.path).to_owned(),
+        }
+    }
+}
+
 /// Information about a navigation scope for the frontend.
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct ScopeInfo {
@@ -57,9 +80,8 @@ pub struct ScopeInfo {
     pub path: String,
     /// Display title.
     pub title: String,
-    /// Section kind.
-    #[serde(rename = "kind")]
-    pub section_kind: String,
+    /// Section identity.
+    pub section: Section,
 }
 
 /// Result of scoped navigation query.
@@ -145,7 +167,7 @@ impl SiteState {
         let mut sections_by_name: HashMap<String, Vec<usize>> = HashMap::new();
         for path in sections.keys() {
             if let Some(&idx) = path_index.get(path.as_str()) {
-                let dir_name = path.rsplit('/').next().unwrap_or(path);
+                let dir_name = section_name(path);
                 sections_by_name
                     .entry(dir_name.to_owned())
                     .or_default()
@@ -359,7 +381,7 @@ impl SiteState {
             let scope = Some(ScopeInfo {
                 path: format!("/{scope_path}"),
                 title: section.title.clone(),
-                section_kind: section.section_kind.clone(),
+                section: Section::from(section),
             });
 
             // Find parent section for back navigation
@@ -388,12 +410,12 @@ impl SiteState {
         }
 
         // Walk up the path to find the nearest section ancestor
-        let mut current = page_path.to_owned();
+        let mut current = page_path;
         while let Some((parent, _)) = current.rsplit_once('/') {
             if self.sections.contains_key(parent) {
                 return parent.to_owned();
             }
-            current = parent.to_owned();
+            current = parent;
         }
 
         // No section ancestor found, return root scope
@@ -405,10 +427,10 @@ impl SiteState {
     /// Sections become leaf nodes - they don't include their children.
     /// Only includes children that have markdown content in their subtree.
     fn build_nav_item_with_section_cutoff(&self, page: &Page) -> NavItem {
-        let is_section = self.sections.contains_key(&page.path);
+        let section_info = self.sections.get(&page.path);
 
         // Sections become leaf nodes - don't include children
-        let children = if is_section {
+        let children = if section_info.is_some() {
             Vec::new()
         } else {
             self.get_children_with_content(&page.path)
@@ -417,15 +439,12 @@ impl SiteState {
                 .collect()
         };
 
-        let section_kind = self
-            .sections
-            .get(&page.path)
-            .map(|s| s.section_kind.clone());
+        let section = section_info.map(Section::from);
 
         NavItem {
             title: page.title.clone(),
             path: page.path.clone(),
-            section_kind,
+            section,
             children,
         }
     }
@@ -440,16 +459,16 @@ impl SiteState {
     ///
     /// `ScopeInfo` for the parent section, or `None` if at root level.
     fn find_parent_section(&self, path: &str) -> Option<ScopeInfo> {
-        let mut current = path.to_owned();
+        let mut current = path;
         while let Some((parent, _)) = current.rsplit_once('/') {
             if let Some(section) = self.sections.get(parent) {
                 return Some(ScopeInfo {
                     path: format!("/{parent}"),
                     title: section.title.clone(),
-                    section_kind: section.section_kind.clone(),
+                    section: Section::from(section),
                 });
             }
-            current = parent.to_owned();
+            current = parent;
         }
         None
     }
@@ -1020,9 +1039,9 @@ mod tests {
             .find(|item| item.title == "Getting Started")
             .unwrap();
 
-        assert_eq!(billing.section_kind, Some("domain".to_owned()));
-        assert_eq!(payments.section_kind, Some("system".to_owned()));
-        assert_eq!(getting_started.section_kind, None);
+        assert_eq!(billing.section.as_ref().unwrap().kind, "domain");
+        assert_eq!(payments.section.as_ref().unwrap().kind, "system");
+        assert!(getting_started.section.is_none());
     }
 
     // NavItem tests
@@ -1032,7 +1051,7 @@ mod tests {
         let item = NavItem {
             title: "Guide".to_owned(),
             path: "guide".to_owned(),
-            section_kind: None,
+            section: None,
             children: Vec::new(),
         };
 
@@ -1046,13 +1065,13 @@ mod tests {
         let child = NavItem {
             title: "Child".to_owned(),
             path: "parent/child".to_owned(),
-            section_kind: None,
+            section: None,
             children: Vec::new(),
         };
         let item = NavItem {
             title: "Parent".to_owned(),
             path: "parent".to_owned(),
-            section_kind: None,
+            section: None,
             children: vec![child],
         };
 
@@ -1065,7 +1084,7 @@ mod tests {
         let item = NavItem {
             title: "Guide".to_owned(),
             path: "guide".to_owned(),
-            section_kind: None,
+            section: None,
             children: Vec::new(),
         };
 
@@ -1081,13 +1100,13 @@ mod tests {
         let child = NavItem {
             title: "Child".to_owned(),
             path: "parent/child".to_owned(),
-            section_kind: None,
+            section: None,
             children: Vec::new(),
         };
         let item = NavItem {
             title: "Parent".to_owned(),
             path: "parent".to_owned(),
-            section_kind: None,
+            section: None,
             children: vec![child],
         };
 
@@ -1101,11 +1120,14 @@ mod tests {
     }
 
     #[test]
-    fn test_nav_item_serialization_with_section_kind() {
+    fn test_nav_item_serialization_with_section() {
         let item = NavItem {
             title: "Billing".to_owned(),
             path: "domains/billing".to_owned(),
-            section_kind: Some("domain".to_owned()),
+            section: Some(Section {
+                kind: "domain".to_owned(),
+                name: "billing".to_owned(),
+            }),
             children: Vec::new(),
         };
 
@@ -1113,21 +1135,22 @@ mod tests {
 
         assert_eq!(json["title"], "Billing");
         assert_eq!(json["path"], "domains/billing");
-        assert_eq!(json["section_kind"], "domain");
+        assert_eq!(json["section"]["kind"], "domain");
+        assert_eq!(json["section"]["name"], "billing");
     }
 
     #[test]
-    fn test_nav_item_serialization_skips_none_section_kind() {
+    fn test_nav_item_serialization_skips_none_section() {
         let item = NavItem {
             title: "Guide".to_owned(),
             path: "guide".to_owned(),
-            section_kind: None,
+            section: None,
             children: Vec::new(),
         };
 
         let json = serde_json::to_value(&item).unwrap();
 
-        assert!(json.get("section_kind").is_none()); // Skipped when None
+        assert!(json.get("section").is_none()); // Skipped when None
     }
 
     // Scoped navigation tests
@@ -1166,7 +1189,7 @@ mod tests {
         // Billing (a section) should have no children in root scope
         let billing = nav.items.iter().find(|i| i.title == "Billing").unwrap();
         assert!(billing.children.is_empty());
-        assert_eq!(billing.section_kind, Some("domain".to_owned()));
+        assert_eq!(billing.section.as_ref().unwrap().kind, "domain");
     }
 
     #[test]
@@ -1236,7 +1259,8 @@ mod tests {
         let scope = nav.scope.unwrap();
         assert_eq!(scope.path, "/billing");
         assert_eq!(scope.title, "Billing");
-        assert_eq!(scope.section_kind, "domain");
+        assert_eq!(scope.section.kind, "domain");
+        assert_eq!(scope.section.name, "billing");
 
         // No parent section
         assert!(nav.parent_scope.is_none());
@@ -1285,13 +1309,15 @@ mod tests {
         let scope = nav.scope.as_ref().unwrap();
         assert_eq!(scope.path, "/billing/payments");
         assert_eq!(scope.title, "Payments");
-        assert_eq!(scope.section_kind, "system");
+        assert_eq!(scope.section.kind, "system");
+        assert_eq!(scope.section.name, "payments");
 
         // Should have parent scope pointing to billing
         let parent = nav.parent_scope.as_ref().unwrap();
         assert_eq!(parent.path, "/billing");
         assert_eq!(parent.title, "Billing");
-        assert_eq!(parent.section_kind, "domain");
+        assert_eq!(parent.section.kind, "domain");
+        assert_eq!(parent.section.name, "billing");
 
         // Should show payments' children
         assert_eq!(nav.items.len(), 1);

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -27,7 +27,7 @@ export interface NavigationResponse {
 export interface NavItemResponse {
   title: string
   path: string
-  sectionKind?: string
+  section?: SectionResponse
   children?: Array<NavItemResponse>
 }
 
@@ -62,7 +62,12 @@ export interface S3Config {
 export interface ScopeInfoResponse {
   path: string
   title: string
+  section: SectionResponse
+}
+
+export interface SectionResponse {
   kind: string
+  name: string
 }
 
 export interface SiteConfig {

--- a/packages/viewer/src/lib/navigation.ts
+++ b/packages/viewer/src/lib/navigation.ts
@@ -19,14 +19,14 @@ function pluralizeKind(kind: string): string {
  * Returns ungrouped items first, then kind groups (alphabetically).
  */
 export function groupNavItems(items: NavItem[]): NavGroup[] {
-  const typedGroups = new Map<string, NavItem[]>();
+  const kindGroups = new Map<string, NavItem[]>();
   const ungrouped: NavItem[] = [];
 
   for (const item of items) {
-    if (item.sectionKind) {
-      const group = typedGroups.get(item.sectionKind) ?? [];
+    if (item.section) {
+      const group = kindGroups.get(item.section.kind) ?? [];
       group.push(item);
-      typedGroups.set(item.sectionKind, group);
+      kindGroups.set(item.section.kind, group);
     } else {
       ungrouped.push(item);
     }
@@ -39,14 +39,14 @@ export function groupNavItems(items: NavItem[]): NavGroup[] {
     groups.push({ label: null, items: ungrouped });
   }
 
-  const typedGroupsSorted = [...typedGroups.entries()]
+  const kindGroupsSorted = [...kindGroups.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([type, groupItems]) => ({
-      label: pluralizeKind(type),
+    .map(([kind, groupItems]) => ({
+      label: pluralizeKind(kind),
       items: groupItems,
     }));
 
-  groups.push(...typedGroupsSorted);
+  groups.push(...kindGroupsSorted);
 
   return groups;
 }

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -1,9 +1,17 @@
+/** Section identity from the API. */
+export interface Section {
+  /** Section kind (e.g., "domain", "system"). */
+  kind: string;
+  /** Section name — last path segment (e.g., "billing"). */
+  name: string;
+}
+
 /** Navigation tree item from GET /api/navigation */
 export interface NavItem {
   title: string;
   path: string;
-  /** Section kind if this item is a section root. */
-  sectionKind?: string;
+  /** Section identity if this item is a section root. */
+  section?: Section;
   children?: NavItem[];
 }
 
@@ -21,8 +29,8 @@ export interface ScopeInfo {
   path: string;
   /** Display title. */
   title: string;
-  /** Section kind (e.g., "domain", "system"). */
-  kind: string;
+  /** Section identity. */
+  section: Section;
 }
 
 /** Complete navigation tree with scope information */


### PR DESCRIPTION
## Summary

- Replace flat `sectionType` string field with nested `section: { kind, name }` object across the API surface (server, napi, viewer types)
- Add `Section { kind, name }` struct to `rw-site` with `From<&SectionInfo>` conversion, where `name` is the last path segment (e.g., `"billing"` from `"domains/billing"`)
- Add `section_name()` helper to deduplicate path segment extraction
- Rename viewer `SectionInfo` type to `Section` to match Rust

## Test plan

- [x] `make test` — all Rust and frontend tests pass
- [x] `make lint` — clippy, svelte-check, eslint clean
- [x] `make format` — all code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)