### PR TITLE
fix(nav): return implicit root scope in navigation API

### DIFF
--- a/crates/rw-server/src/handlers/navigation.rs
+++ b/crates/rw-server/src/handlers/navigation.rs
@@ -26,10 +26,10 @@ pub(crate) struct NavigationQuery {
 pub(crate) struct NavigationResponse {
     /// Navigation tree items.
     items: Vec<NavItemResponse>,
-    /// Current scope info (null at root).
+    /// Current scope info (implicit root section at root, explicit section otherwise).
     #[serde(skip_serializing_if = "Option::is_none")]
     scope: Option<ScopeInfoResponse>,
-    /// Parent scope for back navigation (null at root or if no parent section).
+    /// Parent scope for back navigation (null only at root).
     #[serde(rename = "parentScope", skip_serializing_if = "Option::is_none")]
     parent_scope: Option<ScopeInfoResponse>,
 }

--- a/crates/rw-site/src/site_state.rs
+++ b/crates/rw-site/src/site_state.rs
@@ -87,10 +87,10 @@ pub struct ScopeInfo {
 pub struct Navigation {
     /// Navigation items for this scope.
     pub items: Vec<NavItem>,
-    /// Current scope info (None at root).
+    /// Current scope info (implicit root section at root, explicit section otherwise).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<ScopeInfo>,
-    /// Parent scope for back navigation (None at root or if no parent section).
+    /// Parent scope for back navigation (None only at root).
     #[serde(rename = "parentScope", skip_serializing_if = "Option::is_none")]
     pub parent_scope: Option<ScopeInfo>,
 }
@@ -343,7 +343,8 @@ impl SiteState {
 
     /// Build navigation scoped to a section.
     ///
-    /// If `scope_path` is empty, returns root navigation with sections as leaves.
+    /// If `scope_path` is empty, returns root navigation with an implicit root
+    /// section scope and sections as leaves.
     /// If `scope_path` points to a section, returns that section's children.
     ///
     /// # Arguments
@@ -361,7 +362,7 @@ impl SiteState {
 
             Navigation {
                 items,
-                scope: None,
+                scope: Some(self.root_scope_info()),
                 parent_scope: None,
             }
         } else {
@@ -460,10 +461,14 @@ impl SiteState {
     ///
     /// # Returns
     ///
-    /// `ScopeInfo` for the parent section, or `None` if at root level
-    /// (including pages in the implicit root section, which have no parent
-    /// to navigate back to).
+    /// `ScopeInfo` for the parent section. Falls back to the implicit root
+    /// section for top-level sections. Returns `None` only for the root scope
+    /// itself (which has no parent).
     fn find_parent_section(&self, path: &str) -> Option<ScopeInfo> {
+        if path.is_empty() {
+            return None;
+        }
+
         let mut current = path;
         while let Some((parent, _)) = current.rsplit_once('/') {
             if let Some(section) = self.sections.get(parent) {
@@ -475,7 +480,25 @@ impl SiteState {
             }
             current = parent;
         }
-        None
+
+        Some(self.root_scope_info())
+    }
+
+    /// Build a `ScopeInfo` for the implicit root section.
+    fn root_scope_info(&self) -> ScopeInfo {
+        let title = self
+            .get_page("")
+            .map(|p| p.title.clone())
+            .unwrap_or_else(|| "Home".to_owned());
+
+        ScopeInfo {
+            path: "/".to_owned(),
+            title,
+            section: Section {
+                kind: ROOT_SECTION_KIND.to_owned(),
+                name: ROOT_SECTION_NAME.to_owned(),
+            },
+        }
     }
 
     /// Build a sections map for cross-section link annotation.
@@ -1234,8 +1257,12 @@ mod tests {
 
         let nav = site.navigation("");
 
-        // Root scope should have no scope info
-        assert!(nav.scope.is_none());
+        // Root scope should have implicit root section scope
+        let scope = nav.scope.as_ref().unwrap();
+        assert_eq!(scope.path, "/");
+        assert_eq!(scope.title, "Home");
+        assert_eq!(scope.section.kind, ROOT_SECTION_KIND);
+        assert_eq!(scope.section.name, ROOT_SECTION_NAME);
         assert!(nav.parent_scope.is_none());
 
         // Should show both items
@@ -1317,8 +1344,12 @@ mod tests {
         assert_eq!(scope.section.kind, "domain");
         assert_eq!(scope.section.name, "billing");
 
-        // No parent section
-        assert!(nav.parent_scope.is_none());
+        // Parent is implicit root section
+        let parent = nav.parent_scope.unwrap();
+        assert_eq!(parent.path, "/");
+        assert_eq!(parent.title, "Home");
+        assert_eq!(parent.section.kind, ROOT_SECTION_KIND);
+        assert_eq!(parent.section.name, ROOT_SECTION_NAME);
 
         // Should show billing's children
         assert_eq!(nav.items.len(), 2);

--- a/packages/viewer/e2e/embedded-root-scope.spec.ts
+++ b/packages/viewer/e2e/embedded-root-scope.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Root scope - Embedded", () => {
+  test("root page has no back link or section title", async ({ page }) => {
+    await page.goto("/");
+
+    const sidebar = page.getByRole("complementary", { name: "Sidebar" });
+    await expect(sidebar).toBeVisible();
+
+    // Navigation items should be present
+    await expect(sidebar.getByRole("link", { name: "Getting Started" })).toBeVisible();
+
+    // No back link should be rendered (parentScope is null at root)
+    await expect(sidebar.getByRole("link", { name: "Test Documentation" })).toBeHidden();
+
+    // No section title heading should be rendered
+    await expect(sidebar.getByRole("heading", { level: 2 })).toBeHidden();
+  });
+
+  test("section page shows back-to-home link", async ({ page }) => {
+    // Navigate to a page inside a section (billing/ has kind: domain in meta.yaml)
+    await page.goto("/billing/invoices");
+
+    // Wait for page content to load first
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Invoices");
+
+    // The section watcher detects sectionRef and reloads navigation scoped to this section
+    const sidebar = page.getByRole("complementary", { name: "Sidebar" });
+    const backLink = sidebar.getByRole("link", { name: "Test Documentation" });
+    await expect(backLink).toBeVisible();
+
+    // Section title should be displayed
+    const sectionTitle = sidebar.getByRole("heading", { level: 2 });
+    await expect(sectionTitle).toBeVisible();
+    await expect(sectionTitle).toHaveText("Billing");
+  });
+});

--- a/packages/viewer/e2e/fixtures/docs/billing/index.md
+++ b/packages/viewer/e2e/fixtures/docs/billing/index.md
@@ -1,0 +1,3 @@
+# Billing
+
+Overview of the billing domain.

--- a/packages/viewer/e2e/fixtures/docs/billing/invoices.md
+++ b/packages/viewer/e2e/fixtures/docs/billing/invoices.md
@@ -1,0 +1,3 @@
+# Invoices
+
+Invoice management and processing.

--- a/packages/viewer/e2e/fixtures/docs/billing/meta.yaml
+++ b/packages/viewer/e2e/fixtures/docs/billing/meta.yaml
@@ -1,0 +1,1 @@
+kind: domain

--- a/packages/viewer/e2e/root-scope.spec.ts
+++ b/packages/viewer/e2e/root-scope.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Root scope - Standalone", () => {
+  test("root page has no back link or section title", async ({ page }) => {
+    await page.goto("/");
+
+    const sidebar = page.getByRole("complementary", { name: "Sidebar" });
+    await expect(sidebar).toBeVisible();
+
+    // Navigation items should be present
+    await expect(sidebar.getByRole("link", { name: "Getting Started" })).toBeVisible();
+
+    // No back link should be rendered (parentScope is null at root)
+    await expect(sidebar.getByRole("link", { name: "Test Documentation" })).toBeHidden();
+
+    // No section title heading should be rendered
+    await expect(sidebar.getByRole("heading", { level: 2 })).toBeHidden();
+  });
+
+  test("section page shows back-to-home link", async ({ page }) => {
+    // Navigate to a page inside a section (billing/ has kind: domain in meta.yaml)
+    await page.goto("/billing/invoices");
+
+    // Wait for page content to load first
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("Invoices");
+
+    // The section watcher detects sectionRef and reloads navigation scoped to this section
+    const sidebar = page.getByRole("complementary", { name: "Sidebar" });
+    const backLink = sidebar.getByRole("link", { name: "Test Documentation" });
+    await expect(backLink).toBeVisible();
+
+    // Section title should be displayed
+    const sectionTitle = sidebar.getByRole("heading", { level: 2 });
+    await expect(sectionTitle).toBeVisible();
+    await expect(sectionTitle).toHaveText("Billing");
+
+    // Clicking the back link should navigate to home
+    await backLink.click();
+    await expect(page.getByRole("article")).toContainText("Test Documentation");
+  });
+});

--- a/packages/viewer/src/App.svelte
+++ b/packages/viewer/src/App.svelte
@@ -115,8 +115,9 @@
       // Load navigation — pass sectionRef for scoped loading in embedded mode
       await navigation.load(currentSectionRef ? { sectionRef: currentSectionRef } : undefined);
 
-      // Extract scopePath from navigation response (embedded mode with sectionRef)
-      if (navigation.tree?.scope?.path) {
+      // Extract scopePath from navigation response (embedded mode with sectionRef).
+      // Skip root scope ("/") — it has no path prefix to strip/add.
+      if (navigation.tree?.scope?.path && navigation.tree.scope.path !== "/") {
         router.setScopePath(navigation.tree.scope.path);
       }
 

--- a/packages/viewer/src/components/NavigationSidebar.svelte
+++ b/packages/viewer/src/components/NavigationSidebar.svelte
@@ -4,11 +4,7 @@
 
   const { navigation, router } = getRwContext();
 
-  let backLink = $derived.by(() => {
-    const tree = navigation.tree;
-    if (!tree?.scope) return null;
-    return tree.parentScope ?? { path: "/", title: "Home", href: undefined };
-  });
+  let backLink = $derived(navigation.tree?.parentScope ?? null);
 </script>
 
 {#if navigation.loading}

--- a/packages/viewer/src/lib/sectionRefs.ts
+++ b/packages/viewer/src/lib/sectionRefs.ts
@@ -76,11 +76,13 @@ export async function resolveNavTree(
   tree: NavigationTree,
   resolver: SectionRefResolver,
 ): Promise<NavigationTree> {
-  // For top-level sections (scope exists but no parentScope), synthesize a
-  // root parentScope so the resolver can map it to the source entity URL.
+  // The backend provides parentScope for all non-root sections. This fallback
+  // handles older backends that may omit it for top-level sections. The root
+  // scope itself (path "/") has no parent to navigate back to.
+  const isRootScope = tree.scope?.path === "/";
   const effectiveParentScope: ScopeInfo | undefined =
     tree.parentScope ??
-    (tree.scope
+    (tree.scope && !isRootScope
       ? { path: "/", title: "Home", section: { kind: "section", name: "root" } }
       : undefined);
 


### PR DESCRIPTION
## Summary

- Root navigation API now returns `scope` with implicit root section (`section:default/root`) instead of `null`, enabling the embedded viewer to resolve the root entity's base URL via the section ref resolver
- `find_parent_section` falls back to root section for top-level sections, replacing the hardcoded frontend fallback
- Frontend skips `setScopePath` for root scope (`"/"`) and uses `parentScope` presence to control section UI visibility

Closes #232

## Test plan

- [x] All 94 Rust tests pass (`rw-site` + `rw-server`)
- [x] Verify standalone mode: root page has no back link or section title
- [x] Verify standalone mode: section pages (e.g., billing) show back-to-home link
- [x] Verify embedded mode: root entity nav links are prefixed with host base URL
- [x] Verify embedded mode: root page has no back link or section title

🤖 Generated with [Claude Code](https://claude.com/claude-code)