### PR TITLE
docs: improve rw-renderer public API documentation

### DIFF
--- a/crates/rw-renderer/src/backend.rs
+++ b/crates/rw-renderer/src/backend.rs
@@ -11,15 +11,22 @@ use pulldown_cmark::BlockQuoteKind;
 /// Alert variant for GitHub-style blockquotes (`> [!NOTE]`, `> [!TIP]`, etc.).
 ///
 /// Converted from [`pulldown_cmark::BlockQuoteKind`] when the parser
-/// encounters a blockquote with an alert marker.
+/// encounters a blockquote with an alert marker. Passed to
+/// [`RenderBackend::alert_start`] and [`RenderBackend::alert_end`] so
+/// backends can render format-appropriate alert markup.
 ///
 /// # Examples
 ///
-/// ```
-/// use rw_renderer::AlertKind;
+/// Markdown alerts render as styled callout boxes:
 ///
-/// let kind = AlertKind::Warning;
-/// assert_eq!(kind, AlertKind::Warning);
+/// ```
+/// use rw_renderer::{MarkdownRenderer, HtmlBackend};
+///
+/// let result = MarkdownRenderer::<HtmlBackend>::new()
+///     .render_markdown("> [!WARNING]\n> Do not delete this file.");
+///
+/// assert!(result.html.contains(r#"class="alert alert-warning""#));
+/// assert!(result.html.contains("Do not delete this file."));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlertKind {

--- a/crates/rw-renderer/src/lib.rs
+++ b/crates/rw-renderer/src/lib.rs
@@ -29,6 +29,39 @@
 //! [pulldown-cmark]: https://docs.rs/pulldown-cmark
 //! [CommonMark generic directives]: https://talk.commonmark.org/t/generic-directives-plugins-syntax/444
 //!
+//! ## Wikilinks
+//!
+//! When enabled via [`MarkdownRenderer::with_wikilinks`], the renderer supports
+//! `[[target]]` syntax for section-stable internal links that survive directory
+//! reorganization. Wikilinks are resolved through [`Sections`] (set via
+//! [`MarkdownRenderer::with_sections`]) and display text is looked up via a
+//! [`TitleResolver`] (set via [`MarkdownRenderer::with_title_resolver`]).
+//! Each piece degrades gracefully when omitted:
+//!
+//! - Without [`Sections`], all wikilinks render as broken links
+//!   (`class="rw-broken-link"`)
+//! - Without a [`TitleResolver`], display text falls back to the last path
+//!   segment (e.g., `[[domain:billing::overview]]` displays as "overview")
+//! - Without [`MarkdownRenderer::with_wikilinks`], `[[...]]` syntax is not
+//!   parsed — pulldown-cmark treats it as plain text
+//!
+//! Supported syntax forms:
+//!
+//! | Syntax | Description |
+//! |--------|-------------|
+//! | `[[kind:name::path]]` | Cross-section link (e.g., `[[domain:billing::overview]]`) |
+//! | `[[kind:name]]` | Link to a section root (e.g., `[[domain:billing]]`) |
+//! | `[[name]]` | Short form — section kind defaults to `"section"` |
+//! | `[[::path]]` | Current-section link — resolved relative to `base_path` |
+//! | `[[::]]` | Current-section root |
+//! | `[[#fragment]]` | Same-page fragment link |
+//! | `[[target\|display text]]` | Any form above with explicit display text |
+//!
+//! Unresolved wikilinks render with a `class="rw-broken-link"` indicator.
+//! When no explicit display text is given, the renderer tries (in order):
+//! the [`TitleResolver`], the last path segment, the section name, or the
+//! raw href.
+//!
 //! # Examples
 //!
 //! Render markdown to HTML:
@@ -98,6 +131,13 @@ pub use bundle::bundle_markdown;
 pub use code_block::{CodeBlockProcessor, ExtractedCodeBlock, ProcessResult};
 pub use html::HtmlBackend;
 pub use renderer::{MarkdownRenderer, RenderResult, TitleResolver};
+/// Re-exported from [`rw_sections`] for use with
+/// [`MarkdownRenderer::with_sections`].
+///
+/// Holds a map of section refs (e.g., `"domain:default/billing"`) to
+/// filesystem paths, enabling wikilink resolution and cross-section link
+/// annotation. Built by higher-level crates like `rw-site` from the site
+/// configuration.
 pub use rw_sections::Sections;
 pub use state::{TocEntry, escape_html};
 pub use tabs::TabsDirective;

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -37,8 +37,11 @@ use crate::util::heading_level_to_num;
 /// ```
 #[derive(Debug)]
 pub struct RenderResult {
-    /// Rendered markup. The format depends on the [`RenderBackend`]
-    /// (e.g., HTML from [`HtmlBackend`](crate::HtmlBackend)).
+    /// Rendered markup produced by the [`RenderBackend`].
+    ///
+    /// Named `html` because [`HtmlBackend`](crate::HtmlBackend) is the primary
+    /// backend, but the actual format depends on `B`: [`HtmlBackend`](crate::HtmlBackend)
+    /// produces HTML5, while the downstream Confluence backend produces XHTML.
     pub html: String,
     /// Title extracted from the first H1 heading when
     /// [`with_title_extraction`](MarkdownRenderer::with_title_extraction) is enabled.
@@ -272,10 +275,18 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         self
     }
 
-    /// Set sections for cross-section link annotation.
+    /// Set the section registry for wikilink resolution and link annotation.
     ///
-    /// When set, resolved internal links get `data-section-ref` and
-    /// `data-section-path` attributes on the anchor element.
+    /// [`Sections`] maps section refs (e.g., `"domain:default/billing"`) to
+    /// filesystem paths, allowing the renderer to resolve `[[domain:billing::overview]]`
+    /// to a concrete URL. When set, resolved internal links also get
+    /// `data-section-ref` and `data-section-path` attributes on the anchor
+    /// element so host applications can build cross-entity navigation.
+    ///
+    /// Without this, wikilinks cannot resolve to URLs and render as broken
+    /// links (`class="rw-broken-link"`). See the
+    /// [crate-level wikilink documentation](crate#wikilinks) for the full
+    /// degradation behavior.
     #[must_use]
     pub fn with_sections(mut self, sections: Arc<Sections>) -> Self {
         if sections.is_empty() {
@@ -286,21 +297,43 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         self
     }
 
-    /// Enable wikilink syntax (`[[target]]`).
+    /// Enable `[[wikilink]]` syntax for section-stable internal links.
+    ///
+    /// When enabled, the pulldown-cmark parser recognizes `[[target]]` and
+    /// `[[target|display text]]` syntax. Links are resolved through
+    /// [`Sections`] (see [`with_sections`](Self::with_sections)) and display
+    /// text is looked up via [`with_title_resolver`](Self::with_title_resolver).
+    /// Each piece degrades gracefully when omitted — see the
+    /// [crate-level wikilink documentation](crate#wikilinks) for details.
+    /// Without [`Sections`], all wikilinks render as broken links.
+    /// Without a [`TitleResolver`], display text falls back to the last path
+    /// segment. Without this method, `[[...]]` is not parsed at all.
     #[must_use]
     pub fn with_wikilinks(mut self, enabled: bool) -> Self {
         self.wikilinks = enabled;
         self
     }
 
-    /// Set title resolver for wikilink display text.
+    /// Set a title resolver for wikilink display text.
+    ///
+    /// When a wikilink has no explicit display text (`[[target]]` vs.
+    /// `[[target|text]]`), the renderer calls the resolver to look up a
+    /// human-readable page title. If the resolver returns `None`, the
+    /// renderer falls back to the last path segment of the resolved URL.
+    ///
+    /// Optional — without this, display text falls back to the last path
+    /// segment (e.g., `[[domain:billing::overview]]` displays as "overview")
+    /// or the section name for root links.
     #[must_use]
     pub fn with_title_resolver(mut self, resolver: impl TitleResolver + 'static) -> Self {
         self.title_resolver = Some(Box::new(resolver));
         self
     }
 
-    /// Get parser options based on GFM configuration.
+    /// Returns pulldown-cmark [`Options`] reflecting the current GFM and
+    /// wikilink configuration.
+    ///
+    /// Useful when constructing a parser manually for [`render`](Self::render).
     #[must_use]
     pub fn parser_options(&self) -> Options {
         let mut opts = Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
@@ -316,7 +349,10 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         opts
     }
 
-    /// Create a configured parser for the given markdown text.
+    /// Creates a pulldown-cmark [`Parser`] with the renderer's current options.
+    ///
+    /// Use this with [`render`](Self::render) when you need a pre-built event
+    /// iterator (e.g., to inspect or filter events before rendering).
     #[must_use]
     pub fn create_parser<'a>(&self, markdown: &'a str) -> Parser<'a> {
         Parser::new_ext(markdown, self.parser_options())

--- a/crates/rw-renderer/src/tabs/directive.rs
+++ b/crates/rw-renderer/src/tabs/directive.rs
@@ -11,22 +11,22 @@ use crate::state::escape_html;
 
 /// Metadata for a single tab within a tab group.
 #[derive(Debug, PartialEq, Eq)]
-pub struct TabMetadata {
+pub(crate) struct TabMetadata {
     /// Unique ID for this tab within the document.
-    pub id: usize,
+    pub(crate) id: usize,
     /// Display label for the tab button.
-    pub label: String,
+    pub(crate) label: String,
     /// Line number where the tab was defined (1-indexed).
-    pub line: usize,
+    pub(crate) line: usize,
 }
 
 /// Metadata for a tab group.
 #[derive(Debug, PartialEq, Eq)]
-pub struct TabsGroup {
+pub(crate) struct TabsGroup {
     /// Unique ID for this tab group.
-    pub id: usize,
+    pub(crate) id: usize,
     /// Tabs within this group.
-    pub tabs: Vec<TabMetadata>,
+    pub(crate) tabs: Vec<TabMetadata>,
 }
 
 /// Container directive for tabbed content blocks.
@@ -77,12 +77,6 @@ impl TabsDirective {
             stack: Vec::new(),
             warnings: Vec::new(),
         }
-    }
-
-    /// Consume the directive and return collected tab groups.
-    #[must_use]
-    pub fn into_groups(self) -> Vec<TabsGroup> {
-        self.groups
     }
 }
 


### PR DESCRIPTION
## Summary
- Add comprehensive rustdoc for wikilink graceful degradation behavior
- Improve public API docs based on review feedback (better examples, cross-links between related methods)
- Tighten visibility of internal tab types (`TabMetadata`, `TabsGroup` → `pub(crate)`) and remove unused `into_groups()`

## Test plan
- [x] `cargo doc` builds with no warnings
- [x] All 26 doc tests pass
- [x] `make format` clean
- [x] No logic changes — documentation and visibility only

🤖 Generated with [Claude Code](https://claude.com/claude-code)