### PR TITLE
docs: add comprehensive rustdoc for rw-renderer crate

### DIFF
--- a/crates/rw-renderer/src/backend.rs
+++ b/crates/rw-renderer/src/backend.rs
@@ -1,21 +1,37 @@
 //! Render backend trait for format-specific rendering.
 //!
-//! This trait abstracts the differences between HTML and Confluence output formats,
-//! allowing the main renderer to be generic over the output format.
+//! [`RenderBackend`] abstracts the differences between HTML and Confluence
+//! output formats, letting [`MarkdownRenderer`](crate::MarkdownRenderer)
+//! handle both with the same event-walking logic.
 
 use std::borrow::Cow;
 
 use pulldown_cmark::BlockQuoteKind;
 
-/// Alert type for GitHub-style alerts.
+/// Alert variant for GitHub-style blockquotes (`> [!NOTE]`, `> [!TIP]`, etc.).
 ///
-/// Maps to [`pulldown_cmark::BlockQuoteKind`] for blockquotes with `> [!NOTE]` syntax.
+/// Converted from [`pulldown_cmark::BlockQuoteKind`] when the parser
+/// encounters a blockquote with an alert marker.
+///
+/// # Examples
+///
+/// ```
+/// use rw_renderer::AlertKind;
+///
+/// let kind = AlertKind::Warning;
+/// assert_eq!(kind, AlertKind::Warning);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlertKind {
+    /// Informational note — highlights something the reader should be aware of.
     Note,
+    /// Helpful advice — suggests a better approach or useful trick.
     Tip,
+    /// Critical information — something the reader must not overlook.
     Important,
+    /// Potential issue — something that could go wrong.
     Warning,
+    /// Dangerous action — something that could cause data loss or security issues.
     Caution,
 }
 
@@ -31,84 +47,67 @@ impl From<BlockQuoteKind> for AlertKind {
     }
 }
 
-/// Backend trait for format-specific rendering operations.
+/// Format-specific rendering operations.
 ///
-/// Implementations provide format-specific rendering for:
-/// - Code blocks (HTML uses `<pre><code>`, Confluence uses `ac:structured-macro`)
-/// - Blockquotes (HTML uses `<blockquote>`, Confluence uses info panel macro)
-/// - Images (HTML uses `<img>`, Confluence uses `ac:image`)
-/// - Link transformation (HTML resolves relative `.md` links)
+/// [`MarkdownRenderer`](crate::MarkdownRenderer) calls these methods when it
+/// encounters elements that differ between output formats:
+///
+/// This crate ships [`HtmlBackend`](crate::HtmlBackend); other backends
+/// (e.g., Confluence XHTML) can be implemented downstream.
+///
+/// Methods cover the elements that differ between output formats: code blocks,
+/// blockquotes, alerts, images, link transformation, and line breaks.
 pub trait RenderBackend {
-    /// Whether to skip first H1 in output and shift heading levels.
+    /// Controls first-H1 handling and heading level adjustment.
     ///
-    /// - `true` (Confluence): First H1 becomes page title, not rendered. H2→H1, H3→H2, etc.
-    /// - `false` (HTML): First H1 is rendered normally, no level shifting.
+    /// - `true` (Confluence): first H1 is extracted as page title and
+    ///   suppressed from output; all subsequent headings shift up one level
+    ///   (H2 → H1, H3 → H2, etc.).
+    /// - `false` (HTML): first H1 renders normally, no level shifting.
     const TITLE_AS_METADATA: bool;
 
-    /// Render a code block.
+    /// Writes a fenced code block to `out`.
     ///
-    /// # Arguments
-    ///
-    /// * `lang` - Optional language identifier (e.g., "rust", "python")
-    /// * `content` - The code content
-    /// * `out` - Output buffer to write to
+    /// `lang` is the language identifier from the fence info string (e.g.,
+    /// `"rust"`, `"python"`), or `None` for plain code blocks.
     fn code_block(lang: Option<&str>, content: &str, out: &mut String);
 
-    /// Render blockquote start tag.
+    /// Writes the opening tag for a blockquote.
     fn blockquote_start(out: &mut String);
 
-    /// Render blockquote end tag.
+    /// Writes the closing tag for a blockquote.
     fn blockquote_end(out: &mut String);
 
-    /// Render alert start tag.
-    ///
-    /// Alerts are GitHub-style blockquotes with `> [!NOTE]` syntax.
+    /// Writes the opening markup for a GitHub-style alert.
     fn alert_start(kind: AlertKind, out: &mut String);
 
-    /// Render alert end tag.
+    /// Writes the closing markup for a GitHub-style alert.
     fn alert_end(kind: AlertKind, out: &mut String);
 
-    /// Render an image.
-    ///
-    /// # Arguments
-    ///
-    /// * `src` - Image source URL
-    /// * `alt` - Alt text for the image
-    /// * `title` - Optional title attribute
-    /// * `out` - Output buffer to write to
+    /// Writes an image element. `title` is empty when no title attribute is present.
     fn image(src: &str, alt: &str, title: &str, out: &mut String);
 
-    /// Transform a link URL.
+    /// Transforms a link URL before it is written to output.
     ///
-    /// Default implementation returns the URL unchanged.
-    /// HTML backend overrides this to resolve relative `.md` links.
-    ///
-    /// # Arguments
-    ///
-    /// * `url` - The original link URL
-    /// * `base_path` - Optional base path for resolving relative links
+    /// The default implementation returns the URL unchanged.
+    /// [`HtmlBackend`](crate::HtmlBackend) overrides this to resolve relative
+    /// `.md` links against `base_path`.
     #[must_use]
     fn transform_link<'a>(url: &'a str, _base_path: Option<&str>) -> Cow<'a, str> {
         Cow::Borrowed(url)
     }
 
-    /// Render a hard break.
-    ///
-    /// Default uses `<br>`. Override for format-specific rendering (e.g., `<br />`).
+    /// Writes a hard line break. Default: `<br>`.
     fn hard_break(out: &mut String) {
         out.push_str("<br>");
     }
 
-    /// Render a horizontal rule.
-    ///
-    /// Default uses `<hr>`. Override for format-specific rendering (e.g., `<hr />`).
+    /// Writes a horizontal rule. Default: `<hr>`.
     fn horizontal_rule(out: &mut String) {
         out.push_str("<hr>");
     }
 
-    /// Render a task list marker.
-    ///
-    /// Default uses HTML checkbox. Override for format-specific rendering.
+    /// Writes a task-list checkbox. Default: HTML `<input type="checkbox">`.
     fn task_list_marker(checked: bool, out: &mut String) {
         if checked {
             out.push_str(r#"<input type="checkbox" checked disabled> "#);

--- a/crates/rw-renderer/src/code_block.rs
+++ b/crates/rw-renderer/src/code_block.rs
@@ -106,31 +106,29 @@ impl ExtractedCodeBlock {
     }
 }
 
-/// Trait for processing special code blocks.
+/// Intercepts fenced code blocks during rendering.
 ///
-/// Implementations can handle one or more code block languages, transforming
-/// them into placeholders (for deferred processing) or inline HTML.
+/// Implementations handle one or more code block languages, transforming
+/// them into placeholders (for deferred processing like Kroki HTTP calls)
+/// or inline HTML (for fast, self-contained transforms like YAML tables).
 ///
-/// # Post-Processing
+/// Register processors with
+/// [`MarkdownRenderer::with_processor`](crate::MarkdownRenderer::with_processor).
+/// They are checked in registration order; the first returning a
+/// non-[`PassThrough`](ProcessResult::PassThrough) result wins.
 ///
-/// Processors that use placeholders can implement [`post_process`](Self::post_process)
-/// to replace them after rendering. Call [`MarkdownRenderer::finalize`] to trigger
-/// post-processing on all registered processors.
+/// Processors that use placeholders can implement
+/// [`post_process`](Self::post_process) to replace them after rendering
+/// completes.
+/// [`MarkdownRenderer::render`](crate::MarkdownRenderer::render) calls
+/// `post_process` automatically.
 pub trait CodeBlockProcessor {
-    /// Process a code block and return the result.
+    /// Inspects a code block and decides how to handle it.
     ///
-    /// # Arguments
-    ///
-    /// * `language` - Language identifier from fence info string
-    /// * `attrs` - Attributes parsed from fence (key=value pairs)
-    /// * `source` - Raw content of the code block
-    /// * `index` - Zero-based index for placeholder generation
-    ///
-    /// # Returns
-    ///
-    /// - `ProcessResult::Placeholder` - Replace with placeholder string
-    /// - `ProcessResult::Inline` - Replace with HTML string
-    /// - `ProcessResult::PassThrough` - Render as normal code block
+    /// `language` is the identifier from the fence info string (e.g.,
+    /// `"plantuml"`). `attrs` contains key-value pairs parsed from the
+    /// remainder of the info string (e.g., `format=png`). `index` is a
+    /// zero-based counter useful for generating unique placeholder tokens.
     fn process(
         &mut self,
         language: &str,
@@ -141,7 +139,8 @@ pub trait CodeBlockProcessor {
 
     /// Post-process rendered HTML to replace placeholders.
     ///
-    /// Called by [`MarkdownRenderer::finalize`] after rendering completes.
+    /// Called by [`MarkdownRenderer::render`](crate::MarkdownRenderer::render)
+    /// after rendering completes.
     /// Use this to replace placeholders with actual content (e.g., rendered diagrams).
     ///
     /// Default implementation is a no-op.

--- a/crates/rw-renderer/src/directive/mod.rs
+++ b/crates/rw-renderer/src/directive/mod.rs
@@ -1,24 +1,32 @@
-//! Pluggable directives API for `CommonMark` directive syntax.
+//! Pluggable directives API for [CommonMark generic directive syntax][spec].
 //!
-//! This module provides a trait-based extensibility system for handling `CommonMark`
-//! directives (inline `:name`, leaf `::name`, and container `:::name`).
+//! Directives extend markdown with custom inline, block, and wrapping
+//! elements using a colon-based syntax that does not conflict with standard
+//! CommonMark:
+//!
+//! | Type | Syntax | Trait |
+//! |------|--------|-------|
+//! | Inline | `:name[content]{attrs}` | [`InlineDirective`] |
+//! | Leaf (self-contained block) | `::name[content]{attrs}` | [`LeafDirective`] |
+//! | Container (wrapping block) | `:::name` … `:::` | [`ContainerDirective`] |
+//!
+//! [spec]: https://talk.commonmark.org/t/generic-directives-plugins-syntax/444
 //!
 //! # Architecture
 //!
-//! The directive system uses a two-phase processing model:
+//! Processing is split into two phases because pulldown-cmark does not
+//! understand directive syntax natively:
 //!
-//! 1. **Preprocessing** ([`DirectiveProcessor::process`]): Converts directive syntax
-//!    to intermediate HTML elements that pass through pulldown-cmark unchanged.
+//! 1. **Preprocessing** ([`DirectiveProcessor::process`]) — runs before
+//!    pulldown-cmark parsing. Converts directives to intermediate HTML
+//!    elements (e.g., `<rw-tabs>`) that pass through the parser unchanged,
+//!    or expands `::include` directives into raw markdown for recursive
+//!    processing.
 //!
-//! 2. **Post-processing** ([`DirectiveProcessor::post_process`]): Transforms
-//!    intermediate elements to final HTML using the [`Replacements`] collector
-//!    for single-pass string replacement.
-//!
-//! # Directive Types
-//!
-//! - **Inline** ([`InlineDirective`]): `:name[content]{attrs}` - inline elements
-//! - **Leaf** ([`LeafDirective`]): `::name[content]{attrs}` - self-contained blocks
-//! - **Container** ([`ContainerDirective`]): `:::name` ... `:::` - wrapping blocks
+//! 2. **Post-processing** ([`DirectiveProcessor::post_process`]) — runs
+//!    after rendering. Transforms intermediate elements to final accessible
+//!    HTML using the [`Replacements`] collector for efficient single-pass
+//!    string replacement.
 //!
 //! # Example
 //!

--- a/crates/rw-renderer/src/html.rs
+++ b/crates/rw-renderer/src/html.rs
@@ -1,6 +1,10 @@
 //! HTML backend for markdown rendering.
 //!
-//! Produces semantic HTML5 output suitable for web display.
+//! [`HtmlBackend`] produces semantic HTML5 suitable for the RW web viewer.
+//! It resolves relative `.md` links to clean URL paths and renders
+//! GitHub-style alerts with SVG icons from the [Octicons] set.
+//!
+//! [Octicons]: https://primer.style/octicons/
 
 use std::borrow::Cow;
 use std::fmt::Write;
@@ -15,13 +19,23 @@ const SVG_REPORT: &str = r#"<svg class="alert-icon" viewBox="0 0 16 16" width="1
 const SVG_ALERT: &str = r#"<svg class="alert-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>"#;
 const SVG_STOP: &str = r#"<svg class="alert-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>"#;
 
-/// HTML render backend.
+/// [`RenderBackend`] implementation that produces semantic HTML5.
 ///
-/// Produces semantic HTML5 with:
-/// - `<pre><code>` for code blocks
-/// - `<blockquote>` for blockquotes
-/// - `<img>` for images
-/// - Relative `.md` link resolution
+/// Code blocks use `<pre><code>` with a `language-*` class for syntax
+/// highlighting, images use `<img>`, and relative `.md` links are resolved
+/// to clean URL paths (e.g., `./sibling.md` → `/base/path/sibling`).
+///
+/// # Examples
+///
+/// ```
+/// use rw_renderer::{MarkdownRenderer, HtmlBackend};
+///
+/// let result = MarkdownRenderer::<HtmlBackend>::new()
+///     .with_base_path("/docs/guide")
+///     .render_markdown("[Setup](./setup.md#install)");
+///
+/// assert!(result.html.contains(r#"href="/docs/guide/setup#install""#));
+/// ```
 pub struct HtmlBackend;
 
 impl RenderBackend for HtmlBackend {

--- a/crates/rw-renderer/src/lib.rs
+++ b/crates/rw-renderer/src/lib.rs
@@ -1,31 +1,87 @@
-//! Trait-based markdown renderer with pluggable backends.
-//!
-//! This crate provides a generic [`MarkdownRenderer`] that can produce
-//! HTML output using the [`RenderBackend`] trait.
+//! Trait-based markdown renderer with pluggable backends, extensible code block
+//! processing, and directive syntax support.
 //!
 //! # Architecture
 //!
-//! The renderer uses a trait-based abstraction to handle format-specific differences:
-//! - [`HtmlBackend`]: Produces semantic HTML5 with relative link resolution
+//! [`MarkdownRenderer`] walks [pulldown-cmark] events and delegates
+//! format-specific rendering to a [`RenderBackend`] implementation.
+//! This crate ships [`HtmlBackend`] for semantic HTML5 output with relative
+//! link resolution; other backends (e.g., Confluence XHTML) can be
+//! implemented downstream.
 //!
-//! For Confluence XHTML storage format, use the `rw-confluence` crate.
-//!
-//! Shared functionality (tables, lists, inline formatting) is handled by the
-//! generic renderer, while format-specific elements (code blocks, blockquotes,
+//! Common elements (tables, lists, inline formatting) are handled by the
+//! generic renderer; format-specific elements (code blocks, blockquotes,
 //! images) are delegated to the backend.
 //!
-//! # Example
+//! ## Extension points
+//!
+//! - **Code block processors** ([`CodeBlockProcessor`]) — intercept fenced
+//!   code blocks by language (e.g., diagram rendering via Kroki). Processors
+//!   return a [`ProcessResult`]: a placeholder for deferred work, inline HTML,
+//!   or pass-through for normal syntax highlighting.
+//!
+//! - **Directives** ([`directive`] module) — [CommonMark generic directives]
+//!   syntax (`:inline`, `::leaf`, `:::container`). Directives are preprocessed
+//!   before pulldown-cmark parsing because pulldown-cmark does not understand
+//!   directive syntax natively; a post-processing pass then transforms
+//!   intermediate elements into final HTML.
+//!
+//! [pulldown-cmark]: https://docs.rs/pulldown-cmark
+//! [CommonMark generic directives]: https://talk.commonmark.org/t/generic-directives-plugins-syntax/444
+//!
+//! # Examples
+//!
+//! Render markdown to HTML:
 //!
 //! ```
-//! use pulldown_cmark::Parser;
 //! use rw_renderer::{MarkdownRenderer, HtmlBackend};
 //!
-//! let markdown = "# Hello\n\n**Bold** text";
-//! let parser = Parser::new(markdown);
+//! let markdown = "# Hello\n\n**Bold** text with a [link](other.md).";
 //! let result = MarkdownRenderer::<HtmlBackend>::new()
 //!     .with_title_extraction()
-//!     .render(parser);
+//!     .with_base_path("/docs/guide")
+//!     .render_markdown(markdown);
+//!
+//! assert_eq!(result.title.as_deref(), Some("Hello"));
+//! assert!(result.html.contains("<strong>Bold</strong>"));
+//! assert!(result.html.contains(r#"<a href="/docs/guide/other">"#));
 //! ```
+//!
+//! Add a custom code block processor:
+//!
+//! ```
+//! use std::collections::HashMap;
+//! use rw_renderer::{CodeBlockProcessor, HtmlBackend, MarkdownRenderer, ProcessResult};
+//!
+//! struct MathProcessor;
+//!
+//! impl CodeBlockProcessor for MathProcessor {
+//!     fn process(
+//!         &mut self,
+//!         language: &str,
+//!         _attrs: &HashMap<String, String>,
+//!         source: &str,
+//!         _index: usize,
+//!     ) -> ProcessResult {
+//!         if language == "math" {
+//!             ProcessResult::Inline(format!(r#"<div class="math">{source}</div>"#))
+//!         } else {
+//!             ProcessResult::PassThrough
+//!         }
+//!     }
+//! }
+//!
+//! let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
+//!     .with_processor(MathProcessor);
+//!
+//! let result = renderer.render_markdown("```math\nx^2 + y^2 = z^2\n```");
+//! assert!(result.html.contains(r#"class="math"#));
+//! ```
+//!
+//! # Feature flags
+//!
+//! - **`serde`** — enables `Serialize`/`Deserialize` on [`TocEntry`] for
+//!   JSON serialization in HTTP API responses.
 
 mod backend;
 mod bundle;

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -1,4 +1,6 @@
 //! Generic markdown renderer with pluggable backend.
+//!
+//! See the [crate-level documentation](crate) for an overview and examples.
 
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -14,26 +16,75 @@ use crate::directive::DirectiveProcessor;
 use crate::state::{CodeBlockState, HeadingState, ImageState, TableState, TocEntry, escape_html};
 use crate::util::heading_level_to_num;
 
-/// Result of rendering markdown.
+/// Output produced by [`MarkdownRenderer::render`] or [`MarkdownRenderer::render_markdown`].
+///
+/// Contains the rendered markup, an optional page title extracted from the
+/// first H1 heading, table-of-contents entries for heading navigation, and
+/// any warnings emitted by code block processors or directives.
+///
+/// # Examples
+///
+/// ```
+/// use rw_renderer::{MarkdownRenderer, HtmlBackend};
+///
+/// let result = MarkdownRenderer::<HtmlBackend>::new()
+///     .with_title_extraction()
+///     .render_markdown("# Welcome\n\nHello **world**.");
+///
+/// assert_eq!(result.title.as_deref(), Some("Welcome"));
+/// assert!(result.html.contains("<strong>world</strong>"));
+/// assert!(result.warnings.is_empty());
+/// ```
 #[derive(Debug)]
 pub struct RenderResult {
-    /// Rendered HTML/XHTML content.
+    /// Rendered markup. The format depends on the [`RenderBackend`]
+    /// (e.g., HTML from [`HtmlBackend`](crate::HtmlBackend)).
     pub html: String,
-    /// Title extracted from first H1 heading (if `extract_title` was enabled).
+    /// Title extracted from the first H1 heading when
+    /// [`with_title_extraction`](MarkdownRenderer::with_title_extraction) is enabled.
     pub title: Option<String>,
-    /// Table of contents entries.
+    /// Table-of-contents entries, one per heading (excluding the title heading).
     pub toc: Vec<TocEntry>,
-    /// Warnings generated during conversion (e.g., unresolved includes).
+    /// Warnings generated during conversion (e.g., unresolved includes,
+    /// unclosed container directives).
     pub warnings: Vec<String>,
 }
 
-/// Resolves page paths to their display titles.
+/// Resolves page paths to their display titles for wikilink rendering.
 ///
-/// Used by wikilinks to determine display text when no explicit text is provided.
+/// When a wikilink like `[[domain:billing::overview]]` has no explicit display
+/// text, the renderer calls this trait to look up a human-readable title.
+/// If the resolver returns `None`, the renderer falls back to the last path
+/// segment.
+///
+/// # Examples
+///
+/// ```
+/// use rw_renderer::TitleResolver;
+///
+/// struct MapResolver(std::collections::HashMap<String, String>);
+///
+/// impl TitleResolver for MapResolver {
+///     fn resolve_title(&self, path: &str) -> Option<String> {
+///         self.0.get(path).cloned()
+///     }
+/// }
+///
+/// let mut titles = std::collections::HashMap::new();
+/// titles.insert("domains/billing/overview".into(), "Billing Overview".into());
+/// let resolver = MapResolver(titles);
+///
+/// assert_eq!(
+///     resolver.resolve_title("domains/billing/overview"),
+///     Some("Billing Overview".into()),
+/// );
+/// assert_eq!(resolver.resolve_title("unknown/page"), None);
+/// ```
 pub trait TitleResolver {
-    /// Resolve a page path to its display title.
+    /// Returns the display title for a page at `path`, or `None` if unknown.
     ///
-    /// `path` is an absolute path without leading slash (e.g., `"domains/billing/overview"`).
+    /// `path` is an absolute path without leading slash
+    /// (e.g., `"domains/billing/overview"`).
     fn resolve_title(&self, path: &str) -> Option<String>;
 }
 
@@ -54,20 +105,44 @@ enum WikilinkResolution {
 
 /// Generic markdown renderer with pluggable backend.
 ///
-/// Uses the [`RenderBackend`] trait to delegate format-specific rendering
-/// while handling common elements (tables, lists, inline formatting) generically.
+/// Walks pulldown-cmark events and produces HTML or XHTML depending on the
+/// [`RenderBackend`] implementation (`B`). Common elements (tables, lists,
+/// inline formatting) are handled generically; format-specific elements are
+/// delegated to `B`.
 ///
-/// # Code Block Processors
+/// The two main entry points are:
 ///
-/// Custom code block processing can be added via [`with_processor`](Self::with_processor).
-/// Processors are checked in order; the first returning a non-`PassThrough` result wins.
+/// - [`render_markdown`](Self::render_markdown) — accepts raw markdown,
+///   handles directive pre/post-processing automatically.
+/// - [`render`](Self::render) — accepts a pre-built pulldown-cmark event
+///   iterator (skips directive processing).
 ///
-/// # Directive Processing
+/// # Code block processors
 ///
-/// The renderer supports `CommonMark` directives via [`with_directives`](Self::with_directives).
-/// When a directive processor is configured, [`render_markdown`](Self::render_markdown)
-/// will preprocess the input to expand directives before pulldown-cmark parsing,
-/// and post-process the output to transform intermediate elements.
+/// Register processors via [`with_processor`](Self::with_processor).
+/// Processors are checked in registration order; the first returning a
+/// non-[`PassThrough`](ProcessResult::PassThrough) result wins.
+///
+/// # Directive processing
+///
+/// Configure via [`with_directives`](Self::with_directives). When set,
+/// [`render_markdown`](Self::render_markdown) runs a three-phase pipeline:
+/// preprocess directives → parse and render with pulldown-cmark → post-process
+/// intermediate elements.
+///
+/// # Examples
+///
+/// ```
+/// use rw_renderer::{MarkdownRenderer, HtmlBackend};
+///
+/// let mut renderer = MarkdownRenderer::<HtmlBackend>::new()
+///     .with_title_extraction()
+///     .with_base_path("/docs/guide");
+///
+/// let result = renderer.render_markdown("# Guide\n\nSee [setup](setup.md).");
+/// assert_eq!(result.title.as_deref(), Some("Guide"));
+/// assert!(result.html.contains(r#"href="/docs/guide/setup""#));
+/// ```
 pub struct MarkdownRenderer<B: RenderBackend> {
     output: String,
     list_stack: Vec<bool>,
@@ -247,13 +322,19 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         Parser::new_ext(markdown, self.parser_options())
     }
 
-    /// Render markdown text directly using configured parser options.
+    /// Renders raw markdown to HTML, handling directives automatically.
     ///
-    /// If a directive processor is configured via [`with_directives`](Self::with_directives),
-    /// this method will:
-    /// 1. Preprocess the input to expand directives
-    /// 2. Parse and render the preprocessed markdown
-    /// 3. Post-process the output to transform intermediate elements
+    /// This is the primary entry point. It runs the full pipeline:
+    ///
+    /// 1. **Preprocess** — expands directives (if configured via
+    ///    [`with_directives`](Self::with_directives))
+    /// 2. **Parse & render** — feeds the markdown through pulldown-cmark and
+    ///    the backend
+    /// 3. **Post-process** — transforms intermediate directive elements and
+    ///    replaces code block placeholders
+    ///
+    /// Use [`render`](Self::render) instead when you already have a
+    /// pulldown-cmark event iterator or need to skip directive processing.
     pub fn render_markdown(&mut self, markdown: &str) -> RenderResult {
         // Phase 1: Preprocess directives (if configured)
         let preprocessed = if let Some(ref mut processor) = self.directives {
@@ -420,10 +501,14 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         tag
     }
 
-    /// Render markdown events and return the result.
+    /// Renders pre-parsed pulldown-cmark events to the configured backend.
     ///
-    /// Automatically calls `post_process` on all registered processors
-    /// to replace placeholders with rendered content.
+    /// Prefer [`render_markdown`](Self::render_markdown) for most use cases.
+    /// This method is useful when you need to construct the parser yourself
+    /// (e.g., with custom options) or when directive preprocessing is not needed.
+    ///
+    /// Automatically calls [`CodeBlockProcessor::post_process`] on all
+    /// registered processors to replace placeholders with rendered content.
     pub fn render<'a, I>(&mut self, events: I) -> RenderResult
     where
         I: Iterator<Item = Event<'a>>,

--- a/crates/rw-renderer/src/state.rs
+++ b/crates/rw-renderer/src/state.rs
@@ -137,15 +137,41 @@ impl ImageState {
     }
 }
 
-/// Table of contents entry.
+/// A single heading in the table of contents.
+///
+/// Produced by [`MarkdownRenderer`](crate::MarkdownRenderer) for every heading
+/// in the document (excluding the page title when
+/// [`with_title_extraction`](crate::MarkdownRenderer::with_title_extraction) is enabled).
+/// Collected in [`RenderResult::toc`](crate::RenderResult::toc).
+///
+/// The `id` field matches the `id` attribute on the rendered `<h*>` element,
+/// so frontends can build clickable heading links with `#{id}` fragments.
+///
+/// # Examples
+///
+/// ```
+/// use rw_renderer::{MarkdownRenderer, HtmlBackend};
+///
+/// let result = MarkdownRenderer::<HtmlBackend>::new()
+///     .with_title_extraction()
+///     .render_markdown("# Page Title\n\n## Introduction\n\n## Setup");
+///
+/// assert_eq!(result.toc.len(), 2);
+/// assert_eq!(result.toc[0].title, "Introduction");
+/// assert_eq!(result.toc[0].id, "introduction");
+/// assert_eq!(result.toc[0].level, 2);
+/// ```
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TocEntry {
-    /// Heading level (1-6).
+    /// Heading level (1–6), adjusted for the backend when
+    /// [`TITLE_AS_METADATA`](crate::RenderBackend::TITLE_AS_METADATA) is `true`
+    /// (headings shift up by one after the title H1).
     pub level: u8,
-    /// Heading text.
+    /// Plain-text heading content (inline formatting stripped).
     pub title: String,
-    /// Anchor ID for linking.
+    /// Slug-based anchor ID, matching the `id` attribute on the rendered heading.
+    /// Duplicate headings get a numeric suffix (e.g., `setup`, `setup-1`).
     pub id: String,
 }
 
@@ -344,7 +370,16 @@ fn slugify(text: &str) -> String {
     result
 }
 
-/// Escape HTML special characters.
+/// Escapes the five HTML special characters (`&`, `<`, `>`, `"`, `'`).
+///
+/// # Examples
+///
+/// ```
+/// use rw_renderer::escape_html;
+///
+/// assert_eq!(escape_html("<script>"), "&lt;script&gt;");
+/// assert_eq!(escape_html(r#"a "b" & 'c'"#), "a &quot;b&quot; &amp; &#x27;c&#x27;");
+/// ```
 #[must_use]
 pub fn escape_html(s: &str) -> String {
     let mut result = String::with_capacity(s.len());


### PR DESCRIPTION
## Summary

- Rewrote crate-level docs with architecture overview, two examples (basic rendering + custom code block processor), extension points, and feature flag documentation
- Added doc-tests to all major public items: `RenderResult`, `TitleResolver`, `MarkdownRenderer`, `HtmlBackend`, `TocEntry`, `escape_html`, `AlertKind`
- Improved `RenderBackend` trait docs — removed `# Arguments` sections, clarified method contracts
- Improved `CodeBlockProcessor` trait docs — fixed broken intra-doc links (`finalize` → `render`), explained registration and fallback behavior
- Rewrote `directive` module docs with scannable type table and architectural rationale (pulldown-cmark limitation)
- Removed references to `ConfluenceBackend` and `rw-confluence` to keep docs self-contained

## Test plan

- [x] `cargo test --doc -p rw-renderer` — 26 doc-tests pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p rw-renderer` — clean build
- [x] `cargo test -p rw-renderer` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)