### PR TITLE
refactor: remove linkPrefix option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `rw techdocs build` and `rw techdocs publish` commands — use native Backstage plugins ([rwdocs/backstage-plugins](https://github.com/rwdocs/backstage-plugins)) instead
+- `linkPrefix` option from `@rwdocs/core` `createSite()` config
 
 ## [0.1.17] - 2026-03-10
 

--- a/crates/rw-diagrams/src/lib.rs
+++ b/crates/rw-diagrams/src/lib.rs
@@ -39,6 +39,6 @@ mod output;
 mod plantuml;
 mod processor;
 
-pub use meta_includes::{EntityInfo, LinkConfig, MetaIncludeSource};
+pub use meta_includes::{EntityInfo, MetaIncludeSource};
 pub use output::{DiagramOutput, RenderedDiagramInfo, TagGenerator};
 pub use processor::DiagramProcessor;

--- a/crates/rw-diagrams/src/meta_includes.rs
+++ b/crates/rw-diagrams/src/meta_includes.rs
@@ -4,16 +4,6 @@
 //! `!include systems/sys_payment_gateway.iuml` to resolve dynamically
 //! from `meta.yaml` files without maintaining separate `.iuml` files.
 
-/// Configuration for transforming `$link` URLs in C4 macros.
-///
-/// When provided, diagram link URLs are transformed to prepend a prefix
-/// (e.g., `/rw-docs`) to absolute URLs.
-#[derive(Clone, Debug)]
-pub struct LinkConfig {
-    /// Optional prefix to prepend to absolute URLs (e.g., "/rw-docs").
-    pub link_prefix: Option<String>,
-}
-
 /// Entity metadata for generating `PlantUML` C4 includes.
 #[derive(Clone, Debug)]
 pub struct EntityInfo {
@@ -106,45 +96,22 @@ fn escape_description(desc: &str) -> String {
         .replace('\n', "\\n")
 }
 
-/// Transform a URL according to link configuration.
-///
-/// Prepends `link_prefix` to absolute URLs when configured.
-fn resolve_link(url: &str, config: &LinkConfig) -> String {
-    if let Some(prefix) = &config.link_prefix
-        && url.starts_with('/')
-    {
-        return format!("{prefix}{url}");
-    }
-    url.to_owned()
-}
-
 /// Render a C4 `PlantUML` macro call from entity metadata.
 ///
 /// The output follows the C4-PlantUML conventions used by the mkdocs arch
 /// plugin. The macro variant (`System` vs `System_Ext`) depends on the
 /// `external` flag.
 ///
-/// When `link_config` is provided, URLs are transformed to match the
-/// renderer's link mode. When `None`, absolute URLs are used as-is.
-fn render_c4_macro(
-    entity_type: &str,
-    name: &str,
-    entity: &EntityInfo,
-    external: bool,
-    link_config: Option<&LinkConfig>,
-) -> String {
+fn render_c4_macro(entity_type: &str, name: &str, entity: &EntityInfo, external: bool) -> String {
     let prefix = type_prefix(entity_type);
     let alias = format!("{prefix}_{name}");
 
     let title = &entity.title;
 
-    let link_part = entity.url_path.as_deref().map_or(String::new(), |url| {
-        let resolved = match link_config {
-            Some(config) => resolve_link(url, config),
-            None => url.to_owned(),
-        };
-        format!(", $link=\"{resolved}\"")
-    });
+    let link_part = entity
+        .url_path
+        .as_deref()
+        .map_or(String::new(), |url| format!(", $link=\"{url}\""));
 
     let desc_escaped = entity.description.as_deref().map(escape_description);
 
@@ -189,15 +156,11 @@ fn render_c4_macro(
 /// the entity via the provided [`MetaIncludeSource`], and renders the
 /// appropriate C4 `PlantUML` macro.
 ///
-/// When `link_config` is provided, `$link` URLs are transformed to match the
-/// renderer's link mode (relative paths, trailing slashes).
-///
 /// Returns `None` if the path doesn't match the meta include pattern or the
 /// entity is not found.
 pub(crate) fn resolve_meta_include(
     include_path: &str,
     source: &dyn MetaIncludeSource,
-    link_config: Option<&LinkConfig>,
 ) -> Option<String> {
     let parsed = parse_include_path(include_path)?;
     let entity = source.get_entity(parsed.entity_type, &parsed.name)?;
@@ -206,7 +169,6 @@ pub(crate) fn resolve_meta_include(
         &parsed.name,
         &entity,
         parsed.external,
-        link_config,
     ))
 }
 
@@ -370,7 +332,7 @@ mod tests {
     #[test]
     fn test_render_system_regular() {
         let entity = system_entity();
-        let result = render_c4_macro("system", "payment_gateway", &entity, false, None);
+        let result = render_c4_macro("system", "payment_gateway", &entity, false);
         assert_eq!(
             result,
             "System(sys_payment_gateway, \"Payment Gateway\", \"Processes payments\", $link=\"/domains/billing/systems/payment-gateway\")"
@@ -380,7 +342,7 @@ mod tests {
     #[test]
     fn test_render_system_external() {
         let entity = system_entity();
-        let result = render_c4_macro("system", "payment_gateway", &entity, true, None);
+        let result = render_c4_macro("system", "payment_gateway", &entity, true);
         assert_eq!(
             result,
             "System_Ext(sys_payment_gateway, \"Payment Gateway\", $descr=\"Processes payments\", $link=\"/domains/billing/systems/payment-gateway\")"
@@ -390,7 +352,7 @@ mod tests {
     #[test]
     fn test_render_domain_regular() {
         let entity = domain_entity();
-        let result = render_c4_macro("domain", "billing", &entity, false, None);
+        let result = render_c4_macro("domain", "billing", &entity, false);
         assert_eq!(
             result,
             "System(dmn_billing, \"Billing\", $tags=\"domain\", \"Billing services\", $link=\"/domains/billing\")"
@@ -400,7 +362,7 @@ mod tests {
     #[test]
     fn test_render_domain_external() {
         let entity = domain_entity();
-        let result = render_c4_macro("domain", "billing", &entity, true, None);
+        let result = render_c4_macro("domain", "billing", &entity, true);
         assert_eq!(
             result,
             "System_Ext(dmn_billing, \"Billing\", $descr=\"Billing services\", $link=\"/domains/billing\")"
@@ -410,7 +372,7 @@ mod tests {
     #[test]
     fn test_render_service_regular() {
         let entity = service_entity();
-        let result = render_c4_macro("service", "invoice_api", &entity, false, None);
+        let result = render_c4_macro("service", "invoice_api", &entity, false);
         assert_eq!(
             result,
             "System(svc_invoice_api, \"invoice-api\", $tags=\"service\", $descr=\"Manages invoices\", $link=\"/domains/billing/systems/invoicing/services/invoice-api\")"
@@ -420,7 +382,7 @@ mod tests {
     #[test]
     fn test_render_service_external() {
         let entity = service_entity();
-        let result = render_c4_macro("service", "invoice_api", &entity, true, None);
+        let result = render_c4_macro("service", "invoice_api", &entity, true);
         assert_eq!(
             result,
             "System_Ext(svc_invoice_api, \"invoice-api\", $descr=\"Manages invoices\", $link=\"/domains/billing/systems/invoicing/services/invoice-api\")"
@@ -434,7 +396,7 @@ mod tests {
             description: None,
             url_path: Some("/simple".to_owned()),
         };
-        let result = render_c4_macro("system", "simple", &entity, false, None);
+        let result = render_c4_macro("system", "simple", &entity, false);
         assert_eq!(result, "System(sys_simple, \"Simple\", $link=\"/simple\")");
     }
 
@@ -445,7 +407,7 @@ mod tests {
             description: Some("Has no docs".to_owned()),
             url_path: None,
         };
-        let result = render_c4_macro("system", "no_docs", &entity, false, None);
+        let result = render_c4_macro("system", "no_docs", &entity, false);
         assert_eq!(result, "System(sys_no_docs, \"No Docs\", \"Has no docs\")");
         assert!(!result.contains("$link"));
     }
@@ -457,7 +419,7 @@ mod tests {
             description: Some("Line one\nLine two".to_owned()),
             url_path: Some("/multi".to_owned()),
         };
-        let result = render_c4_macro("system", "multi", &entity, false, None);
+        let result = render_c4_macro("system", "multi", &entity, false);
         assert!(result.contains("Line one\\nLine two"));
         assert!(!result.contains('\n'));
     }
@@ -469,7 +431,7 @@ mod tests {
             description: Some("He said \"hello\"".to_owned()),
             url_path: Some("/quoted".to_owned()),
         };
-        let result = render_c4_macro("system", "quoted", &entity, false, None);
+        let result = render_c4_macro("system", "quoted", &entity, false);
         assert!(result.contains(r#"He said \"hello\""#));
     }
 
@@ -480,7 +442,7 @@ mod tests {
             description: Some(r"C:\Users\docs".to_owned()),
             url_path: Some("/paths".to_owned()),
         };
-        let result = render_c4_macro("system", "paths", &entity, false, None);
+        let result = render_c4_macro("system", "paths", &entity, false);
         assert!(result.contains(r"C:\\Users\\docs"));
     }
 
@@ -489,54 +451,28 @@ mod tests {
     #[test]
     fn test_resolve_meta_include_system() {
         let source = TestSource::new().with_entity("system", "payment_gateway", system_entity());
-        let result =
-            resolve_meta_include("systems/sys_payment_gateway.iuml", &source, None).unwrap();
+        let result = resolve_meta_include("systems/sys_payment_gateway.iuml", &source).unwrap();
         assert!(result.contains("System(sys_payment_gateway"));
     }
 
     #[test]
     fn test_resolve_meta_include_external() {
         let source = TestSource::new().with_entity("system", "payment_gateway", system_entity());
-        let result =
-            resolve_meta_include("systems/ext/sys_payment_gateway.iuml", &source, None).unwrap();
+        let result = resolve_meta_include("systems/ext/sys_payment_gateway.iuml", &source).unwrap();
         assert!(result.contains("System_Ext"));
     }
 
     #[test]
     fn test_resolve_meta_include_not_found() {
         let source = TestSource::new();
-        let result = resolve_meta_include("systems/sys_unknown.iuml", &source, None);
+        let result = resolve_meta_include("systems/sys_unknown.iuml", &source);
         assert!(result.is_none());
     }
 
     #[test]
     fn test_resolve_meta_include_non_meta_path() {
         let source = TestSource::new().with_entity("system", "payment_gateway", system_entity());
-        let result = resolve_meta_include("c4/context.iuml", &source, None);
+        let result = resolve_meta_include("c4/context.iuml", &source);
         assert!(result.is_none());
-    }
-
-    // ── LinkConfig tests ─────────────────────────────────────────────
-
-    #[test]
-    fn test_render_no_url_with_link_config() {
-        let entity = EntityInfo {
-            title: "Virtual".to_owned(),
-            description: None,
-            url_path: None,
-        };
-        let config = LinkConfig { link_prefix: None };
-        let result = render_c4_macro("system", "virtual", &entity, false, Some(&config));
-        assert!(!result.contains("$link"));
-    }
-
-    #[test]
-    fn test_render_with_link_prefix() {
-        let entity = system_entity();
-        let config = LinkConfig {
-            link_prefix: Some("/rw-docs".to_owned()),
-        };
-        let result = render_c4_macro("system", "payment_gateway", &entity, false, Some(&config));
-        assert!(result.contains("$link=\"/rw-docs/domains/billing/systems/payment-gateway\""));
     }
 }

--- a/crates/rw-diagrams/src/plantuml.rs
+++ b/crates/rw-diagrams/src/plantuml.rs
@@ -9,9 +9,7 @@ use std::path::PathBuf;
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::meta_includes::{
-    LinkConfig, MetaIncludeSource, is_meta_include_pattern, resolve_meta_include,
-};
+use crate::meta_includes::{MetaIncludeSource, is_meta_include_pattern, resolve_meta_include};
 
 static INCLUDE_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?m)^(\s*)!include\s+(.+)$").unwrap());
@@ -48,7 +46,6 @@ pub(crate) fn resolve_includes(
     source: &str,
     include_dirs: &[PathBuf],
     meta_source: Option<&dyn MetaIncludeSource>,
-    link_config: Option<&LinkConfig>,
     depth: usize,
     warnings: &mut Vec<String>,
 ) -> String {
@@ -71,7 +68,7 @@ pub(crate) fn resolve_includes(
 
         // Try meta include source first
         if let Some(meta) = meta_source
-            && let Some(content) = resolve_meta_include(include_path, meta, link_config)
+            && let Some(content) = resolve_meta_include(include_path, meta)
         {
             let indented_content = indent_content(&content, leading_whitespace);
             result = result.replace(full_match, &indented_content);
@@ -83,14 +80,8 @@ pub(crate) fn resolve_includes(
         for dir in include_dirs {
             let full_path = dir.join(include_path);
             if let Ok(content) = std::fs::read_to_string(&full_path) {
-                let resolved_content = resolve_includes(
-                    &content,
-                    include_dirs,
-                    meta_source,
-                    link_config,
-                    depth + 1,
-                    warnings,
-                );
+                let resolved_content =
+                    resolve_includes(&content, include_dirs, meta_source, depth + 1, warnings);
                 // Indent included content to match the !include directive
                 let indented_content = indent_content(&resolved_content, leading_whitespace);
                 result = result.replace(full_match, &indented_content);
@@ -145,17 +136,9 @@ pub fn prepare_diagram_source(
     include_dirs: &[PathBuf],
     dpi: u32,
     meta_source: Option<&dyn MetaIncludeSource>,
-    link_config: Option<&LinkConfig>,
 ) -> PrepareResult {
     let mut warnings = Vec::new();
-    let resolved = resolve_includes(
-        source,
-        include_dirs,
-        meta_source,
-        link_config,
-        0,
-        &mut warnings,
-    );
+    let resolved = resolve_includes(source, include_dirs, meta_source, 0, &mut warnings);
 
     // Inject DPI and font config after @startuml directive
     let config_block = format!(
@@ -196,7 +179,7 @@ mod tests {
     #[test]
     fn test_prepare_diagram_source() {
         let source = "@startuml\nAlice -> Bob\n@enduml";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
 
         // DPI and font should be injected after @startuml
         assert_eq!(
@@ -209,7 +192,7 @@ mod tests {
     #[test]
     fn test_prepare_diagram_source_custom_dpi() {
         let source = "@startuml\nAlice -> Bob\n@enduml";
-        let result = prepare_diagram_source(source, &[], 300, None, None);
+        let result = prepare_diagram_source(source, &[], 300, None);
 
         assert_eq!(
             result.source,
@@ -221,7 +204,7 @@ mod tests {
     #[test]
     fn test_prepare_diagram_source_preserves_content_before_startuml() {
         let source = "' comment\n@startuml\nAlice -> Bob\n@enduml";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
 
         // Content before @startuml should be preserved
         assert_eq!(
@@ -234,7 +217,7 @@ mod tests {
     #[test]
     fn test_unresolved_include_generates_warning() {
         let source = "@startuml\n!include missing.iuml\nAlice -> Bob\n@enduml";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
 
         assert_eq!(result.warnings.len(), 1);
         assert!(result.warnings[0].contains("missing.iuml"));
@@ -245,7 +228,7 @@ mod tests {
     fn test_unresolved_include_with_dirs_shows_searched_paths() {
         let source = "@startuml\n!include missing.iuml\nAlice -> Bob\n@enduml";
         let include_dirs = vec![PathBuf::from("/tmp/includes")];
-        let result = prepare_diagram_source(source, &include_dirs, DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &include_dirs, DEFAULT_DPI, None);
 
         assert_eq!(result.warnings.len(), 1);
         assert!(result.warnings[0].contains("missing.iuml"));
@@ -255,7 +238,7 @@ mod tests {
     #[test]
     fn test_stdlib_include_no_warning() {
         let source = "@startuml\n!include <tupadr3/common>\nAlice -> Bob\n@enduml";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
 
         // Stdlib includes should not generate warnings
         assert!(result.warnings.is_empty());
@@ -271,13 +254,8 @@ mod tests {
         std::fs::write(&include_path, "Component(comp, \"Component\")").unwrap();
 
         let source = "@startuml\nSystem_Boundary(sys, \"System\")\n  !include test_component.iuml\nBoundary_End()\n@enduml";
-        let result = prepare_diagram_source(
-            source,
-            std::slice::from_ref(&temp_dir),
-            DEFAULT_DPI,
-            None,
-            None,
-        );
+        let result =
+            prepare_diagram_source(source, std::slice::from_ref(&temp_dir), DEFAULT_DPI, None);
 
         // Cleanup
         std::fs::remove_file(&include_path).unwrap();
@@ -291,7 +269,7 @@ mod tests {
     #[test]
     fn test_indented_include_warning() {
         let source = "@startuml\nSystem_Boundary(sys, \"System\")\n  !include missing.iuml\nBoundary_End()\n@enduml";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
 
         // Should generate warning for indented include too
         assert_eq!(result.warnings.len(), 1);
@@ -302,7 +280,7 @@ mod tests {
     fn test_prepare_diagram_source_no_startuml() {
         // Source without @startuml - fallback to prepending config
         let source = "Alice -> Bob";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
 
         // Config should be prepended
         assert!(result.source.starts_with("skinparam dpi 192\n"));
@@ -314,7 +292,7 @@ mod tests {
     fn test_prepare_diagram_source_startuml_no_newline() {
         // @startuml at end of source without newline
         let source = "@startuml";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
 
         // Should fallback to prepending
         assert!(result.source.contains("skinparam dpi 192"));
@@ -331,13 +309,8 @@ mod tests {
         std::fs::write(&include_path, "!include recursive.iuml\nContent").unwrap();
 
         let source = "@startuml\n!include recursive.iuml\n@enduml";
-        let result = prepare_diagram_source(
-            source,
-            std::slice::from_ref(&temp_dir),
-            DEFAULT_DPI,
-            None,
-            None,
-        );
+        let result =
+            prepare_diagram_source(source, std::slice::from_ref(&temp_dir), DEFAULT_DPI, None);
 
         std::fs::remove_file(&include_path).unwrap();
 
@@ -354,13 +327,8 @@ mod tests {
         std::fs::write(&include2, "Bob -> Charlie").unwrap();
 
         let source = "@startuml\n!include part1.iuml\n!include part2.iuml\n@enduml";
-        let result = prepare_diagram_source(
-            source,
-            std::slice::from_ref(&temp_dir),
-            DEFAULT_DPI,
-            None,
-            None,
-        );
+        let result =
+            prepare_diagram_source(source, std::slice::from_ref(&temp_dir), DEFAULT_DPI, None);
 
         std::fs::remove_file(&include1).unwrap();
         std::fs::remove_file(&include2).unwrap();
@@ -380,13 +348,8 @@ mod tests {
         std::fs::write(&outer, "OuterBefore\n!include inner.iuml\nOuterAfter").unwrap();
 
         let source = "@startuml\n!include outer.iuml\n@enduml";
-        let result = prepare_diagram_source(
-            source,
-            std::slice::from_ref(&temp_dir),
-            DEFAULT_DPI,
-            None,
-            None,
-        );
+        let result =
+            prepare_diagram_source(source, std::slice::from_ref(&temp_dir), DEFAULT_DPI, None);
 
         std::fs::remove_file(&outer).unwrap();
         std::fs::remove_file(&inner).unwrap();
@@ -404,13 +367,8 @@ mod tests {
         std::fs::write(&include_path, "Line1\n\nLine3").unwrap();
 
         let source = "@startuml\n  !include with_empty.iuml\n@enduml";
-        let result = prepare_diagram_source(
-            source,
-            std::slice::from_ref(&temp_dir),
-            DEFAULT_DPI,
-            None,
-            None,
-        );
+        let result =
+            prepare_diagram_source(source, std::slice::from_ref(&temp_dir), DEFAULT_DPI, None);
 
         std::fs::remove_file(&include_path).unwrap();
 
@@ -441,7 +399,7 @@ mod tests {
     fn test_meta_include_resolves_before_filesystem() {
         let source = "@startuml\n!include systems/sys_payment_gateway.iuml\nA -> B\n@enduml";
         let meta_source = TestMetaSource;
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, Some(&meta_source), None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, Some(&meta_source));
         assert!(result.warnings.is_empty());
         assert!(result.source.contains("System(sys_payment_gateway,"));
         assert!(result.source.contains("Payment Gateway"));
@@ -452,7 +410,7 @@ mod tests {
     fn test_meta_include_falls_back_to_filesystem() {
         let source = "@startuml\n!include systems/sys_unknown.iuml\n@enduml";
         let meta_source = TestMetaSource;
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, Some(&meta_source), None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, Some(&meta_source));
         assert!(!result.warnings.is_empty());
         assert!(result.warnings[0].contains("sys_unknown.iuml"));
     }
@@ -460,7 +418,7 @@ mod tests {
     #[test]
     fn test_no_meta_source_behaves_as_before() {
         let source = "@startuml\n!include missing.iuml\n@enduml";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
         assert!(!result.warnings.is_empty());
         assert!(result.warnings[0].contains("missing.iuml"));
     }
@@ -468,7 +426,7 @@ mod tests {
     #[test]
     fn test_meta_pattern_include_no_warning_without_meta_source() {
         let source = "@startuml\n!include systems/sys_payment_gateway.iuml\n@enduml";
-        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None, None);
+        let result = prepare_diagram_source(source, &[], DEFAULT_DPI, None);
         assert!(
             result.warnings.is_empty(),
             "Meta-pattern includes should not warn when no meta source: {:?}",

--- a/crates/rw-diagrams/src/processor.rs
+++ b/crates/rw-diagrams/src/processor.rs
@@ -19,7 +19,7 @@ use crate::kroki::{
     render_all_svg_partial,
 };
 use crate::language::{DiagramFormat, DiagramLanguage, ExtractedDiagram};
-use crate::meta_includes::{LinkConfig, MetaIncludeSource};
+use crate::meta_includes::MetaIncludeSource;
 use crate::output::{DiagramOutput, RenderedDiagramInfo, TagGenerator};
 use crate::plantuml::{PrepareResult, prepare_diagram_source, resolve_includes};
 use rw_cache::{Cache, CacheBucket, CacheBucketExt};
@@ -45,8 +45,6 @@ struct ProcessorConfig {
     agent: Agent,
     /// Optional metadata source for resolving virtual `PlantUML` includes.
     meta_include_source: Option<Arc<dyn MetaIncludeSource>>,
-    /// Optional link configuration for transforming `$link` URLs in C4 macros.
-    link_config: Option<LinkConfig>,
 }
 
 /// Code block processor for diagram languages.
@@ -112,7 +110,6 @@ impl DiagramProcessor {
                 output: DiagramOutput::default(),
                 agent: create_agent(DEFAULT_TIMEOUT),
                 meta_include_source: None,
-                link_config: None,
             },
             extracted: Vec::new(),
             warnings: Vec::new(),
@@ -223,15 +220,6 @@ impl DiagramProcessor {
         self
     }
 
-    /// Set link configuration for transforming `$link` URLs in C4 macros.
-    ///
-    /// When set, diagram include URLs are transformed to prepend a link prefix.
-    #[must_use]
-    pub fn with_link_config(mut self, link_config: LinkConfig) -> Self {
-        self.config.link_config = Some(link_config);
-        self
-    }
-
     /// Prepare diagram source for rendering.
     ///
     /// For `PlantUML` diagrams, this resolves `!include` directives and injects config.
@@ -243,7 +231,6 @@ impl DiagramProcessor {
                 &config.include_dirs,
                 config.dpi,
                 config.meta_include_source.as_deref(),
-                config.link_config.as_ref(),
             )
         } else {
             PrepareResult {
@@ -345,8 +332,7 @@ impl CodeBlockProcessor for DiagramProcessor {
         let resolved = resolve_includes(
             source,
             &self.config.include_dirs,
-            None, // Skip meta includes — resolved at request time with link_prefix
-            None,
+            None, // Skip meta includes — resolved at request time
             0,
             &mut warnings,
         );

--- a/crates/rw-napi/src/lib.rs
+++ b/crates/rw-napi/src/lib.rs
@@ -81,8 +81,6 @@ pub fn create_site(config: SiteConfig) -> Result<RwSite> {
         ));
     }
 
-    let link_prefix = config.link_prefix;
-
     let (storage, renderer_config, cache): (
         Arc<dyn Storage>,
         PageRendererConfig,
@@ -117,7 +115,6 @@ pub fn create_site(config: SiteConfig) -> Result<RwSite> {
 
         let mut renderer_config = PageRendererConfig {
             extract_title: true,
-            link_prefix,
             ..Default::default()
         };
         apply_diagrams_config(&mut renderer_config, config.diagrams.as_ref());
@@ -142,7 +139,6 @@ pub fn create_site(config: SiteConfig) -> Result<RwSite> {
             kroki_url: rw_config.diagrams_resolved.kroki_url,
             include_dirs: rw_config.diagrams_resolved.include_dirs,
             dpi: rw_config.diagrams_resolved.dpi,
-            link_prefix,
             ..Default::default()
         };
         apply_diagrams_config(&mut renderer_config, config.diagrams.as_ref());

--- a/crates/rw-napi/src/types.rs
+++ b/crates/rw-napi/src/types.rs
@@ -14,8 +14,6 @@ pub struct SiteConfig {
     #[napi(js_name = "projectDir")]
     pub project_dir: Option<String>,
     pub s3: Option<S3Config>,
-    #[napi(js_name = "linkPrefix")]
-    pub link_prefix: Option<String>,
     pub diagrams: Option<DiagramsConfig>,
 }
 

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -58,8 +58,6 @@ pub struct MarkdownRenderer<B: RenderBackend> {
     alert_stack: Vec<Option<AlertKind>>,
     /// Optional directive processor for `CommonMark` directives.
     directives: Option<DirectiveProcessor>,
-    /// Prefix prepended to all resolved internal link paths (e.g. `/rw-docs`).
-    link_prefix: Option<String>,
     _backend: PhantomData<B>,
 }
 
@@ -82,7 +80,6 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
             gfm: true,
             alert_stack: Vec::new(),
             directives: None,
-            link_prefix: None,
             _backend: PhantomData,
         }
     }
@@ -150,18 +147,6 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
     #[must_use]
     pub fn with_directives(mut self, processor: DirectiveProcessor) -> Self {
         self.directives = Some(processor);
-        self
-    }
-
-    /// Set a prefix for all resolved internal link paths (e.g., `/rw-docs`).
-    ///
-    /// When set, absolute link paths like `/docs/guide` become `/rw-docs/docs/guide`.
-    /// External links, fragment links, and protocol-relative links are not affected.
-    ///
-    /// The prefix should not end with `/` to avoid double slashes in output.
-    #[must_use]
-    pub fn with_link_prefix(mut self, prefix: impl Into<String>) -> Self {
-        self.link_prefix = Some(prefix.into());
         self
     }
 
@@ -267,24 +252,6 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         } else {
             self.output.push_str(content);
         }
-    }
-
-    /// Apply link-prefix transformation to a resolved href.
-    ///
-    /// Handles fragment (`#section`) correctly by splitting before path manipulation
-    /// and rejoining after.
-    fn resolve_href(&self, href: &str) -> String {
-        if let Some(prefix) = &self.link_prefix
-            && href.starts_with('/')
-        {
-            // Split fragment before path manipulation
-            let (path, fragment) = match href.find('#') {
-                Some(pos) => (&href[..pos], &href[pos..]),
-                None => (href, ""),
-            };
-            return format!("{prefix}{path}{fragment}");
-        }
-        href.to_owned()
     }
 
     /// Render markdown events and return the result.
@@ -406,7 +373,6 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
             Tag::Strikethrough => self.push_inline("<s>"),
             Tag::Link { dest_url, .. } => {
                 let href = B::transform_link(&dest_url, self.base_path.as_deref());
-                let href = self.resolve_href(&href);
                 let link_tag = format!(r#"<a href="{}">"#, escape_html(&href));
                 self.push_inline(&link_tag);
             }
@@ -1128,45 +1094,5 @@ Install with apt.
         let result = renderer.render_markdown(":::tab[Test]\nContent");
 
         assert!(result.warnings.iter().any(|w| w.contains("unclosed")));
-    }
-
-    #[test]
-    fn test_link_prefix_prepends_to_internal_links() {
-        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
-            .with_base_path("/docs/usage")
-            .with_link_prefix("/rw-docs");
-        let result = renderer.render_markdown("[link](./quick-start.md)");
-        assert!(
-            result
-                .html
-                .contains(r#"href="/rw-docs/docs/usage/quick-start""#)
-        );
-    }
-
-    #[test]
-    fn test_link_prefix_skips_external_links() {
-        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
-            .with_base_path("/docs")
-            .with_link_prefix("/rw-docs");
-        let result = renderer.render_markdown("[link](https://example.com)");
-        assert!(result.html.contains(r#"href="https://example.com""#));
-    }
-
-    #[test]
-    fn test_link_prefix_skips_fragment_links() {
-        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
-            .with_base_path("/docs")
-            .with_link_prefix("/rw-docs");
-        let result = renderer.render_markdown("[link](#section)");
-        assert!(result.html.contains(r##"href="#section""##));
-    }
-
-    #[test]
-    fn test_link_prefix_preserves_fragment_on_internal_links() {
-        let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
-            .with_base_path("/docs")
-            .with_link_prefix("/rw-docs");
-        let result = renderer.render_markdown("[link](./page.md#section)");
-        assert!(result.html.contains(r#"href="/rw-docs/docs/page#section""#));
     }
 }

--- a/crates/rw-server/src/lib.rs
+++ b/crates/rw-server/src/lib.rs
@@ -154,7 +154,6 @@ pub async fn run_server(config: ServerConfig) -> Result<(), ServerError> {
         kroki_url: config.kroki_url.clone(),
         include_dirs: config.include_dirs.clone(),
         dpi: config.dpi,
-        link_prefix: None,
     };
     let site = Arc::new(Site::new(Arc::clone(&storage), cache, site_config));
 

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use rw_cache::{Cache, CacheBucket, CacheBucketExt};
-use rw_diagrams::{DiagramProcessor, LinkConfig, MetaIncludeSource};
+use rw_diagrams::{DiagramProcessor, MetaIncludeSource};
 use rw_renderer::directive::DirectiveProcessor;
 use rw_renderer::{HtmlBackend, MarkdownRenderer, TabsDirective, TocEntry, escape_html};
 use rw_storage::{Metadata, Storage, StorageError, StorageErrorKind};
@@ -27,10 +27,6 @@ pub struct PageRendererConfig {
     pub include_dirs: Vec<PathBuf>,
     /// DPI for diagram rendering (default: 192 for retina).
     pub dpi: u32,
-    /// Prefix prepended to all resolved internal link paths (e.g. `/rw-docs`).
-    ///
-    /// Default: `None` (no prefix).
-    pub link_prefix: Option<String>,
 }
 
 impl Default for PageRendererConfig {
@@ -40,7 +36,6 @@ impl Default for PageRendererConfig {
             kroki_url: None,
             include_dirs: Vec::new(),
             dpi: 192,
-            link_prefix: None,
         }
     }
 }
@@ -129,7 +124,6 @@ pub(crate) struct PageRenderer {
     kroki_url: Option<String>,
     include_dirs: Vec<PathBuf>,
     dpi: u32,
-    link_prefix: Option<String>,
 }
 
 impl PageRenderer {
@@ -147,7 +141,6 @@ impl PageRenderer {
             kroki_url: config.kroki_url,
             include_dirs: config.include_dirs,
             dpi: config.dpi,
-            link_prefix: config.link_prefix,
         }
     }
 
@@ -253,10 +246,6 @@ impl PageRenderer {
             .with_base_path(format!("/{base_path}"))
             .with_directives(directives);
 
-        if let Some(prefix) = &self.link_prefix {
-            renderer = renderer.with_link_prefix(prefix);
-        }
-
         if self.extract_title {
             renderer = renderer.with_title_extraction();
         }
@@ -281,12 +270,6 @@ impl PageRenderer {
 
         if let Some(source) = meta_include_source {
             processor = processor.with_meta_include_source(source);
-        }
-
-        if self.link_prefix.is_some() {
-            processor = processor.with_link_config(LinkConfig {
-                link_prefix: self.link_prefix.clone(),
-            });
         }
 
         Some(processor)

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -73,7 +73,6 @@ export interface SectionResponse {
 export interface SiteConfig {
   projectDir?: string
   s3?: S3Config
-  linkPrefix?: string
   diagrams?: DiagramsConfig
 }
 


### PR DESCRIPTION
## Summary

- Remove `linkPrefix` option from `@rwdocs/core` `createSite()` config and all internal wiring
- Remove `LinkConfig`, `resolve_link()`, `resolve_href()`, `with_link_prefix()` and related parameter threading from renderer, diagrams, and site crates
- Delete 7 link-prefix tests from renderer and 2 from diagrams

## Test plan

- [x] All 726 Rust tests pass
- [x] `make format` clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)