### PR TITLE
refactor: replace duplicated error chain formatters with shared utility

### DIFF
--- a/crates/rw-napi/src/lib.rs
+++ b/crates/rw-napi/src/lib.rs
@@ -12,7 +12,7 @@ use rw_cache::{Cache, NullCache};
 use rw_cache_s3::S3Cache;
 use rw_config::Config;
 use rw_site::{NavItem, PageRendererConfig, ScopeInfo, Site};
-use rw_storage::Storage;
+use rw_storage::{Storage, format_error_chain};
 use rw_storage_fs::FsStorage;
 use rw_storage_s3::{S3Config, S3Storage};
 
@@ -20,18 +20,6 @@ use crate::types::{
     BreadcrumbResponse, DiagramsConfig, NavItemResponse, NavigationResponse, PageMetaResponse,
     PageResponse, ScopeInfoResponse, SectionResponse, SiteConfig, TocEntryResponse,
 };
-
-/// Format an error with its full source chain.
-fn error_chain(err: &dyn std::error::Error) -> String {
-    let mut msg = err.to_string();
-    let mut source = err.source();
-    while let Some(cause) = source {
-        msg.push_str(": ");
-        msg.push_str(&cause.to_string());
-        source = cause.source();
-    }
-    msg
-}
 
 fn apply_diagrams_config(
     renderer_config: &mut PageRendererConfig,
@@ -115,7 +103,7 @@ pub fn create_site(config: SiteConfig) -> Result<RwSite> {
             secret_access_key: s3.secret_access_key,
         };
         let storage = S3Storage::new(s3_config).map_err(|e| {
-            napi::Error::from_reason(format!("Failed to create S3 storage: {}", error_chain(&e)))
+            napi::Error::from_reason(format!("Failed to create S3 storage: {}", format_error_chain(&e)))
         })?;
 
         let cache: Arc<dyn Cache> = Arc::new(S3Cache::new(
@@ -174,7 +162,7 @@ impl RwSite {
         let nav = self
             .site
             .navigation(section_ref.as_deref())
-            .map_err(|e| napi::Error::from_reason(e.display_chain()))?;
+            .map_err(|e| napi::Error::from_reason(format_error_chain(&e)))?;
         Ok(NavigationResponse {
             items: nav.items.into_iter().map(convert_nav_item).collect(),
             scope: nav.scope.map(convert_scope_info),
@@ -199,14 +187,14 @@ impl RwSite {
 fn build_page_response(site: &Site, path: &str) -> Result<PageResponse> {
     let result = site
         .render(path)
-        .map_err(|e| napi::Error::from_reason(error_chain(&e)))?;
+        .map_err(|e| napi::Error::from_reason(format_error_chain(&e)))?;
 
     let source_mtime = UNIX_EPOCH + Duration::from_secs_f64(result.source_mtime);
     let last_modified: DateTime<Utc> = source_mtime.into();
     let last_modified = last_modified.to_rfc3339();
     let section_ref = site
         .get_section_ref(path)
-        .map_err(|e| napi::Error::from_reason(e.display_chain()))?;
+        .map_err(|e| napi::Error::from_reason(format_error_chain(&e)))?;
 
     let (description, page_kind, vars) = if let Some(ref meta) = result.metadata {
         (

--- a/crates/rw-server/src/error.rs
+++ b/crates/rw-server/src/error.rs
@@ -4,7 +4,7 @@ use std::net::AddrParseError;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use rw_storage::StorageError;
+use rw_storage::{StorageError, format_error_chain};
 use serde_json::json;
 
 /// Error returned when the server fails to start.
@@ -52,15 +52,15 @@ impl IntoResponse for HandlerError {
             ),
             Self::Render(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                json!({"error": e.to_string()}),
+                json!({"error": format_error_chain(e)}),
             ),
             Self::Io(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                json!({"error": e.to_string()}),
+                json!({"error": format_error_chain(e)}),
             ),
             Self::Storage(e) => (
                 StatusCode::SERVICE_UNAVAILABLE,
-                json!({"error": "Storage unavailable", "detail": e.display_chain()}),
+                json!({"error": "Storage unavailable", "detail": format_error_chain(e)}),
             ),
         };
 

--- a/crates/rw-server/src/error.rs
+++ b/crates/rw-server/src/error.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {
     /// Failed to start file watching for live reload.
-    #[error("failed to start file watcher: {0}")]
+    #[error("failed to start file watcher")]
     Watch(#[from] StorageError),
 
     /// Invalid bind address.

--- a/crates/rw-server/src/error.rs
+++ b/crates/rw-server/src/error.rs
@@ -31,15 +31,15 @@ pub(crate) enum HandlerError {
     PageNotFound(String),
 
     /// Render error from rw-site.
-    #[error("Render error: {0}")]
+    #[error("Render error")]
     Render(#[from] rw_site::RenderError),
 
     /// I/O error.
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     Io(#[from] std::io::Error),
 
     /// Storage backend unavailable.
-    #[error("Storage error: {0}")]
+    #[error("Storage error")]
     Storage(#[from] rw_storage::StorageError),
 }
 

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -96,10 +96,10 @@ pub enum RenderError {
     #[error("Page not found: {0}")]
     PageNotFound(String),
     /// I/O error reading source file.
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     Io(#[source] std::io::Error),
     /// Storage backend error (e.g., S3 unavailable).
-    #[error("Storage error: {0}")]
+    #[error("Storage error")]
     Storage(#[source] StorageError),
 }
 

--- a/crates/rw-storage-s3/src/s3.rs
+++ b/crates/rw-storage-s3/src/s3.rs
@@ -110,18 +110,8 @@ pub async fn upload(
         .content_type(content_type)
         .send()
         .await
-        .map_err(|e| error_chain(&e))?;
+        .map_err(|e| rw_storage::format_error_chain(&e))?;
     tracing::debug!(key = %key, "Uploaded");
     Ok(())
 }
 
-/// Format an error and its full source chain into a single string.
-pub(crate) fn error_chain(err: &dyn std::error::Error) -> String {
-    let mut msgs = vec![err.to_string()];
-    let mut source = err.source();
-    while let Some(s) = source {
-        msgs.push(s.to_string());
-        source = s.source();
-    }
-    msgs.join(": ")
-}

--- a/crates/rw-storage-s3/src/s3.rs
+++ b/crates/rw-storage-s3/src/s3.rs
@@ -114,4 +114,3 @@ pub async fn upload(
     tracing::debug!(key = %key, "Uploaded");
     Ok(())
 }
-

--- a/crates/rw-storage/src/lib.rs
+++ b/crates/rw-storage/src/lib.rs
@@ -38,4 +38,6 @@ pub use event::{StorageEvent, StorageEventKind, StorageEventReceiver, WatchHandl
 pub use metadata::{Metadata, MetadataError};
 #[cfg(feature = "mock")]
 pub use mock::MockStorage;
-pub use storage::{Document, ErrorStatus, Storage, StorageError, StorageErrorKind};
+pub use storage::{
+    Document, ErrorStatus, Storage, StorageError, StorageErrorKind, format_error_chain,
+};

--- a/crates/rw-storage/src/storage.rs
+++ b/crates/rw-storage/src/storage.rs
@@ -501,7 +501,7 @@ mod tests {
 
     #[test]
     fn test_format_error_chain() {
-        let inner = std::io::Error::new(std::io::ErrorKind::Other, "connection reset");
+        let inner = std::io::Error::other("connection reset");
         let err = StorageError::new(StorageErrorKind::Unavailable)
             .with_backend("S3")
             .with_source(inner);

--- a/crates/rw-storage/src/storage.rs
+++ b/crates/rw-storage/src/storage.rs
@@ -137,24 +137,6 @@ impl StorageError {
         self
     }
 
-    /// Format the error with its full source chain.
-    ///
-    /// Unlike `Display` (which shows only the immediate source), this walks
-    /// the entire `.source()` chain so wrapped errors like the AWS SDK's
-    /// "dispatch failure" reveal the root cause.
-    #[must_use]
-    pub fn display_chain(&self) -> String {
-        let mut msg = self.to_string();
-        // Display already includes the immediate source, so start one level deeper.
-        let mut next = self.source.as_deref().and_then(std::error::Error::source);
-        while let Some(cause) = next {
-            msg.push_str(": ");
-            msg.push_str(&cause.to_string());
-            next = cause.source();
-        }
-        msg
-    }
-
     /// Downcast the source error to a concrete type.
     #[must_use]
     pub fn downcast_source<E: std::error::Error + 'static>(&self) -> Option<&E> {
@@ -209,10 +191,6 @@ impl std::fmt::Display for StorageError {
 
         write!(f, "{kind_str}")?;
 
-        if let Some(source) = &self.source {
-            write!(f, ": {source}")?;
-        }
-
         if let Some(path) = &self.path {
             write!(f, " (path: {})", path.display())?;
         }
@@ -227,6 +205,21 @@ impl std::error::Error for StorageError {
             .as_ref()
             .map(|s| s.as_ref() as &(dyn std::error::Error + 'static))
     }
+}
+
+/// Format an error with its full source chain.
+///
+/// Produces a colon-separated chain like
+/// `"Unavailable: dispatch failure: TLS error"`.
+pub fn format_error_chain(err: &dyn std::error::Error) -> String {
+    let mut msg = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        msg.push_str(": ");
+        msg.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    msg
 }
 
 /// Storage abstraction for document scanning and retrieval.
@@ -503,9 +496,19 @@ mod tests {
             .with_path("/foo/bar")
             .with_source(io_err);
 
+        assert_eq!(err.to_string(), "[Fs] Not found (path: /foo/bar)");
+    }
+
+    #[test]
+    fn test_format_error_chain() {
+        let inner = std::io::Error::new(std::io::ErrorKind::Other, "connection reset");
+        let err = StorageError::new(StorageErrorKind::Unavailable)
+            .with_backend("S3")
+            .with_source(inner);
+
         assert_eq!(
-            err.to_string(),
-            "[Fs] Not found: file not found (path: /foo/bar)"
+            format_error_chain(&err),
+            "[S3] Unavailable: connection reset"
         );
     }
 

--- a/crates/rw/src/error.rs
+++ b/crates/rw/src/error.rs
@@ -7,22 +7,22 @@ use rw_server::ServerError;
 /// CLI error type.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CliError {
-    #[error("{0}")]
+    #[error(transparent)]
     Config(#[from] ConfigError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Confluence(#[from] ConfluenceError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Update(#[from] UpdateError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     BundlePublish(#[from] rw_storage_s3::BundlePublishError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Server(#[from] ServerError),
 
     #[error("{0}")]

--- a/crates/rw/src/main.rs
+++ b/crates/rw/src/main.rs
@@ -15,6 +15,7 @@ use tracing_subscriber::EnvFilter;
 
 use commands::{BackstageCommand, ConfluenceCommand, ServeArgs};
 use output::Output;
+use rw_storage::format_error_chain;
 
 /// Application version from Cargo.toml.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -65,7 +66,7 @@ fn main() {
     };
 
     if let Err(err) = result {
-        output.error(&format!("Error: {err}"));
+        output.error(&format!("Error: {}", format_error_chain(&err)));
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
## Summary

- Remove source errors from `StorageError::Display`, `RenderError`, and `HandlerError` — follows idiomatic Rust convention where `Display` shows only the error's own message
- Add shared `format_error_chain()` utility in `rw-storage` that walks `Error::source()` to produce colon-separated chains
- Delete three duplicate implementations: `StorageError::display_chain()`, `error_chain()` in rw-napi, `error_chain()` in rw-storage-s3
- Fixes message duplication when `RenderError` wraps `StorageError` (both previously embedded the source in Display)

## Test plan

- [x] `cargo test -p rw-storage` — all 41 tests pass including new `test_format_error_chain`
- [x] `cargo test -p rw-site -p rw-server` — all 97 tests pass
- [x] `make test` — full suite passes (700+ tests)
- [x] `make lint` — no warnings
- [x] `make format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)