### PR TITLE
docs: add comprehensive rustdoc for rw-sections crate

### DIFF
--- a/crates/rw-sections/src/lib.rs
+++ b/crates/rw-sections/src/lib.rs
@@ -1,44 +1,127 @@
-//! Section reference types and utilities for RW.
+//! Section reference types and path-to-section resolution.
 //!
-//! Provides the core types for identifying documentation sections and
-//! matching URL paths to sections.
+//! A **section** is a named subtree of a documentation site. Each section has a
+//! freeform [`kind`](Section::kind) (e.g., `"domain"`, `"system"`,
+//! `"component"`) and a [`name`](Section::name) derived from the last segment
+//! of its scope path (e.g., `"billing"` for path `domains/billing`). Sections
+//! let you organize a flat directory of markdown files into a structured
+//! hierarchy that other tools can consume programmatically — for example,
+//! Backstage can map sections to catalog entities based on their kind.
+//!
+//! Every section has a canonical **ref string** of the form
+//! `"kind:namespace/name"` (e.g., `"domain:default/billing"`). The namespace is
+//! currently always `default`.
+//!
+//! The main entry point is [`Sections`], a map from scope paths to
+//! [`Section`] values that supports prefix-based lookup.
+//!
+//! # Examples
+//!
+//! ```
+//! use std::collections::HashMap;
+//! use rw_sections::{Section, Sections};
+//!
+//! // Build a section map (typically done by rw-site from page metadata)
+//! let sections = Sections::new(HashMap::from([
+//!     ("domains/billing".to_owned(), Section {
+//!         kind: "domain".to_owned(),
+//!         name: "billing".to_owned(),
+//!     }),
+//! ]));
+//!
+//! // Find which section owns a given page path
+//! let (section, remainder) = sections.find("/domains/billing/api").unwrap();
+//! assert_eq!(section.to_string(), "domain:default/billing");
+//! assert_eq!(remainder, "api");
+//!
+//! // Resolve an internal link to section ref attributes
+//! let (ref_string, path) = sections.resolve_ref("/domains/billing/api#endpoints").unwrap();
+//! assert_eq!(ref_string, "domain:default/billing");
+//! assert_eq!(path, "api");
+//! ```
+//!
+//! # Feature flags
+//!
+//! - **`serde`** — derives `serde::Serialize` on [`Section`] for JSON API
+//!   responses.
 
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
 /// Default kind for the implicit root section.
+///
+/// Used when a documentation site has pages at the root level that don't belong
+/// to any explicitly defined section.
 pub const ROOT_SECTION_KIND: &str = "section";
 
-/// Name used for sections rooted at the empty path (both implicit and explicit).
+/// Name used for sections rooted at the empty scope path.
+///
+/// Both the implicit root section and any explicit section mapped to `""` use
+/// this name.
 pub const ROOT_SECTION_NAME: &str = "root";
 
-/// Section ref string for the implicit root section (`"section:default/root"`).
+/// Ref string for the implicit root section (`"section:default/root"`).
+///
+/// Pages at the root of a documentation site that aren't covered by any
+/// explicit section are associated with this ref.
 pub const ROOT_SECTION_REF: &str = "section:default/root";
 
-/// Section identity.
+/// A named documentation section with a kind and name.
 ///
-/// Represents a documentation section with a kind (e.g., `"domain"`, `"system"`)
-/// and a name (last path segment, e.g., `"billing"`). Used in navigation items,
-/// breadcrumbs, scope info, and for annotating internal links with
-/// `data-section-ref` attributes.
+/// Represents one node in the section hierarchy. The [`kind`](Self::kind) is a
+/// freeform label — any string is valid, though typical values include
+/// `"domain"`, `"system"`, and `"component"`. The [`name`](Self::name) is
+/// currently derived from the last segment of the section's scope path
+/// (e.g., `"billing"` for scope path `domains/billing`).
+///
+/// Formats as a ref string via [`Display`](fmt::Display)
+/// (e.g., `"domain:default/billing"`) and parses back via
+/// [`FromStr`].
+///
+/// # Examples
+///
+/// ```
+/// use rw_sections::Section;
+///
+/// // Parse a ref string
+/// let section: Section = "domain:default/billing".parse()?;
+/// assert_eq!(section.kind, "domain");
+/// assert_eq!(section.name, "billing");
+///
+/// // Round-trips through Display
+/// assert_eq!(section.to_string(), "domain:default/billing");
+/// # Ok::<(), rw_sections::ParseSectionError>(())
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Section {
-    /// Section kind (e.g., `"component"`, `"domain"`).
+    /// Freeform label classifying this section (e.g., `"domain"`, `"system"`).
     pub kind: String,
-    /// Section name — last path segment (e.g., `"billing"`).
+    /// Section name, currently the last segment of the scope path (e.g., `"billing"`).
     pub name: String,
 }
 
 impl fmt::Display for Section {
-    /// Formats as a section reference string (e.g., `"domain:default/billing"`).
+    /// Formats as `"kind:default/name"`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:default/{}", self.kind, self.name)
     }
 }
 
-/// Error returned when parsing a section ref string fails.
+/// Error returned when parsing a [`Section`] from a ref string fails.
+///
+/// The expected format is `"kind:default/name"` where both `kind` and `name`
+/// are non-empty.
+///
+/// # Examples
+///
+/// ```
+/// use rw_sections::Section;
+///
+/// let err = "invalid".parse::<Section>().unwrap_err();
+/// assert_eq!(err.to_string(), "invalid section ref: expected \"kind:default/name\"");
+/// ```
 #[derive(Debug)]
 pub struct ParseSectionError;
 
@@ -53,7 +136,23 @@ impl std::error::Error for ParseSectionError {}
 impl FromStr for Section {
     type Err = ParseSectionError;
 
-    /// Parses a section ref string (e.g., `"domain:default/billing"`).
+    /// Parses a ref string in `"kind:default/name"` format.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParseSectionError`] if the string does not contain
+    /// `:default/`, or if either the kind or name segment is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rw_sections::Section;
+    ///
+    /// let section: Section = "component:default/auth".parse()?;
+    /// assert_eq!(section.kind, "component");
+    /// assert_eq!(section.name, "auth");
+    /// # Ok::<(), rw_sections::ParseSectionError>(())
+    /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (kind, name) = s
             .split_once(":default/")
@@ -66,42 +165,140 @@ impl FromStr for Section {
     }
 }
 
-/// Map of section root paths to section identities.
+/// Map from scope paths to [`Section`] values with prefix-based lookup.
 ///
-/// Provides prefix-based matching for resolving internal links to their
-/// containing section. Keys are root paths without leading slashes
-/// (e.g., `"domains/billing"`).
+/// Scope paths are stored without leading slashes (e.g., `"domains/billing"`).
+/// Lookup methods accept href-style paths with leading slashes and perform
+/// segment-aware prefix matching — `"domains/bill"` does **not** match
+/// `"/domains/billing"`.
+///
+/// When multiple sections match a path, the deepest (longest prefix) wins.
+///
+/// Typically built by `rw-site` from page metadata and passed to the renderer
+/// and diagram processor for link annotation.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+/// use rw_sections::{Section, Sections};
+///
+/// let sections = Sections::new(HashMap::from([
+///     ("domains/billing".to_owned(), Section {
+///         kind: "domain".to_owned(),
+///         name: "billing".to_owned(),
+///     }),
+///     ("domains/billing/systems/pay".to_owned(), Section {
+///         kind: "system".to_owned(),
+///         name: "pay".to_owned(),
+///     }),
+/// ]));
+///
+/// // Deepest match wins
+/// let (section, remainder) = sections.find("/domains/billing/systems/pay/api").unwrap();
+/// assert_eq!(section.to_string(), "system:default/pay");
+/// assert_eq!(remainder, "api");
+///
+/// // Reverse lookup: ref string → scope path
+/// let path = sections.find_by_ref("domain:default/billing");
+/// assert_eq!(path, Some("domains/billing"));
+/// ```
 #[derive(Debug, Default)]
 pub struct Sections {
     map: HashMap<String, Section>,
 }
 
 impl Sections {
-    /// Create from a `HashMap`.
+    /// Creates a [`Sections`] map from scope-path/section pairs.
+    ///
+    /// Keys are scope paths without leading slashes (e.g., `"domains/billing"`).
+    /// Use an empty string key for the root section.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rw_sections::{Section, Sections};
+    ///
+    /// let sections = Sections::new(HashMap::from([
+    ///     ("".to_owned(), Section {
+    ///         kind: "section".to_owned(),
+    ///         name: "root".to_owned(),
+    ///     }),
+    /// ]));
+    /// assert!(!sections.is_empty());
+    /// ```
     #[must_use]
     pub fn new(map: HashMap<String, Section>) -> Self {
         Self { map }
     }
 
-    /// Whether the map is empty.
+    /// Returns `true` if no sections are registered.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }
 
-    /// Look up a section by exact path.
+    /// Returns the section at the given scope path, or `None`.
+    ///
+    /// The `path` must match a key exactly (no prefix matching). Use
+    /// [`find`](Self::find) for prefix-based lookup from an href.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rw_sections::{Section, Sections};
+    ///
+    /// let sections = Sections::new(HashMap::from([
+    ///     ("domains/billing".to_owned(), Section {
+    ///         kind: "domain".to_owned(),
+    ///         name: "billing".to_owned(),
+    ///     }),
+    /// ]));
+    ///
+    /// assert!(sections.get("domains/billing").is_some());
+    /// assert!(sections.get("domains/billing/api").is_none());
+    /// ```
     #[must_use]
     pub fn get(&self, path: &str) -> Option<&Section> {
         self.map.get(path)
     }
 
-    /// Find the deepest section matching a resolved href path.
+    /// Finds the deepest section whose scope path is a prefix of `href`.
     ///
-    /// Returns the matching `Section` and the remainder path within that section
-    /// (empty string for exact matches), or `None` if no section prefix matches.
+    /// Returns the matching [`Section`] and the remainder path within that
+    /// section (empty string for exact matches), or `None` if no section
+    /// matches.
     ///
-    /// Matching is segment-aware: prefix `"domains/bill"` does NOT match path
-    /// `/domains/billing`. The section key has no leading slash; the href has one.
+    /// The `href` may have a leading slash (it is stripped before matching).
+    /// Matching is segment-aware: scope path `"domains/bill"` does **not**
+    /// match href `"/domains/billing"`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rw_sections::{Section, Sections};
+    ///
+    /// let sections = Sections::new(HashMap::from([
+    ///     ("domains/billing".to_owned(), Section {
+    ///         kind: "domain".to_owned(),
+    ///         name: "billing".to_owned(),
+    ///     }),
+    /// ]));
+    ///
+    /// // Exact match — remainder is empty
+    /// let (section, remainder) = sections.find("/domains/billing").unwrap();
+    /// assert_eq!(remainder, "");
+    ///
+    /// // Prefix match — remainder is the path within the section
+    /// let (_, remainder) = sections.find("/domains/billing/use-cases").unwrap();
+    /// assert_eq!(remainder, "use-cases");
+    ///
+    /// // No partial-segment match
+    /// assert!(sections.find("/domains/bill").is_none());
+    /// ```
     #[must_use]
     pub fn find(&self, href: &str) -> Option<(&Section, String)> {
         let path = href.strip_prefix('/').unwrap_or(href);
@@ -134,11 +331,30 @@ impl Sections {
         Some((section, remainder))
     }
 
-    /// Find the scope path (without leading slash) for a section ref string.
+    /// Finds the scope path for a given ref string.
     ///
-    /// The ref format is `"kind:default/name"` (e.g., `"domain:default/billing"`).
-    /// Returns `None` if the ref is malformed or no section matches.
-    /// Linear scan — the map is small.
+    /// Parses the ref string (e.g., `"domain:default/billing"`) and returns the
+    /// scope path (e.g., `"domains/billing"`) of the matching section, or
+    /// `None` if the ref is malformed or no section matches.
+    ///
+    /// This is a linear scan — the map is expected to be small.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rw_sections::{Section, Sections};
+    ///
+    /// let sections = Sections::new(HashMap::from([
+    ///     ("domains/billing".to_owned(), Section {
+    ///         kind: "domain".to_owned(),
+    ///         name: "billing".to_owned(),
+    ///     }),
+    /// ]));
+    ///
+    /// assert_eq!(sections.find_by_ref("domain:default/billing"), Some("domains/billing"));
+    /// assert_eq!(sections.find_by_ref("system:default/unknown"), None);
+    /// ```
     #[must_use]
     pub fn find_by_ref(&self, ref_string: &str) -> Option<&str> {
         let target: Section = ref_string.parse().ok()?;
@@ -148,14 +364,37 @@ impl Sections {
             .map(|(path, _)| path.as_str())
     }
 
-    /// Resolve an href to section ref attributes for link annotation.
+    /// Resolves an internal href to section ref attributes for link annotation.
     ///
-    /// Given an internal absolute href (e.g., `/domains/billing/api#section`),
-    /// finds the matching section and returns `(ref_string, section_path)` suitable
-    /// for `data-section-ref` and `data-section-path` HTML attributes.
+    /// Given an absolute href like `"/domains/billing/api#endpoints"`, finds the
+    /// owning section and returns `(ref_string, section_path)` suitable for
+    /// `data-section-ref` and `data-section-path` HTML attributes. Fragments
+    /// are stripped before matching.
     ///
-    /// Returns `None` for external links (not starting with `/`) or links not
-    /// matching any section. Fragments are stripped before matching.
+    /// Returns `None` for relative or external links (those not starting with
+    /// `/`), and for paths that don't match any section.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use rw_sections::{Section, Sections};
+    ///
+    /// let sections = Sections::new(HashMap::from([
+    ///     ("domains/billing".to_owned(), Section {
+    ///         kind: "domain".to_owned(),
+    ///         name: "billing".to_owned(),
+    ///     }),
+    /// ]));
+    ///
+    /// // Fragment is stripped, remainder path returned
+    /// let (ref_string, path) = sections.resolve_ref("/domains/billing/api#endpoints").unwrap();
+    /// assert_eq!(ref_string, "domain:default/billing");
+    /// assert_eq!(path, "api");
+    ///
+    /// // External links are ignored
+    /// assert!(sections.resolve_ref("https://example.com").is_none());
+    /// ```
     #[must_use]
     pub fn resolve_ref(&self, href: &str) -> Option<(String, String)> {
         if !href.starts_with('/') {


### PR DESCRIPTION
## Summary

- Added crate-level `//!` docs with summary, domain explanation, getting-started example, and feature flag documentation
- Added doc comments with `# Examples` doc-tests to all public items: `Section`, `ParseSectionError`, `Sections`, and all methods
- Added `# Errors` section on `FromStr` impl documenting failure conditions

## Test plan

- [x] `cargo test --doc -p rw-sections` — all 10 doc-tests pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p rw-sections` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)