### PR TITLE
fix: make get_section_ref always return a section ref

### DIFF
--- a/crates/rw-napi/src/types.rs
+++ b/crates/rw-napi/src/types.rs
@@ -82,7 +82,7 @@ pub struct PageMetaResponse {
     pub page_kind: Option<String>,
     pub vars: Option<Value>,
     #[napi(js_name = "sectionRef")]
-    pub section_ref: Option<String>,
+    pub section_ref: String,
 }
 
 #[napi(object)]

--- a/crates/rw-sections/src/lib.rs
+++ b/crates/rw-sections/src/lib.rs
@@ -13,6 +13,9 @@ pub const ROOT_SECTION_KIND: &str = "section";
 /// Name used for sections rooted at the empty path (both implicit and explicit).
 pub const ROOT_SECTION_NAME: &str = "root";
 
+/// Section ref string for the implicit root section (`"section:default/root"`).
+pub const ROOT_SECTION_REF: &str = "section:default/root";
+
 /// Section identity.
 ///
 /// Represents a documentation section with a kind (e.g., `"domain"`, `"system"`)

--- a/crates/rw-server/src/handlers/pages.rs
+++ b/crates/rw-server/src/handlers/pages.rs
@@ -54,9 +54,8 @@ struct PageMeta {
     /// Custom variables (from metadata).
     #[serde(skip_serializing_if = "Option::is_none")]
     vars: Option<serde_json::Value>,
-    /// Section ref for this page's section (null at root scope).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    section_ref: Option<String>,
+    /// Section ref for this page's section.
+    section_ref: String,
 }
 
 /// Breadcrumb item for serialization.
@@ -261,7 +260,7 @@ mod tests {
             description: None,
             page_kind: None,
             vars: None,
-            section_ref: None,
+            section_ref: "section:default/root".to_owned(),
         };
 
         let json = serde_json::to_value(&meta).unwrap();
@@ -270,8 +269,8 @@ mod tests {
         assert_eq!(json["path"], "/guide");
         assert_eq!(json["sourceFile"], "/docs/guide.md");
         assert_eq!(json["lastModified"], "2025-01-01T00:00:00Z");
-        // sectionRef, description, kind, and vars should be omitted when None
-        assert!(json.get("sectionRef").is_none());
+        assert_eq!(json["sectionRef"], "section:default/root");
+        // description, kind, and vars should be omitted when None
         assert!(json.get("description").is_none());
         assert!(json.get("kind").is_none());
         assert!(json.get("vars").is_none());
@@ -290,7 +289,7 @@ mod tests {
             description: Some("Domain overview".to_owned()),
             page_kind: Some("domain".to_owned()),
             vars: Some(serde_json::to_value(vars).unwrap()),
-            section_ref: Some("domain:default/domain".to_owned()),
+            section_ref: "domain:default/domain".to_owned(),
         };
 
         let json = serde_json::to_value(&meta).unwrap();

--- a/crates/rw-site/src/site.rs
+++ b/crates/rw-site/src/site.rs
@@ -192,7 +192,8 @@ impl Site {
     /// Get the section ref string for the section a page belongs to.
     ///
     /// Reloads site if needed and returns the ref (e.g., `"domain:default/billing"`)
-    /// for the nearest section ancestor, or `None` if the page is at root scope.
+    /// for the nearest section ancestor, falling back to the implicit root
+    /// section (`section:default/root`) when no explicit section is found.
     ///
     /// # Arguments
     ///
@@ -202,7 +203,7 @@ impl Site {
     ///
     /// Panics if internal locks are poisoned.
     #[must_use]
-    pub fn get_section_ref(&self, page_path: &str) -> Option<String> {
+    pub fn get_section_ref(&self, page_path: &str) -> String {
         self.reload_if_needed().state.get_section_ref(page_path)
     }
 

--- a/crates/rw-site/src/site_state.rs
+++ b/crates/rw-site/src/site_state.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rw_cache::{CacheBucket, CacheBucketExt};
-use rw_sections::{ROOT_SECTION_KIND, ROOT_SECTION_NAME, Section, Sections};
+use rw_sections::{ROOT_SECTION_KIND, ROOT_SECTION_NAME, ROOT_SECTION_REF, Section, Sections};
 use serde::{Deserialize, Serialize};
 
 use crate::page::{BreadcrumbItem, Page};
@@ -399,29 +399,31 @@ impl SiteState {
     /// Get the section ref string for the section a page belongs to.
     ///
     /// Returns the ref (e.g., `"domain:default/billing"`) for the nearest section
-    /// ancestor, or `None` if the page is at root scope.
+    /// ancestor, falling back to the implicit root section (`section:default/root`)
+    /// when no explicit section is found.
     ///
     /// # Arguments
     ///
     /// * `page_path` - URL path without leading slash.
     #[must_use]
-    pub fn get_section_ref(&self, page_path: &str) -> Option<String> {
-        // If the page itself is a section, return its ref
+    pub fn get_section_ref(&self, page_path: &str) -> String {
         if let Some(section) = self.sections.get(page_path) {
-            return Some(Section::from(section).to_string());
+            return Section::from(section).to_string();
         }
 
-        // Walk up the path to find the nearest section ancestor
         let mut current = page_path;
         while let Some((parent, _)) = current.rsplit_once('/') {
             if let Some(section) = self.sections.get(parent) {
-                return Some(Section::from(section).to_string());
+                return Section::from(section).to_string();
             }
             current = parent;
         }
 
-        // No section ancestor found — root scope
-        None
+        if let Some(section) = self.sections.get("") {
+            return Section::from(section).to_string();
+        }
+
+        ROOT_SECTION_REF.to_owned()
     }
 
     /// Build [`NavItem`] but stop recursion at section boundaries.
@@ -1392,7 +1394,7 @@ mod tests {
 
         let section_ref = site.get_section_ref("billing");
 
-        assert_eq!(section_ref.as_deref(), Some("domain:default/billing"));
+        assert_eq!(section_ref, "domain:default/billing");
     }
 
     #[test]
@@ -1418,7 +1420,7 @@ mod tests {
 
         let section_ref = site.get_section_ref("billing/payments");
 
-        assert_eq!(section_ref.as_deref(), Some("domain:default/billing"));
+        assert_eq!(section_ref, "domain:default/billing");
     }
 
     #[test]
@@ -1452,7 +1454,7 @@ mod tests {
 
         // API page should belong to the payments section (nearest ancestor)
         let section_ref = site.get_section_ref("billing/payments/api");
-        assert_eq!(section_ref.as_deref(), Some("system:default/payments"));
+        assert_eq!(section_ref, "system:default/payments");
     }
 
     #[test]
@@ -1470,7 +1472,8 @@ mod tests {
 
         let section_ref = site.get_section_ref("guide");
 
-        assert!(section_ref.is_none()); // Root scope
+        // Falls back to implicit root section
+        assert_eq!(section_ref, ROOT_SECTION_REF);
     }
 
     #[test]

--- a/packages/viewer/src/api/client.test.ts
+++ b/packages/viewer/src/api/client.test.ts
@@ -12,7 +12,7 @@ const mockPage: PageResponse = {
     path: "/test",
     sourceFile: "test.md",
     lastModified: "2025-01-01T00:00:00Z",
-    sectionRef: undefined,
+    sectionRef: "section:default/root",
   },
   breadcrumbs: [],
   toc: [],

--- a/packages/viewer/src/state/page.test.svelte.ts
+++ b/packages/viewer/src/state/page.test.svelte.ts
@@ -10,7 +10,7 @@ const mockPageResponse: PageResponse = {
     path: "/test",
     sourceFile: "test.md",
     lastModified: "2025-01-01T00:00:00Z",
-    sectionRef: undefined,
+    sectionRef: "section:default/root",
   },
   breadcrumbs: [{ title: "Home", path: "/" }],
   toc: [{ level: 2, title: "Section", id: "section" }],

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -55,8 +55,8 @@ export interface PageMeta {
   description?: string;
   kind?: string;
   vars?: Record<string, unknown>;
-  /** Section ref for this page's section (e.g., "domain:default/billing"). Absent at root scope. */
-  sectionRef?: string;
+  /** Section ref for this page's section (e.g., "domain:default/billing"). */
+  sectionRef: string;
 }
 
 /** Breadcrumb navigation item */


### PR DESCRIPTION
## Summary

- `get_section_ref` now falls back to the implicit root section (`section:default/root`) instead of returning `None`, fixing a mismatch where navigation items included the implicit root (via `build_sections`/`apply_sections`) but page API responses did not
- `sectionRef` field is now non-optional (`String` in Rust, `string` in TypeScript) across server API, NAPI, and viewer types

## Test plan

- [x] All existing Rust tests updated and passing
- [x] All existing frontend tests updated and passing
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)