### PR TITLE
feat: add rw-meta crate for frontmatter and H1 extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Frontmatter support — page metadata can now be defined in YAML frontmatter (`---` delimited) at the top of markdown files, in addition to meta.yaml sidecar files. Frontmatter values override meta.yaml when both exist.
+
+### Fixed
+
+- Page metadata no longer extracts `#` comments inside fenced code blocks as H1 titles
+- Page metadata now correctly extracts plain text from H1 titles with inline formatting (bold, italic, code, links)
+
 ## [0.1.20] - 2026-03-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,12 @@ crates/
 │       ├── meta_includes.rs  # MetaIncludeSource trait, C4 macro generation from metadata
 │       └── html_embed.rs     # SVG scaling, placeholder replacement
 │
+├── rw-meta/               # Metadata extraction and resolution
+│   └── src/
+│       ├── lib.rs            # Public API: Meta::resolve()
+│       ├── head.rs           # Head::parse(): pulldown-cmark frontmatter + H1 extraction
+│       └── fields.rs         # MetaFields::from_yaml(), MetaFields::merge()
+│
 ├── rw-cache/              # Cache abstraction layer
 │   └── src/
 │       ├── lib.rs            # Cache/CacheBucket traits, NullCache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rw-meta"
+version = "0.1.20"
+dependencies = [
+ "pulldown-cmark",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
 name = "rw-renderer"
 version = "0.1.20"
 dependencies = [
@@ -3077,9 +3087,8 @@ dependencies = [
  "ignore",
  "notify",
  "rayon",
- "regex",
+ "rw-meta",
  "rw-storage",
- "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rw-config = { path = "crates/rw-config" }
 rw-confluence = { path = "crates/rw-confluence" }
 rw-diagrams = { path = "crates/rw-diagrams" }
 rw-embedded-preview = { path = "crates/rw-embedded-preview" }
+rw-meta = { path = "crates/rw-meta" }
 rw-renderer = { path = "crates/rw-renderer" }
 rw-sections = { path = "crates/rw-sections" }
 rw-server = { path = "crates/rw-server" }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Publish the same markdown to Confluence pages or embed in Backstage with native 
 - **Tabbed content** — group related content with `:::tab` syntax
 - **GitHub-style alerts** — `[!NOTE]`, `[!TIP]`, `[!WARNING]`, and more
 - **Navigation and TOC** — automatic sidebar, breadcrumbs, and table of contents
-- **Page metadata** — YAML sidecar files for titles, descriptions, and custom variables
+- **Page metadata** — YAML frontmatter or sidecar files for titles, descriptions, and custom variables
 - **Confluence publishing** — update pages via REST API with OAuth authentication
 - **Backstage integration** — embed docs with native Backstage plugins
 

--- a/crates/rw-meta/Cargo.toml
+++ b/crates/rw-meta/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rw-meta"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Metadata extraction and resolution for RW documentation engine"
+
+[lints]
+workspace = true
+
+[dependencies]
+pulldown-cmark = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }

--- a/crates/rw-meta/src/fields.rs
+++ b/crates/rw-meta/src/fields.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct MetaFields {
+    #[serde(alias = "type")]
+    pub kind: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub vars: HashMap<String, serde_json::Value>,
+}
+
+impl MetaFields {
+    /// Parse YAML string into `MetaFields`. Returns default on invalid YAML.
+    pub(crate) fn from_yaml(yaml: &str) -> Self {
+        serde_yaml::from_str(yaml).unwrap_or_default()
+    }
+
+    /// Merge `other` onto self. `other` fields win when Some; vars merged at key level.
+    pub(crate) fn merge(mut self, other: Self) -> Self {
+        self.kind = other.kind.or(self.kind);
+        self.title = other.title.or(self.title);
+        self.description = other.description.or(self.description);
+        for (key, value) in other.vars {
+            self.vars.insert(key, value);
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_yaml() {
+        let yaml = "title: My Page\nkind: service";
+        let fields = MetaFields::from_yaml(yaml);
+        assert_eq!(fields.title.as_deref(), Some("My Page"));
+        assert_eq!(fields.kind.as_deref(), Some("service"));
+    }
+
+    #[test]
+    fn parse_type_alias() {
+        let yaml = "type: domain";
+        let fields = MetaFields::from_yaml(yaml);
+        assert_eq!(fields.kind.as_deref(), Some("domain"));
+    }
+
+    #[test]
+    fn parse_with_vars() {
+        let yaml = "vars:\n  owner: team-a\n  priority: 1";
+        let fields = MetaFields::from_yaml(yaml);
+        assert_eq!(
+            fields.vars.get("owner").and_then(|v| v.as_str()),
+            Some("team-a")
+        );
+        assert_eq!(
+            fields
+                .vars
+                .get("priority")
+                .and_then(serde_json::Value::as_u64),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn parse_invalid_yaml_returns_default() {
+        let fields = MetaFields::from_yaml(": : invalid: [unclosed");
+        assert!(fields.title.is_none());
+        assert!(fields.kind.is_none());
+        assert!(fields.vars.is_empty());
+    }
+
+    #[test]
+    fn parse_empty_string_returns_default() {
+        let fields = MetaFields::from_yaml("");
+        assert!(fields.title.is_none());
+        assert!(fields.kind.is_none());
+        assert!(fields.vars.is_empty());
+    }
+
+    #[test]
+    fn merge_overlay_title_wins() {
+        let base = MetaFields {
+            title: Some("Base Title".to_owned()),
+            ..Default::default()
+        };
+        let overlay = MetaFields {
+            title: Some("Overlay Title".to_owned()),
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(merged.title.as_deref(), Some("Overlay Title"));
+    }
+
+    #[test]
+    fn merge_base_title_when_overlay_none() {
+        let base = MetaFields {
+            title: Some("Base Title".to_owned()),
+            ..Default::default()
+        };
+        let overlay = MetaFields {
+            title: None,
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(merged.title.as_deref(), Some("Base Title"));
+    }
+
+    #[test]
+    fn merge_vars_key_level() {
+        let mut base_vars = HashMap::new();
+        base_vars.insert(
+            "a".to_owned(),
+            serde_json::Value::String("base-a".to_owned()),
+        );
+        base_vars.insert(
+            "b".to_owned(),
+            serde_json::Value::String("base-b".to_owned()),
+        );
+
+        let mut overlay_vars = HashMap::new();
+        overlay_vars.insert(
+            "a".to_owned(),
+            serde_json::Value::String("overlay-a".to_owned()),
+        );
+        overlay_vars.insert(
+            "c".to_owned(),
+            serde_json::Value::String("overlay-c".to_owned()),
+        );
+
+        let base = MetaFields {
+            vars: base_vars,
+            ..Default::default()
+        };
+        let overlay = MetaFields {
+            vars: overlay_vars,
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+
+        assert_eq!(
+            merged.vars.get("a").and_then(|v| v.as_str()),
+            Some("overlay-a"),
+            "overlay key wins"
+        );
+        assert_eq!(
+            merged.vars.get("b").and_then(|v| v.as_str()),
+            Some("base-b"),
+            "base-only key preserved"
+        );
+        assert_eq!(
+            merged.vars.get("c").and_then(|v| v.as_str()),
+            Some("overlay-c"),
+            "overlay-only key present"
+        );
+    }
+
+    #[test]
+    fn merge_all_fields() {
+        let base = MetaFields {
+            title: Some("Base Title".to_owned()),
+            kind: Some("service".to_owned()),
+            description: Some("Base desc".to_owned()),
+            ..Default::default()
+        };
+        let overlay = MetaFields {
+            title: None,
+            kind: None,
+            description: Some("Overlay desc".to_owned()),
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(
+            merged.title.as_deref(),
+            Some("Base Title"),
+            "base title preserved"
+        );
+        assert_eq!(
+            merged.kind.as_deref(),
+            Some("service"),
+            "base kind preserved"
+        );
+        assert_eq!(
+            merged.description.as_deref(),
+            Some("Overlay desc"),
+            "overlay description wins"
+        );
+    }
+}

--- a/crates/rw-meta/src/head.rs
+++ b/crates/rw-meta/src/head.rs
@@ -1,0 +1,166 @@
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+
+pub(crate) struct Head {
+    pub frontmatter: Option<String>,
+    pub title: Option<String>,
+}
+
+impl Head {
+    pub(crate) fn parse(markdown: &str) -> Self {
+        let opts = Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
+        let parser = Parser::new_ext(markdown, opts);
+
+        let mut frontmatter: Option<String> = None;
+        let mut title: Option<String> = None;
+        let mut in_metadata = false;
+        let mut in_h1 = false;
+        let mut title_buf = String::new();
+
+        for event in parser {
+            match event {
+                Event::Start(Tag::MetadataBlock(_)) => {
+                    in_metadata = true;
+                }
+                Event::Text(ref text) if in_metadata => {
+                    frontmatter = Some(text.to_string());
+                }
+                Event::End(TagEnd::MetadataBlock(_)) => {
+                    in_metadata = false;
+                }
+                Event::Start(Tag::Heading {
+                    level: HeadingLevel::H1,
+                    ..
+                }) => {
+                    in_h1 = true;
+                }
+                Event::Text(ref text) | Event::Code(ref text) if in_h1 => {
+                    title_buf.push_str(text);
+                }
+                Event::End(TagEnd::Heading(HeadingLevel::H1)) => {
+                    title = Some(title_buf);
+                    break;
+                }
+                // Stop scanning once we hit a non-heading block element — frontmatter
+                // is always at the top and H1 conventionally appears before body content.
+                Event::Start(
+                    Tag::Paragraph
+                    | Tag::BlockQuote(_)
+                    | Tag::List(_)
+                    | Tag::CodeBlock(_)
+                    | Tag::HtmlBlock
+                    | Tag::Table(_),
+                ) if !in_metadata => break,
+                _ => {}
+            }
+        }
+
+        Self { frontmatter, title }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_frontmatter_no_h1() {
+        let head = Head::parse("Some plain text without headings.");
+        assert!(head.frontmatter.is_none());
+        assert!(head.title.is_none());
+    }
+
+    #[test]
+    fn simple_h1() {
+        let head = Head::parse("# Hello World\n\nSome content.");
+        assert!(head.frontmatter.is_none());
+        assert_eq!(head.title.as_deref(), Some("Hello World"));
+    }
+
+    #[test]
+    fn h1_with_bold() {
+        let head = Head::parse("# Hello **world**\n");
+        assert_eq!(head.title.as_deref(), Some("Hello world"));
+    }
+
+    #[test]
+    fn h1_with_code_span() {
+        let head = Head::parse("# The `main` function\n");
+        assert_eq!(head.title.as_deref(), Some("The main function"));
+    }
+
+    #[test]
+    fn h1_with_italic_and_bold() {
+        let head = Head::parse("# *italic* and **bold**\n");
+        assert_eq!(head.title.as_deref(), Some("italic and bold"));
+    }
+
+    #[test]
+    fn h1_with_link() {
+        let head = Head::parse("# See [docs](url)\n");
+        assert_eq!(head.title.as_deref(), Some("See docs"));
+    }
+
+    #[test]
+    fn code_block_comment_not_h1() {
+        let md = "```\n# comment\n```\n";
+        let head = Head::parse(md);
+        assert!(head.title.is_none());
+    }
+
+    #[test]
+    fn no_h1_only_h2() {
+        let head = Head::parse("## Second level\n\nSome content.");
+        assert!(head.frontmatter.is_none());
+        assert!(head.title.is_none());
+    }
+
+    #[test]
+    fn frontmatter_only() {
+        let md = "---\ntitle: My Page\n---\n\nSome content.";
+        let head = Head::parse(md);
+        assert!(head.frontmatter.is_some());
+        assert!(head.frontmatter.unwrap().contains("title: My Page"));
+        assert!(head.title.is_none());
+    }
+
+    #[test]
+    fn frontmatter_and_h1() {
+        let md = "---\ntitle: My Page\n---\n\n# Heading One\n\nContent.";
+        let head = Head::parse(md);
+        assert!(head.frontmatter.is_some());
+        assert!(head.frontmatter.unwrap().contains("title: My Page"));
+        assert_eq!(head.title.as_deref(), Some("Heading One"));
+    }
+
+    #[test]
+    fn invalid_frontmatter_treated_as_thematic_break() {
+        // Empty frontmatter (---\n---) is treated as thematic breaks, not metadata
+        let md = "---\n---\n";
+        let head = Head::parse(md);
+        assert!(head.frontmatter.is_none());
+        assert!(head.title.is_none());
+    }
+
+    #[test]
+    fn frontmatter_with_dots_closing() {
+        let md = "---\ntitle: Dots\n...\n\n# Heading\n";
+        let head = Head::parse(md);
+        assert!(head.frontmatter.is_some());
+        assert!(head.frontmatter.unwrap().contains("title: Dots"));
+        assert_eq!(head.title.as_deref(), Some("Heading"));
+    }
+
+    #[test]
+    fn h1_after_paragraph_not_extracted() {
+        let md = "Some introductory paragraph.\n\n# Late Heading\n";
+        let head = Head::parse(md);
+        assert!(head.title.is_none());
+    }
+
+    #[test]
+    fn only_takes_first_h1() {
+        let md = "# First\n\n# Second\n";
+        let head = Head::parse(md);
+        assert_eq!(head.title.as_deref(), Some("First"));
+    }
+}

--- a/crates/rw-meta/src/lib.rs
+++ b/crates/rw-meta/src/lib.rs
@@ -1,0 +1,243 @@
+mod fields;
+mod head;
+
+use std::collections::HashMap;
+
+use fields::MetaFields;
+use head::Head;
+
+/// Resolved page metadata from all sources.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Meta {
+    /// Page kind (e.g., "domain", "guide").
+    pub kind: Option<String>,
+    /// Page title (always resolved — falls back to titlecase of filename).
+    pub title: String,
+    /// Page description.
+    pub description: Option<String>,
+    /// Custom variables (key-level merge from meta.yaml and frontmatter).
+    pub vars: HashMap<String, serde_json::Value>,
+}
+
+impl Meta {
+    /// Extract and merge metadata from markdown content and meta.yaml.
+    ///
+    /// Internally:
+    /// 1. Parses meta.yaml into base fields
+    /// 2. Extracts frontmatter and first H1 from markdown via pulldown-cmark
+    /// 3. Merges frontmatter over meta.yaml (frontmatter wins per field, vars key-level merge)
+    /// 4. Resolves title: frontmatter.title > meta.title > H1 > titlecase(filename)
+    #[must_use]
+    pub fn resolve(markdown: Option<&str>, meta_yaml: Option<&str>, filename: &str) -> Self {
+        let base = meta_yaml.map(MetaFields::from_yaml).unwrap_or_default();
+
+        let (frontmatter, h1_title) = markdown
+            .map(Head::parse)
+            .map_or((None, None), |h| (h.frontmatter, h.title));
+
+        let overlay = frontmatter
+            .as_deref()
+            .map(MetaFields::from_yaml)
+            .unwrap_or_default();
+        let merged = base.merge(overlay);
+
+        let title = merged
+            .title
+            .or(h1_title)
+            .filter(|t| !t.is_empty())
+            .unwrap_or_else(|| {
+                let name = filename.strip_suffix(".md").unwrap_or(filename);
+                titlecase_from_slug(name)
+            });
+
+        Self {
+            kind: merged.kind,
+            title,
+            description: merged.description,
+            vars: merged.vars,
+        }
+    }
+}
+
+/// Convert a slug to title case.
+///
+/// Replaces `-` and `_` with spaces, capitalizes each word.
+///
+/// `"setup-guide"` → `"Setup Guide"`, `"my_page"` → `"My Page"`
+fn titlecase_from_slug(slug: &str) -> String {
+    slug.replace(['-', '_'], " ")
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().chain(chars).collect(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- titlecase_from_slug ---
+
+    #[test]
+    fn titlecase_kebab() {
+        assert_eq!(titlecase_from_slug("setup-guide"), "Setup Guide");
+    }
+
+    #[test]
+    fn titlecase_snake() {
+        assert_eq!(titlecase_from_slug("my_page"), "My Page");
+    }
+
+    #[test]
+    fn titlecase_single_word() {
+        assert_eq!(titlecase_from_slug("hello"), "Hello");
+    }
+
+    #[test]
+    fn titlecase_empty() {
+        assert_eq!(titlecase_from_slug(""), "");
+    }
+
+    // --- resolve: title priority ---
+
+    #[test]
+    fn resolve_frontmatter_title_wins_over_meta_yaml() {
+        let md = "---\ntitle: Frontmatter Title\n---\n\n# H1 Title\n";
+        let meta_yaml = "title: Meta YAML Title";
+        let meta = Meta::resolve(Some(md), Some(meta_yaml), "page.md");
+        assert_eq!(meta.title, "Frontmatter Title");
+    }
+
+    #[test]
+    fn resolve_meta_yaml_title_wins_over_h1() {
+        let md = "# H1 Title\n\nSome content.";
+        let meta_yaml = "title: Meta YAML Title";
+        let meta = Meta::resolve(Some(md), Some(meta_yaml), "page.md");
+        assert_eq!(meta.title, "Meta YAML Title");
+    }
+
+    #[test]
+    fn resolve_h1_wins_over_filename() {
+        let md = "# H1 Title\n\nSome content.";
+        let meta = Meta::resolve(Some(md), None, "page.md");
+        assert_eq!(meta.title, "H1 Title");
+    }
+
+    #[test]
+    fn resolve_filename_fallback() {
+        let meta = Meta::resolve(None, None, "setup-guide.md");
+        assert_eq!(meta.title, "Setup Guide");
+    }
+
+    #[test]
+    fn resolve_filename_strips_md_extension() {
+        let meta = Meta::resolve(None, None, "my-page.md");
+        assert_eq!(meta.title, "My Page");
+    }
+
+    #[test]
+    fn resolve_no_markdown_with_meta_yaml() {
+        let meta_yaml = "title: From Meta\ndescription: A description";
+        let meta = Meta::resolve(None, Some(meta_yaml), "page.md");
+        assert_eq!(meta.title, "From Meta");
+        assert_eq!(meta.description.as_deref(), Some("A description"));
+    }
+
+    // --- resolve: field merging ---
+
+    #[test]
+    fn resolve_frontmatter_description_wins() {
+        let md = "---\ndescription: Frontmatter desc\n---\n\n# Title\n";
+        let meta_yaml = "description: Meta YAML desc";
+        let meta = Meta::resolve(Some(md), Some(meta_yaml), "page.md");
+        assert_eq!(meta.description.as_deref(), Some("Frontmatter desc"));
+    }
+
+    #[test]
+    fn resolve_meta_yaml_description_when_no_frontmatter() {
+        let md = "# Title\n\nSome content.";
+        let meta_yaml = "description: Meta YAML desc";
+        let meta = Meta::resolve(Some(md), Some(meta_yaml), "page.md");
+        assert_eq!(meta.description.as_deref(), Some("Meta YAML desc"));
+    }
+
+    #[test]
+    fn resolve_vars_merged() {
+        let md = "---\nvars:\n  a: frontmatter-a\n  c: frontmatter-c\n---\n";
+        let meta_yaml = "vars:\n  a: meta-a\n  b: meta-b";
+        let meta = Meta::resolve(Some(md), Some(meta_yaml), "page.md");
+        assert_eq!(
+            meta.vars.get("a").and_then(|v| v.as_str()),
+            Some("frontmatter-a"),
+            "frontmatter key wins"
+        );
+        assert_eq!(
+            meta.vars.get("b").and_then(|v| v.as_str()),
+            Some("meta-b"),
+            "meta-only key preserved"
+        );
+        assert_eq!(
+            meta.vars.get("c").and_then(|v| v.as_str()),
+            Some("frontmatter-c"),
+            "frontmatter-only key present"
+        );
+    }
+
+    // --- resolve: error handling ---
+
+    #[test]
+    fn resolve_malformed_frontmatter_ignored() {
+        let md = "---\n: : invalid: [unclosed\n---\n\n# H1 Title\n";
+        let meta = Meta::resolve(Some(md), None, "page.md");
+        // Malformed frontmatter is ignored; H1 is still extracted
+        assert_eq!(meta.title, "H1 Title");
+    }
+
+    #[test]
+    fn resolve_malformed_meta_yaml_ignored() {
+        let meta_yaml = ": : invalid: [unclosed";
+        let md = "# H1 Title\n";
+        let meta = Meta::resolve(Some(md), Some(meta_yaml), "page.md");
+        // Malformed meta.yaml is ignored; H1 is used
+        assert_eq!(meta.title, "H1 Title");
+    }
+
+    // --- resolve: edge cases ---
+
+    #[test]
+    fn resolve_code_block_comment_not_h1() {
+        let md = "```\n# comment\n```\n";
+        let meta = Meta::resolve(Some(md), None, "my-page.md");
+        // Code block # is not an H1; falls back to filename
+        assert_eq!(meta.title, "My Page");
+    }
+
+    #[test]
+    fn resolve_formatted_h1() {
+        let md = "# Hello **world** with `code`\n";
+        let meta = Meta::resolve(Some(md), None, "page.md");
+        assert_eq!(meta.title, "Hello world with code");
+    }
+
+    #[test]
+    fn resolve_empty_h1_falls_back_to_filename() {
+        let md = "# \n\nSome content.";
+        let meta = Meta::resolve(Some(md), None, "setup-guide.md");
+        assert_eq!(meta.title, "Setup Guide");
+    }
+
+    #[test]
+    fn resolve_no_sources() {
+        let meta = Meta::resolve(None, None, "some-page.md");
+        assert_eq!(meta.title, "Some Page");
+        assert!(meta.description.is_none());
+        assert!(meta.kind.is_none());
+        assert!(meta.vars.is_empty());
+    }
+}

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -63,6 +63,8 @@ pub struct MarkdownRenderer<B: RenderBackend> {
     /// Sections for annotating internal links.
     /// Shared via Arc because the map can be large (~500 entries) and is reused across renders.
     sections: Option<Arc<Sections>>,
+    /// Whether we are currently inside a YAML metadata block (frontmatter).
+    in_metadata_block: bool,
     _backend: PhantomData<B>,
 }
 
@@ -86,6 +88,7 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
             alert_stack: Vec::new(),
             directives: None,
             sections: None,
+            in_metadata_block: false,
             _backend: PhantomData,
         }
     }
@@ -173,14 +176,14 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
     /// Get parser options based on GFM configuration.
     #[must_use]
     pub fn parser_options(&self) -> Options {
+        let mut opts = Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
         if self.gfm {
-            Options::ENABLE_TABLES
+            opts |= Options::ENABLE_TABLES
                 | Options::ENABLE_STRIKETHROUGH
                 | Options::ENABLE_TASKLISTS
-                | Options::ENABLE_GFM
-        } else {
-            Options::empty()
+                | Options::ENABLE_GFM;
         }
+        opts
     }
 
     /// Create a configured parser for the given markdown text.
@@ -314,8 +317,16 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         match event {
             Event::Start(tag) => self.start_tag(tag),
             Event::End(tag) => self.end_tag(tag),
-            Event::Text(text) => self.text(&text),
-            Event::Code(code) => self.inline_code(&code),
+            Event::Text(text) => {
+                if !self.in_metadata_block {
+                    self.text(&text);
+                }
+            }
+            Event::Code(code) => {
+                if !self.in_metadata_block {
+                    self.inline_code(&code);
+                }
+            }
             Event::Html(html) | Event::InlineHtml(html) => self.raw_html(&html),
             Event::SoftBreak => self.soft_break(),
             Event::HardBreak => self.hard_break(),
@@ -372,7 +383,10 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
             Tag::Item => {
                 self.output.push_str("<li>");
             }
-            Tag::FootnoteDefinition(_) | Tag::HtmlBlock | Tag::MetadataBlock(_) => {}
+            Tag::FootnoteDefinition(_) | Tag::HtmlBlock => {}
+            Tag::MetadataBlock(_) => {
+                self.in_metadata_block = true;
+            }
             Tag::DefinitionList => {
                 self.output.push_str("<dl>");
             }
@@ -502,7 +516,10 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
             TagEnd::Item => {
                 self.output.push_str("</li>");
             }
-            TagEnd::FootnoteDefinition | TagEnd::HtmlBlock | TagEnd::MetadataBlock(_) => {}
+            TagEnd::FootnoteDefinition | TagEnd::HtmlBlock => {}
+            TagEnd::MetadataBlock(_) => {
+                self.in_metadata_block = false;
+            }
             TagEnd::Image => {
                 // Render image with collected alt text
                 let alt = self.image.end();
@@ -1283,5 +1300,39 @@ Install with apt.
         // No sections configured — no data attributes
         assert!(!result.html.contains("data-section-ref"));
         assert!(result.html.contains(r#"href="/domains/billing/use-cases""#));
+    }
+
+    #[test]
+    fn frontmatter_does_not_appear_in_rendered_output() {
+        let markdown = "---\ntitle: My Page\nauthor: Alice\n---\n\n# Hello\n\nSome content.";
+        let mut renderer = MarkdownRenderer::<HtmlBackend>::new();
+        let result = renderer.render_markdown(markdown);
+        // Frontmatter should not appear as an <hr> or paragraph
+        assert!(
+            !result.html.contains("<hr"),
+            "frontmatter rendered as <hr>: {}",
+            result.html
+        );
+        assert!(
+            !result.html.contains("title: My Page"),
+            "frontmatter content leaked into output: {}",
+            result.html
+        );
+        assert!(
+            !result.html.contains("author: Alice"),
+            "frontmatter content leaked into output: {}",
+            result.html
+        );
+        // The actual page content should still render
+        assert!(
+            result.html.contains("<h1"),
+            "h1 heading missing: {}",
+            result.html
+        );
+        assert!(
+            result.html.contains("Some content"),
+            "page content missing: {}",
+            result.html
+        );
     }
 }

--- a/crates/rw-storage-fs/Cargo.toml
+++ b/crates/rw-storage-fs/Cargo.toml
@@ -14,8 +14,7 @@ rw-storage = { workspace = true }
 glob = { workspace = true }
 ignore = { workspace = true }
 notify = { workspace = true }
-regex = { workspace = true }
-serde = { workspace = true }
+rw-meta = { workspace = true }
 serde_yaml = { workspace = true }
 rayon = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rw-storage-fs/src/lib.rs
+++ b/crates/rw-storage-fs/src/lib.rs
@@ -4,7 +4,7 @@
 //! [`Storage`](rw_storage::Storage) trait. It handles:
 //!
 //! - Recursive directory scanning for markdown files
-//! - Title extraction from H1 headings with mtime caching
+//! - Metadata extraction (title, description, kind) with mtime caching
 //! - Metadata loading from YAML sidecar files with inheritance
 //! - File watching with event debouncing
 //!
@@ -39,8 +39,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use glob::Pattern;
 use notify::{RecursiveMode, Watcher};
 use rayon::prelude::*;
-use regex::Regex;
-use serde::Deserialize;
+use rw_meta::Meta;
 
 use debouncer::{EventDebouncer, RawEventKind};
 use inheritance::{build_ancestor_chain, merge_metadata};
@@ -50,18 +49,6 @@ use rw_storage::{
 };
 use scanner::{DocumentRef, Scanner};
 use source::file_path_to_url;
-
-/// Parsed fields from a YAML metadata file.
-///
-/// Lightweight struct for the fields needed during scan — avoids full
-/// [`Metadata`] parsing (which includes `vars` deep-merge).
-#[derive(Deserialize)]
-struct YamlFields {
-    pub title: Option<String>,
-    #[serde(rename = "kind", alias = "type")]
-    pub page_kind: Option<String>,
-    pub description: Option<String>,
-}
 
 /// Backend identifier for error messages.
 const BACKEND: &str = "Fs";
@@ -78,39 +65,22 @@ fn storage_event_kind(kind: notify::EventKind) -> Option<RawEventKind> {
     }
 }
 
-/// Convert a slug (kebab-case or `snake_case`) to title case.
-///
-/// Replaces `-` and `_` with spaces, then capitalizes the first letter of each word.
-///
-/// Converts `"setup-guide"` to `"Setup Guide"`, `"my_page"` to `"My Page"`.
-fn titlecase_from_slug(slug: &str) -> String {
-    slug.replace(['-', '_'], " ")
-        .split_whitespace()
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(first) => first.to_uppercase().chain(chars).collect(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-/// Cached file metadata for incremental title extraction.
+/// Cached resolved metadata for incremental extraction.
 #[derive(Debug)]
-struct CachedFile {
-    /// File modification time.
-    mtime: SystemTime,
-    /// Extracted title from the file.
-    title: String,
+struct CachedMeta {
+    /// Markdown file modification time.
+    md_mtime: SystemTime,
+    /// Meta YAML file modification time (`None` if no meta.yaml exists).
+    meta_mtime: Option<SystemTime>,
+    /// Resolved metadata.
+    meta: Meta,
 }
 
 /// Filesystem storage implementation.
 ///
 /// Scans a source directory recursively for markdown files and extracts
-/// titles from the first H1 heading. Uses mtime caching to avoid re-reading
-/// unchanged files.
+/// metadata (title, description, kind) using `rw_meta`. Uses mtime caching
+/// to avoid re-reading unchanged files.
 ///
 /// # Example
 ///
@@ -133,10 +103,8 @@ pub struct FsStorage {
     source_dir: PathBuf,
     /// Scanner for document discovery.
     scanner: Scanner,
-    /// Regex for extracting first H1 heading.
-    h1_regex: Regex,
-    /// Mtime cache for incremental title extraction.
-    mtime_cache: RwLock<HashMap<PathBuf, CachedFile>>,
+    /// Mtime cache for incremental metadata extraction.
+    mtime_cache: RwLock<HashMap<PathBuf, CachedMeta>>,
     /// Patterns for file watching (e.g., "**/*.md").
     watch_patterns: Vec<Pattern>,
     /// Metadata file name (e.g., "meta.yaml").
@@ -156,11 +124,6 @@ impl FsStorage {
     /// # Arguments
     ///
     /// * `source_dir` - Root directory containing markdown files
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal regex for H1 heading extraction fails to compile.
-    /// This should never happen as the regex is a compile-time constant.
     #[must_use]
     pub fn new(source_dir: PathBuf) -> Self {
         Self::with_patterns(source_dir, &["**/*.md".to_owned()])
@@ -174,10 +137,6 @@ impl FsStorage {
     ///
     /// * `source_dir` - Root directory containing markdown files
     /// * `meta_filename` - Name of metadata files (e.g., "meta.yaml")
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal regex for H1 heading extraction fails to compile.
     #[must_use]
     pub fn with_meta_filename(source_dir: PathBuf, meta_filename: &str) -> Self {
         Self::with_patterns_and_meta(source_dir, &["**/*.md".to_owned()], meta_filename)
@@ -194,9 +153,7 @@ impl FsStorage {
     ///
     /// # Panics
     ///
-    /// Panics if:
-    /// - The internal regex for H1 heading extraction fails to compile
-    /// - Any of the provided glob patterns are invalid
+    /// Panics if any of the provided glob patterns are invalid.
     #[must_use]
     pub fn with_patterns(source_dir: PathBuf, patterns: &[String]) -> Self {
         Self::with_patterns_and_meta(source_dir, patterns, DEFAULT_META_FILENAME)
@@ -212,9 +169,7 @@ impl FsStorage {
     ///
     /// # Panics
     ///
-    /// Panics if:
-    /// - The internal regex for H1 heading extraction fails to compile
-    /// - Any of the provided glob patterns are invalid
+    /// Panics if any of the provided glob patterns are invalid.
     #[must_use]
     pub fn with_patterns_and_meta(
         source_dir: PathBuf,
@@ -234,7 +189,6 @@ impl FsStorage {
         Self {
             source_dir,
             scanner,
-            h1_regex: Regex::new(r"(?m)^#\s+(.+)$").unwrap(),
             mtime_cache: RwLock::new(HashMap::new()),
             watch_patterns,
             meta_filename: meta_filename.to_owned(),
@@ -322,110 +276,86 @@ impl FsStorage {
     /// Returns `None` if the ref produces no valid document (e.g., empty meta.yaml
     /// for a virtual page).
     fn build_document(&self, doc_ref: &DocumentRef) -> Option<Document> {
-        // Parse metadata fields if present
-        let fields: Option<YamlFields> = doc_ref
-            .meta_path
-            .as_ref()
-            .and_then(|p| fs::read_to_string(p).ok())
-            .and_then(|c| serde_yaml::from_str(&c).ok());
-
-        let meta_title = fields.as_ref().and_then(|f| f.title.clone());
-        let page_kind = fields.as_ref().and_then(|f| f.page_kind.clone());
-        let description = fields.as_ref().and_then(|f| f.description.clone());
-
         if let Some(md_path) = &doc_ref.content_path {
-            // Real page with content
             let name_lower = md_path
                 .file_name()
                 .map_or(String::new(), |n| n.to_string_lossy().to_lowercase());
 
-            // Title priority: meta > H1 > filename
-            let title = meta_title.unwrap_or_else(|| self.get_title(md_path, &name_lower));
+            let meta = self.get_meta(md_path, doc_ref.meta_path.as_deref(), &name_lower);
 
             Some(Document {
                 path: doc_ref.url_path.clone(),
-                title,
+                title: meta.title,
                 has_content: true,
-                page_kind,
-                description,
+                page_kind: meta.kind,
+                description: meta.description,
             })
-        } else if doc_ref.meta_path.is_some() {
-            // Virtual page (meta.yaml only) — skip if YAML was empty/invalid
-            fields?;
-            let title = meta_title.unwrap_or_else(|| {
-                Path::new(&doc_ref.url_path).file_name().map_or_else(
-                    || "Untitled".to_owned(),
-                    |n| Self::title_from_dir_name(&n.to_string_lossy()),
-                )
-            });
+        } else if let Some(meta_path) = &doc_ref.meta_path {
+            let meta_yaml = fs::read_to_string(meta_path).ok()?;
+
+            if meta_yaml.trim().is_empty() {
+                return None;
+            }
+
+            let dir_name = Path::new(&doc_ref.url_path)
+                .file_name()
+                .map_or("untitled", |n| n.to_str().unwrap_or("untitled"));
+
+            let meta = Meta::resolve(None, Some(&meta_yaml), dir_name);
 
             Some(Document {
                 path: doc_ref.url_path.clone(),
-                title,
+                title: meta.title,
                 has_content: false,
-                page_kind,
-                description,
+                page_kind: meta.kind,
+                description: meta.description,
             })
         } else {
-            // No sources - shouldn't happen but handle gracefully
             None
         }
     }
 
-    /// Generate title from directory name.
-    fn title_from_dir_name(name: &str) -> String {
-        titlecase_from_slug(name)
-    }
+    /// Get resolved metadata for a file, using mtime cache when possible.
+    ///
+    /// Only reads the markdown file content on cache miss, avoiding unnecessary
+    /// I/O for unchanged files during scans. Invalidates when either the markdown
+    /// file or its associated meta.yaml changes.
+    fn get_meta(&self, file_path: &Path, meta_path: Option<&Path>, filename: &str) -> Meta {
+        let current_md_mtime = fs::metadata(file_path).ok().and_then(|m| m.modified().ok());
+        let current_meta_mtime = meta_path
+            .and_then(|p| fs::metadata(p).ok())
+            .and_then(|m| m.modified().ok());
 
-    /// Get title for a file, using mtime cache when possible.
-    fn get_title(&self, file_path: &Path, name_lower: &str) -> String {
-        // Get current mtime
-        let current_mtime = fs::metadata(file_path).ok().and_then(|m| m.modified().ok());
-
-        // Check cache
+        // Check cache — avoid reading file content if both mtimes unchanged
         {
             let cache = self.mtime_cache.read().unwrap();
-            if let (Some(cached), Some(mtime)) = (cache.get(file_path), current_mtime)
-                && cached.mtime == mtime
+            if let (Some(cached), Some(md_mtime)) = (cache.get(file_path), current_md_mtime)
+                && cached.md_mtime == md_mtime
+                && cached.meta_mtime == current_meta_mtime
             {
-                return cached.title.clone();
+                return cached.meta.clone();
             }
         }
 
-        // Cache miss - extract title
-        let title = self
-            .extract_title_from_content(file_path)
-            .unwrap_or_else(|| Self::title_from_filename(name_lower));
+        // Cache miss — read file content now
+        let markdown = fs::read_to_string(file_path).ok();
+        let meta_yaml = meta_path.and_then(|p| fs::read_to_string(p).ok());
+        let meta = Meta::resolve(markdown.as_deref(), meta_yaml.as_deref(), filename);
 
         // Update cache
-        if let Some(mtime) = current_mtime {
+        if let Some(md_mtime) = current_md_mtime {
             let mut cache = self.mtime_cache.write().unwrap();
             cache.insert(
                 file_path.to_path_buf(),
-                CachedFile {
-                    mtime,
-                    title: title.clone(),
+                CachedMeta {
+                    md_mtime,
+                    meta_mtime: current_meta_mtime,
+                    meta: meta.clone(),
                 },
             );
         }
 
-        title
-    }
-
-    /// Extract title from first H1 heading in markdown file.
-    fn extract_title_from_content(&self, file_path: &Path) -> Option<String> {
-        let content = fs::read_to_string(file_path).ok()?;
-        self.h1_regex
-            .captures(&content)
-            .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str().trim().to_owned())
-    }
-
-    /// Generate title from filename.
-    fn title_from_filename(name_lower: &str) -> String {
-        // Remove .md extension
-        let name = name_lower.strip_suffix(".md").unwrap_or(name_lower);
-        titlecase_from_slug(name)
+        meta
     }
 
     /// Set up a file watcher for README.md (outside `source_dir`).
@@ -470,33 +400,16 @@ impl FsStorage {
 
 /// Resolve title for a URL path from filesystem.
 ///
-/// Checks meta.yaml title first, falls back to H1 extraction, then filename.
+/// Uses `Meta::resolve()` to extract title from markdown and meta.yaml.
 /// Used by the watch drain thread to populate `StorageEventKind::Modified`.
-///
-/// FIXME: duplicates title resolution logic from `FsStorage::build_document` and
-/// reverse-engineers URL-to-path mapping from `source::file_path_to_url`. Extract
-/// a shared function or look up `DocumentRef` paths instead.
-fn resolve_title(
-    source_dir: &Path,
-    url_path: &str,
-    meta_filename: &str,
-    h1_regex: &Regex,
-) -> String {
-    // 1. Check meta.yaml title
+fn resolve_title(source_dir: &Path, url_path: &str, meta_filename: &str) -> String {
     let meta_path = if url_path.is_empty() {
         source_dir.join(meta_filename)
     } else {
         source_dir.join(format!("{url_path}/{meta_filename}"))
     };
+    let meta_yaml = fs::read_to_string(&meta_path).ok();
 
-    if let Ok(content) = fs::read_to_string(&meta_path)
-        && let Ok(fields) = serde_yaml::from_str::<YamlFields>(&content)
-        && let Some(title) = fields.title
-    {
-        return title;
-    }
-
-    // 2. Check H1 in markdown file
     let md_paths = if url_path.is_empty() {
         vec![source_dir.join("index.md")]
     } else {
@@ -506,28 +419,35 @@ fn resolve_title(
         ]
     };
 
-    for md_path in &md_paths {
-        if let Ok(content) = fs::read_to_string(md_path) {
-            if let Some(caps) = h1_regex.captures(&content)
-                && let Some(m) = caps.get(1)
-            {
-                return m.as_str().trim().to_owned();
-            }
-            // No H1 — fall back to filename
-            let name_lower = md_path
-                .file_name()
-                .map_or(String::new(), |n| n.to_string_lossy().to_lowercase());
-            return FsStorage::title_from_filename(&name_lower);
-        }
-    }
+    let (markdown, filename) = md_paths
+        .iter()
+        .find_map(|p| {
+            fs::read_to_string(p).ok().map(|content| {
+                let name = p
+                    .file_name()
+                    .map_or(String::new(), |n| n.to_string_lossy().to_lowercase());
+                (content, name)
+            })
+        })
+        .unwrap_or_default();
 
-    // 3. Nothing found — use URL slug
-    let slug = url_path.rsplit('/').next().unwrap_or(url_path);
-    if slug.is_empty() {
-        "Home".to_owned()
+    let slug = if filename.is_empty() {
+        url_path.rsplit('/').next().unwrap_or(url_path)
     } else {
-        titlecase_from_slug(slug)
-    }
+        &filename
+    };
+    let fallback = if slug.is_empty() { "home" } else { slug };
+
+    Meta::resolve(
+        if markdown.is_empty() {
+            None
+        } else {
+            Some(&markdown)
+        },
+        meta_yaml.as_deref(),
+        fallback,
+    )
+    .title
 }
 
 impl Storage for FsStorage {
@@ -557,12 +477,11 @@ impl Storage for FsStorage {
             && !documents.iter().any(|d| d.path.is_empty())
             && readme_path.exists()
         {
-            let title = self
-                .extract_title_from_content(readme_path)
-                .unwrap_or_else(|| "Home".to_owned());
+            let markdown = fs::read_to_string(readme_path).ok();
+            let meta = Meta::resolve(markdown.as_deref(), None, "home");
             documents.push(Document {
                 path: String::new(),
-                title,
+                title: meta.title,
                 has_content: true,
                 page_kind: None,
                 description: None,
@@ -669,7 +588,6 @@ impl Storage for FsStorage {
         // Spawn thread to drain debouncer and send to channel
         let source_dir_for_drain = self.source_dir.clone();
         let meta_filename_for_drain = self.meta_filename.clone();
-        let h1_regex_for_drain = self.h1_regex.clone();
         std::thread::spawn(move || {
             // Keep watcher references alive in this thread
             let _watcher_guard = watcher;
@@ -713,7 +631,6 @@ impl Storage for FsStorage {
                                 &source_dir_for_drain,
                                 &url_path,
                                 &meta_filename_for_drain,
-                                &h1_regex_for_drain,
                             );
                             StorageEventKind::Modified { title }
                         }
@@ -1268,7 +1185,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mtime_cache_detects_changes() {
+    fn test_mtime_cache_detects_markdown_changes() {
         let temp_dir = create_test_dir();
         fs::write(temp_dir.path().join("guide.md"), "# Original Title").unwrap();
 
@@ -1290,17 +1207,30 @@ mod tests {
     }
 
     #[test]
-    fn test_title_from_filename() {
-        assert_eq!(
-            FsStorage::title_from_filename("setup-guide.md"),
-            "Setup Guide"
-        );
-        assert_eq!(FsStorage::title_from_filename("my_page.md"), "My Page");
-        assert_eq!(
-            FsStorage::title_from_filename("complex-name_here.md"),
-            "Complex Name Here"
-        );
-        assert_eq!(FsStorage::title_from_filename("simple.md"), "Simple");
+    fn test_mtime_cache_detects_meta_yaml_changes() {
+        let temp_dir = create_test_dir();
+        let guide_dir = temp_dir.path().join("guide");
+        fs::create_dir(&guide_dir).unwrap();
+        fs::write(guide_dir.join("index.md"), "# H1 Title").unwrap();
+        fs::write(guide_dir.join("meta.yaml"), "title: YAML Title").unwrap();
+
+        let storage = FsStorage::new(temp_dir.path().to_path_buf());
+
+        // First scan — meta.yaml title wins over H1
+        let docs1 = storage.scan().unwrap();
+        let guide1 = docs1.iter().find(|d| d.path == "guide").unwrap();
+        assert_eq!(guide1.title, "YAML Title");
+
+        // Small delay to ensure mtime changes
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // Modify only meta.yaml, not the markdown file
+        fs::write(guide_dir.join("meta.yaml"), "title: New YAML Title").unwrap();
+
+        // Second scan should see new title from meta.yaml
+        let docs2 = storage.scan().unwrap();
+        let guide2 = docs2.iter().find(|d| d.path == "guide").unwrap();
+        assert_eq!(guide2.title, "New YAML Title");
     }
 
     // Note: file_path_to_url tests are in source.rs

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,8 +1,29 @@
 # Page Metadata
 
-Pages can have metadata defined in YAML sidecar files (default: `meta.yaml` in the same directory as `index.md`).
+Pages can have metadata defined in two ways:
 
-## Example
+1. **Frontmatter** — YAML block at the top of a markdown file, delimited by `---`
+2. **Sidecar file** — `meta.yaml` in the same directory as `index.md`
+
+When both exist, frontmatter values override meta.yaml. Variables (`vars`) are deep-merged at the key level.
+
+## Examples
+
+### Frontmatter
+
+```markdown
+---
+title: "My Domain"
+description: "Domain overview"
+kind: domain
+vars:
+  owner: team-a
+---
+
+# Page content starts here
+```
+
+### Sidecar file
 
 ```yaml
 # docs/domain-a/meta.yaml
@@ -16,10 +37,21 @@ vars:
 
 ## Fields
 
+These fields are available in both frontmatter and meta.yaml:
+
 - `title` -- custom page title (overrides H1 extraction)
 - `description` -- page description for display
-- `kind` -- page kind (e.g., `domain`, `guide`). Pages with `kind` are registered as sections
+- `kind` -- page kind (e.g., `domain`, `guide`). Pages with `kind` are registered as sections. Also accepts `type` as an alias.
 - `vars` -- custom variables (key-value pairs)
+
+## Title resolution
+
+The page title is resolved in this order:
+
+1. `title` from frontmatter
+2. `title` from meta.yaml
+3. First H1 heading in the markdown content
+4. Title-cased filename (e.g., `setup-guide.md` becomes "Setup Guide")
 
 ## Inheritance
 


### PR DESCRIPTION
## Summary

- New `rw-meta` crate that extracts YAML frontmatter and first H1 title from markdown using pulldown-cmark, replacing regex-based extraction
- Frontmatter support — page metadata can now be defined in YAML frontmatter (`---` delimited) in addition to meta.yaml sidecar files, with frontmatter values overriding meta.yaml
- Fixed H1 title extraction: no longer matches `#` comments inside fenced code blocks, and page metadata now correctly extracts plain text from formatted H1 titles

## API

- `Meta::resolve(markdown, meta_yaml, filename)` — merges frontmatter over meta.yaml, resolves title via priority chain (frontmatter > meta.yaml > H1 > filename)
- `MetaFields::from_yaml()` / `MetaFields::merge()` — internal YAML parsing and field merging
- `Head::parse()` — internal pulldown-cmark frontmatter + H1 extraction

## Test plan

- [x] 42 unit tests in rw-meta covering title priority chain, field merging, malformed YAML, edge cases
- [x] 88 rw-storage-fs tests pass (including 7 ignored timing-sensitive watch tests)
- [x] 205 rw-renderer tests pass including frontmatter suppression test
- [x] Full workspace test suite passes
- [x] Clippy clean across all crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)