### PR TITLE
refactor: remove source from Display to prevent error chain duplication

### DIFF
--- a/crates/rw-config/src/lib.rs
+++ b/crates/rw-config/src/lib.rs
@@ -236,10 +236,10 @@ pub enum ConfigError {
     #[error("Configuration file not found: {}", .0.display())]
     NotFound(PathBuf),
     /// I/O error.
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     Io(#[from] std::io::Error),
     /// TOML parsing error.
-    #[error("TOML parse error: {0}")]
+    #[error("TOML parse error")]
     Parse(#[from] toml::de::Error),
     /// Validation error.
     #[error("Configuration error: {0}")]

--- a/crates/rw-confluence/src/updater/error.rs
+++ b/crates/rw-confluence/src/updater/error.rs
@@ -10,10 +10,10 @@ pub enum UpdateError {
     Config(String),
 
     /// Confluence API error.
-    #[error("Confluence API error: {0}")]
+    #[error("Confluence API error")]
     Confluence(#[from] ConfluenceError),
 
     /// IO error (file operations, temp directory).
-    #[error("IO error: {0}")]
+    #[error("I/O error")]
     Io(#[from] std::io::Error),
 }

--- a/crates/rw-server/src/error.rs
+++ b/crates/rw-server/src/error.rs
@@ -11,15 +11,15 @@ use serde_json::json;
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {
     /// Failed to start file watching for live reload.
-    #[error("failed to start file watcher: {0}")]
+    #[error("failed to start file watcher")]
     Watch(#[from] StorageError),
 
     /// Invalid bind address.
-    #[error("invalid bind address: {0}")]
+    #[error("invalid bind address")]
     InvalidAddress(#[from] AddrParseError),
 
     /// I/O error (bind or serve failure).
-    #[error("{0}")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 }
 
@@ -31,15 +31,15 @@ pub(crate) enum HandlerError {
     PageNotFound(String),
 
     /// Render error from rw-site.
-    #[error("Render error: {0}")]
+    #[error("render error")]
     Render(#[from] rw_site::RenderError),
 
     /// I/O error.
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     Io(#[from] std::io::Error),
 
     /// Storage backend unavailable.
-    #[error("Storage error: {0}")]
+    #[error("storage unavailable")]
     Storage(#[from] rw_storage::StorageError),
 }
 

--- a/crates/rw-storage-s3/src/publisher.rs
+++ b/crates/rw-storage-s3/src/publisher.rs
@@ -16,13 +16,13 @@ use crate::s3::{self, S3Config};
 /// Errors that can occur during publishing.
 #[derive(Debug, thiserror::Error)]
 pub enum BundlePublishError {
-    #[error("Storage error: {0}")]
+    #[error("storage error")]
     Storage(#[from] rw_storage::StorageError),
-    #[error("JSON error: {0}")]
+    #[error("JSON serialization error")]
     Json(#[from] serde_json::Error),
     #[error("S3 error: {0}")]
     S3(String),
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     Io(#[from] std::io::Error),
 }
 

--- a/crates/rw/src/error.rs
+++ b/crates/rw/src/error.rs
@@ -7,22 +7,22 @@ use rw_server::ServerError;
 /// CLI error type.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CliError {
-    #[error("{0}")]
+    #[error(transparent)]
     Config(#[from] ConfigError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Confluence(#[from] ConfluenceError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Update(#[from] UpdateError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     BundlePublish(#[from] rw_storage_s3::BundlePublishError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Server(#[from] ServerError),
 
     #[error("{0}")]


### PR DESCRIPTION
## Summary

- Remove `{0}` (source error) from `#[error("...")]` format strings on variants that also use `#[from]`, preventing the source from appearing in both `Display` and `source()` — which causes duplication when walking the error chain
- Use `#[error(transparent)]` for pass-through wrappers (`CliError`) and contextual prefixes without `{0}` for context-adding variants (`ServerError`, `HandlerError`, `BundlePublishError`, `UpdateError`, `ConfigError`)

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all tests pass
- [ ] Verify error messages at CLI boundary still show full chain after `refactor/remove-custom-error-chain` is merged on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)