### PR TITLE
docs: add comprehensive rustdoc for rw-site crate

### DIFF
--- a/crates/rw-site/src/lib.rs
+++ b/crates/rw-site/src/lib.rs
@@ -1,10 +1,73 @@
-//! Site structure and page rendering for RW.
+//! Manages the document hierarchy and page rendering pipeline for RW.
 //!
-//! This crate provides:
-//! - [`Site`]: Unified site structure and page rendering
-//! - Navigation tree building for UI presentation
+//! This crate turns a flat list of documents from a [`Storage`](rw_storage::Storage) backend into a
+//! navigable site with parent/child relationships, breadcrumbs, section-scoped
+//! navigation, and on-demand markdown-to-HTML rendering with caching.
 //!
-//! # Quick Start
+//! # Core types
+//!
+//! - [`Site`] — the main entry point. Owns storage, cache, and renderer;
+//!   provides [`navigation`](Site::navigation), [`render`](Site::render), and
+//!   page lookup methods. Designed for shared ownership (`Arc<Site>`) and
+//!   concurrent access.
+//! - [`PageRendererConfig`] — controls title extraction, diagram rendering
+//!   (Kroki URL, DPI), and PlantUML include directories.
+//! - [`PageRenderResult`] — the output of rendering a page: HTML, title,
+//!   table of contents, breadcrumbs, and metadata.
+//! - [`Navigation`] — a scoped navigation tree with [`NavItem`] children,
+//!   current [`ScopeInfo`], and optional parent scope for back-navigation.
+//!
+//! # Sections and scoped navigation
+//!
+//! A **section** is a sub-site with its own navigation sidebar. Any page
+//! becomes a section root when its metadata includes a `kind` field (e.g.,
+//! `kind: domain`). This `kind` value becomes the section's kind in its
+//! [section ref](crate#sections-and-scoped-navigation) and in
+//! [`Section::kind`]. Kind values are freeform strings.
+//!
+//! Sections are identified by **section ref** strings with the format
+//! `kind:namespace/name` (e.g., `"domain:default/billing"`). The namespace
+//! is currently always `default`; it is reserved for future use. The name
+//! is the last path segment of the section root's URL path.
+//!
+//! When navigating, sections act as boundaries — [`Site::navigation`] scoped
+//! to a section shows only that section's children, with child sections
+//! appearing as leaf nodes (not expanded). The currently viewed section is
+//! called the **scope** (see [`ScopeInfo`]); the [`Navigation`] response
+//! includes the current scope and a parent scope for "back" navigation.
+//!
+//! Every site has an implicit **root section** with kind `"section"` and
+//! name `"root"` (ref `"section:default/root"`). It is used as the scope
+//! when no explicit section is defined at the site root, and as the
+//! fallback for [`Site::get_section_ref`] when a page has no section
+//! ancestor.
+//!
+//! See [`Section`] and [`Sections`] (re-exported from [`rw_sections`]) for
+//! the ref format and lookup API.
+//!
+//! # Virtual pages
+//!
+//! A **virtual page** is a page with no markdown content
+//! ([`has_content`](PageRenderResult::has_content) is `false`). Virtual pages
+//! appear when a directory has child content but no `index.md` of its own.
+//! They render as a bare `<h1>` title and participate in navigation and
+//! breadcrumbs like any other page.
+//!
+//! # Crate consumers
+//!
+//! This crate is used by `rw-server` (the HTTP server) and `rw-napi`
+//! (the Node.js native addon). Both wrap [`Site`] in `Arc` and call
+//! [`Site::invalidate`] when the underlying storage changes.
+//!
+//! # Lazy reload
+//!
+//! [`Site`] uses a lazy reload pattern. Callers signal that the underlying
+//! storage has changed by calling [`Site::invalidate`], but the actual reload
+//! happens on the next read operation ([`navigation`](Site::navigation),
+//! [`render`](Site::render), etc.). Concurrent readers continue using the
+//! previous snapshot until the reload completes.
+//!
+//! # Examples
 //!
 //! ```no_run
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,16 +77,19 @@
 //! use rw_cache::NullCache;
 //! use rw_storage_fs::FsStorage;
 //!
+//! // Create a site backed by the local filesystem
 //! let storage = Arc::new(FsStorage::new(PathBuf::from("docs")));
 //! let config = PageRendererConfig::default();
 //! let cache = Arc::new(NullCache);
 //! let site = Arc::new(Site::new(storage, cache, config));
 //!
-//! // Get navigation (root)
+//! // Fetch root navigation (triggers initial load from storage)
 //! let nav = site.navigation(None)?;
 //!
-//! // Render a page
+//! // Render a page by URL path (without leading slash)
 //! let result = site.render("guide")?;
+//! println!("Title: {:?}", result.title);
+//! println!("HTML length: {}", result.html.len());
 //! # Ok(())
 //! # }
 //! ```
@@ -33,11 +99,24 @@ pub(crate) mod site;
 pub(crate) mod site_state;
 
 pub use page::{BreadcrumbItem, PageRenderResult, PageRendererConfig, RenderError};
+
+/// A section identity consisting of a freeform `kind` and a `name`
+/// (the last path segment of the section root). Parsed from and
+/// serialized to section ref strings like `"domain:default/billing"`.
 pub use rw_sections::Section;
+
+/// A parsed section ref broken into its `kind`, `namespace`, and `name`
+/// components. See the [sections overview](crate#sections-and-scoped-navigation).
 pub use rw_sections::SectionPath;
+
+/// A map from URL paths to [`Section`] values, supporting lookup by
+/// section ref string and prefix-based path matching.
 pub use rw_sections::Sections;
+
 pub use site::Site;
 pub use site_state::{NavItem, Navigation, ScopeInfo};
 
-// Re-export TocEntry from rw-renderer for convenience
+/// A heading entry for building a table-of-contents sidebar.
+///
+/// Contains the heading `title`, `id` (anchor), and `level` (2–6).
 pub use rw_renderer::TocEntry;

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -1,8 +1,9 @@
 //! Page rendering pipeline.
 //!
-//! [`PageRenderer`] handles markdown-to-HTML conversion, page caching,
-//! diagram processing, and metadata loading. Extracted from [`Site`](crate::Site)
-//! to enable independent testing of the rendering pipeline.
+//! Contains the internal [`PageRenderer`] that handles markdown-to-HTML
+//! conversion, page caching, diagram processing, and metadata loading.
+//! Also defines the public result and configuration types used by
+//! [`Site`](crate::Site).
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -28,18 +29,43 @@ pub(crate) struct RenderContext {
     pub(crate) snapshot: Option<Arc<SiteSnapshot>>,
 }
 
-/// Configuration for [`PageRenderer`].
+/// Controls how [`Site`](crate::Site) renders markdown pages.
+///
+/// # Examples
+///
+/// ```
+/// use rw_site::PageRendererConfig;
+///
+/// // Default: title extraction on, no diagram rendering
+/// let config = PageRendererConfig::default();
+/// assert!(config.extract_title);
+/// assert!(config.kroki_url.is_none());
+/// ```
+///
+/// ```
+/// use rw_site::PageRendererConfig;
+///
+/// // Enable diagram rendering via a Kroki instance
+/// let config = PageRendererConfig {
+///     kroki_url: Some("https://kroki.io".to_owned()),
+///     dpi: 144,
+///     ..Default::default()
+/// };
+/// ```
 #[derive(Debug, Clone)]
 pub struct PageRendererConfig {
-    /// Extract title from first H1 heading.
+    /// When `true`, the first `# H1` heading is extracted from the rendered
+    /// HTML and returned separately in [`PageRenderResult::title`].
     pub extract_title: bool,
-    /// Kroki URL for diagram rendering.
+    /// Base URL of a [Kroki](https://kroki.io) instance for rendering diagrams.
     ///
-    /// If `None`, diagrams are rendered as syntax-highlighted code blocks.
+    /// When `None`, fenced code blocks for diagram languages (PlantUML,
+    /// Mermaid, etc.) are rendered as syntax-highlighted code instead of images.
     pub kroki_url: Option<String>,
-    /// Directories to search for `PlantUML` includes.
+    /// Directories to search when resolving PlantUML `!include` directives.
+    /// Defaults to empty (no include resolution).
     pub include_dirs: Vec<PathBuf>,
-    /// DPI for diagram rendering (default: 192 for retina).
+    /// DPI for rendered diagram images. Defaults to `192` (retina).
     pub dpi: u32,
 }
 
@@ -54,64 +80,100 @@ impl Default for PageRendererConfig {
     }
 }
 
-/// Document page data.
+/// A single document in the site hierarchy.
+///
+/// Every entry in the navigation tree corresponds to a `Page`. Pages with
+/// markdown content have [`has_content`](Self::has_content) set to `true`;
+/// [virtual pages](crate#virtual-pages) (directories without `index.md`)
+/// have it set to `false`.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Page {
-    /// Page title (from H1 heading, filename, or metadata override).
+    /// Display title, resolved from (in priority order): metadata `title`
+    /// field, first `# H1` heading, or filename.
     pub title: String,
-    /// URL path without leading slash (e.g., "guide", "domain/page", "" for root).
+    /// URL path without leading slash (e.g., `"guide"`, `"domain/billing"`,
+    /// `""` for the site root).
     pub path: String,
-    /// True if page has content (real page). False for virtual pages (metadata only).
+    /// Whether this page has markdown content. `false` for virtual pages
+    /// that exist only as navigation containers.
     pub has_content: bool,
 }
 
-/// Breadcrumb navigation item.
+/// One segment of the breadcrumb trail leading to a page.
+///
+/// Breadcrumbs always start with a "Home" entry (path `""`) and include
+/// each ancestor page up to (but not including) the current page.
+///
+/// # Examples
+///
+/// A page at `"domain/billing/overview"` produces breadcrumbs:
+///
+/// ```text
+/// Home → Domain → Billing
+/// ```
+///
+/// where "Home" has `path ""`, "Domain" has `path "domain"`, and
+/// "Billing" has `path "domain/billing"`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct BreadcrumbItem {
-    /// Display title.
+    /// Display title for this breadcrumb segment.
     pub title: String,
-    /// Link target path.
+    /// URL path without leading slash. Empty string for the site root.
     pub path: String,
-    /// Section identity if this breadcrumb's path matches a section.
+    /// Present when this breadcrumb's path is a [section](crate#sections-and-scoped-navigation) root.
     pub section: Option<Section>,
 }
 
-/// Result of rendering a markdown page.
+/// Output of rendering a single page via [`Site::render`](crate::Site::render).
+///
+/// Contains everything the frontend needs to display a page: rendered HTML,
+/// extracted title, table of contents for the sidebar, breadcrumb trail,
+/// and optional YAML metadata.
 #[derive(Debug)]
 pub struct PageRenderResult {
-    /// Rendered HTML content.
+    /// Rendered HTML body content.
     pub html: String,
-    /// Title extracted from first H1 heading (if enabled).
+    /// Title extracted from the first `# H1` heading, or `None` if title
+    /// extraction is disabled or the page has no H1.
     pub title: Option<String>,
-    /// Table of contents entries.
+    /// Headings found in the page, used to build a "table of contents" sidebar.
     pub toc: Vec<TocEntry>,
-    /// Warnings generated during conversion (e.g., unresolved includes).
+    /// Non-fatal issues encountered during rendering (e.g., unresolved
+    /// `!include` directives). Intended for logging or developer tooling,
+    /// not for display to end users.
     pub warnings: Vec<String>,
-    /// Whether result was served from cache.
+    /// `true` when the HTML was served from cache rather than re-rendered.
     pub from_cache: bool,
-    /// Whether the page has content (real page vs virtual page).
+    /// `false` for [virtual pages](crate#virtual-pages) that have no markdown source.
     pub has_content: bool,
-    /// Source file modification time (Unix timestamp).
+    /// Source file modification time as a Unix timestamp (seconds since
+    /// epoch). Stored as `f64` for sub-second precision and JavaScript
+    /// interoperability.
     pub source_mtime: f64,
-    /// Breadcrumb navigation items.
+    /// Ancestor trail from "Home" to the parent of this page.
+    /// See [`BreadcrumbItem`] for the structure.
     pub breadcrumbs: Vec<BreadcrumbItem>,
-    /// Page metadata from YAML sidecar file.
+    /// Page metadata from YAML frontmatter or sidecar `meta.yaml` file,
+    /// if present.
     pub metadata: Option<Metadata>,
 }
 
-/// Error returned when page rendering fails.
+/// Reasons why [`Site::render`](crate::Site::render) can fail.
 #[derive(Debug, thiserror::Error)]
 pub enum RenderError {
-    /// Content not found for page.
+    /// The page exists in the site structure but its markdown source file
+    /// is missing from storage.
     #[error("Content not found: {0}")]
     FileNotFound(String),
-    /// Page not found in site structure.
+    /// No page with this URL path exists in the site structure. The path
+    /// may be misspelled or the site may need a reload.
     #[error("Page not found: {0}")]
     PageNotFound(String),
-    /// I/O error reading source file.
+    /// I/O error while reading the markdown source file.
     #[error("I/O error: {0}")]
     Io(#[source] std::io::Error),
-    /// Storage backend error (e.g., S3 unavailable).
+    /// The storage backend itself failed (e.g., S3 connectivity issues,
+    /// permission errors).
     #[error("Storage error: {0}")]
     Storage(#[source] StorageError),
 }

--- a/crates/rw-site/src/site.rs
+++ b/crates/rw-site/src/site.rs
@@ -1,45 +1,8 @@
-//! Unified site loading and rendering.
+//! Site loading, caching, and rendering orchestration.
 //!
-//! Provides [`Site`] for building [`SiteState`] structures from a [`Storage`]
-//! backend, with integrated page rendering. Includes optional file-based caching.
-//!
-//! # Architecture
-//!
-//! The [`Site`] combines site structure loading and page rendering:
-//! - `index.md` files become section landing pages
-//! - Other `.md` files become standalone pages
-//! - Directories without `index.md` have their children promoted to parent level
-//!
-//! # Thread Safety
-//!
-//! `Site` is designed for concurrent access:
-//! - `snapshot()` returns `Arc<SiteSnapshot>` with minimal locking (just Arc clone)
-//! - `reload_if_needed()` uses double-checked locking for efficient cache validation
-//! - `invalidate()` is lock-free (atomic flag)
-//!
-//! # Example
-//!
-//! ```no_run
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use std::path::PathBuf;
-//! use std::sync::Arc;
-//! use rw_site::{Site, PageRendererConfig};
-//! use rw_cache::NullCache;
-//! use rw_storage_fs::FsStorage;
-//!
-//! let storage = Arc::new(FsStorage::new(PathBuf::from("docs")));
-//! let config = PageRendererConfig::default();
-//! let cache = Arc::new(NullCache);
-//! let site = Arc::new(Site::new(storage, cache, config));
-//!
-//! // Load site structure
-//! let nav = site.navigation(None)?;
-//!
-//! // Render a page
-//! let result = site.render("guide")?;
-//! # Ok(())
-//! # }
-//! ```
+//! This module provides [`Site`], the main entry point for the crate. See
+//! the [crate-level docs](crate) for an overview of sections, virtual pages,
+//! and the lazy reload pattern.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -119,18 +82,52 @@ impl TitleResolver for SiteTitleResolver {
     }
 }
 
-/// Unified site structure and page rendering.
+/// Manages the document hierarchy and renders pages on demand.
 ///
-/// Combines site structure loading from a [`Storage`] implementation with
-/// page rendering functionality. Uses `index.md` files as section landing pages.
-/// Titles are provided by the storage (extracted or stored depending on backend).
+/// `Site` scans documents from a [`Storage`] backend, builds a tree of
+/// parent/child page relationships, and renders markdown to HTML through
+/// an internal page renderer. Results are cached so repeated requests
+/// for the same page are fast.
 ///
-/// # Thread Safety
+/// Callers typically wrap `Site` in `Arc` and share it across threads.
+/// All public methods use internal synchronization — no external locking
+/// is required.
 ///
-/// This struct is designed for concurrent access without external locking:
-/// - Uses internal `RwLock<Arc<SiteSnapshot>>` for the current site snapshot
-/// - Uses `Mutex<()>` for serializing reload operations
-/// - Uses `AtomicBool` for cache validity tracking
+/// # Lazy reload
+///
+/// `Site` does not re-scan storage on every request. Call
+/// [`invalidate`](Self::invalidate) to mark the cached site structure as
+/// stale; the next read method ([`navigation`](Self::navigation),
+/// [`render`](Self::render), etc.) will reload from storage before
+/// returning. Concurrent readers see the previous snapshot until the
+/// reload completes.
+///
+/// # Examples
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::sync::Arc;
+/// use std::path::PathBuf;
+/// use rw_site::{Site, PageRendererConfig};
+/// use rw_cache::NullCache;
+/// use rw_storage_fs::FsStorage;
+///
+/// let storage = Arc::new(FsStorage::new(PathBuf::from("docs")));
+/// let site = Arc::new(Site::new(
+///     storage,
+///     Arc::new(NullCache),
+///     PageRendererConfig::default(),
+/// ));
+///
+/// // First call triggers a scan of the storage backend
+/// let nav = site.navigation(None)?;
+///
+/// // Render a page — cached on second call if the source file hasn't changed
+/// let result = site.render("guide")?;
+/// assert!(result.has_content);
+/// # Ok(())
+/// # }
+/// ```
 pub struct Site {
     storage: Arc<dyn Storage>,
     // Buckets
@@ -151,13 +148,11 @@ pub struct Site {
 }
 
 impl Site {
-    /// Create a new site with storage, configuration, and cache.
+    /// Creates a new site backed by the given storage and cache.
     ///
-    /// # Arguments
-    ///
-    /// * `storage` - Storage implementation for document scanning and reading
-    /// * `cache` - Cache implementation for site structure, pages, and diagrams
-    /// * `config` - Page renderer configuration
+    /// The site starts empty — no storage scan happens until the first read
+    /// method is called. Pass [`NullCache`](rw_cache::NullCache) to disable
+    /// caching entirely.
     #[must_use]
     pub fn new(
         storage: Arc<dyn Storage>,
@@ -188,15 +183,18 @@ impl Site {
         Arc::clone(&self.current_snapshot.read().unwrap())
     }
 
-    /// Get scoped navigation tree.
+    /// Returns the navigation tree scoped to a section.
     ///
-    /// Reloads site if needed and returns navigation for the given section.
-    /// Pass `None` for root navigation, or a section ref string
-    /// (e.g., `"domain:default/billing"`) to scope to that section.
+    /// Pass `None` for root navigation, or a
+    /// [section ref](crate#sections-and-scoped-navigation) (e.g.,
+    /// `"domain:default/billing"`) to get that section's children.
+    /// Triggers a reload on first call or after [`invalidate`](Self::invalidate).
     ///
     /// # Errors
     ///
-    /// Returns `StorageError` if initial site load fails.
+    /// Returns [`StorageError`] if the initial site load fails (storage
+    /// unreachable). Subsequent reload failures are logged and stale data
+    /// is returned instead.
     pub fn navigation(&self, section_ref: Option<&str>) -> Result<Navigation, StorageError> {
         let snapshot = self.reload_if_needed()?;
         let scope_path = section_ref
@@ -207,56 +205,46 @@ impl Site {
         Ok(nav)
     }
 
-    /// Get the current sections map.
+    /// Returns the current [`Sections`] map for cross-section link resolution.
     ///
     /// # Errors
     ///
-    /// Returns `StorageError` if initial site load fails.
+    /// Returns [`StorageError`] if the initial site load fails.
     pub fn sections(&self) -> Result<Arc<Sections>, StorageError> {
         let snapshot = self.reload_if_needed()?;
         Ok(Arc::clone(&snapshot.sections))
     }
 
-    /// Get the section ref string for the section a page belongs to.
+    /// Returns the [section ref](crate#sections-and-scoped-navigation) for
+    /// the section that contains `page_path`.
     ///
-    /// Reloads site if needed and returns the ref (e.g., `"domain:default/billing"`)
-    /// for the nearest section ancestor, falling back to the implicit root
-    /// section (`section:default/root`) when no explicit section is found.
-    ///
-    /// # Arguments
-    ///
-    /// * `page_path` - URL path without leading slash.
+    /// Walks up the path hierarchy to find the nearest section ancestor.
+    /// Falls back to the implicit root section (`"section:default/root"`)
+    /// when no explicit section is found.
     ///
     /// # Errors
     ///
-    /// Returns `StorageError` if initial site load fails.
+    /// Returns [`StorageError`] if the initial site load fails.
     pub fn get_section_ref(&self, page_path: &str) -> Result<String, StorageError> {
         Ok(self.reload_if_needed()?.state.get_section_ref(page_path))
     }
 
-    /// Check if a page exists at the given URL path.
-    ///
-    /// Reloads site if needed and returns whether the page exists.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - URL path without leading slash (e.g., "guide", "domain/page", "" for root)
+    /// Returns `true` if a page exists at `path` in the site structure.
     ///
     /// # Errors
     ///
-    /// Returns `StorageError` if initial site load fails.
+    /// Returns [`StorageError`] if the initial site load fails.
     pub fn has_page(&self, path: &str) -> Result<bool, StorageError> {
         Ok(self.reload_if_needed()?.state.get_page(path).is_some())
     }
 
-    /// Get the title of a page from the current cached snapshot.
+    /// Returns the title of a page from the current cached snapshot, or
+    /// `None` if the page does not exist.
     ///
-    /// Reads from the current snapshot without triggering a reload.
-    /// Returns `None` if the page doesn't exist in the cached state.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - URL path without leading slash (e.g., "guide", "" for root)
+    /// Unlike other methods, this does **not** trigger a reload — it reads
+    /// whatever snapshot is currently in memory. This makes it suitable for
+    /// use in tight loops (e.g., resolving wikilink display text) where
+    /// staleness is acceptable.
     #[must_use]
     pub fn page_title(&self, path: &str) -> Option<String> {
         self.snapshot()
@@ -265,38 +253,32 @@ impl Site {
             .map(|p| p.title.clone())
     }
 
-    /// Get breadcrumbs for a page.
+    /// Returns the [`BreadcrumbItem`] trail for a page.
     ///
-    /// Reloads site if needed and returns breadcrumb navigation items
-    /// for a given URL path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - URL path without leading slash (e.g., "guide/setup", "" for root)
+    /// The trail starts with "Home" (path `""`) and includes each ancestor
+    /// up to but not including the page itself. Returns an empty `Vec` for
+    /// the root page.
     ///
     /// # Errors
     ///
-    /// Returns `StorageError` if initial site load fails.
+    /// Returns [`StorageError`] if the initial site load fails.
     pub fn get_breadcrumbs(&self, path: &str) -> Result<Vec<BreadcrumbItem>, StorageError> {
         Ok(self.reload_if_needed()?.state.get_breadcrumbs(path))
     }
 
-    /// Reload site from storage if cache is invalid.
+    /// Returns the current snapshot, reloading from storage if stale.
     ///
-    /// Uses double-checked locking pattern:
-    /// 1. Fast path: return current snapshot if cache valid
-    /// 2. Slow path: acquire `reload_lock`, recheck, then reload
+    /// Uses a double-checked locking pattern: the fast path (cache valid)
+    /// requires only an atomic load and an `RwLock` read; the slow path
+    /// acquires a `Mutex` to serialize reloads.
     ///
-    /// On initial load, storage errors are propagated to the caller.
-    /// On subsequent reloads, storage errors are logged and stale data is kept.
-    ///
-    /// # Returns
-    ///
-    /// `Arc<SiteSnapshot>` containing the current site snapshot.
+    /// On the **initial** load, storage errors propagate to the caller so
+    /// that misconfigured storage is surfaced immediately. On subsequent
+    /// reloads, errors are logged and the previous snapshot is kept.
     ///
     /// # Errors
     ///
-    /// Returns `StorageError` if the initial site load fails.
+    /// Returns [`StorageError`] if the initial site load fails.
     ///
     /// # Panics
     ///
@@ -350,33 +332,33 @@ impl Site {
         Ok(snapshot)
     }
 
-    /// Invalidate cached site state.
+    /// Marks the cached site structure as stale.
     ///
-    /// Marks cache as invalid and bumps the generation counter so the
-    /// old site bucket entry won't match. Next `reload_if_needed()` will reload.
-    /// Current readers continue using their existing `Arc<SiteSnapshot>`.
+    /// The next call to any read method ([`navigation`](Self::navigation),
+    /// [`render`](Self::render), etc.) will re-scan storage before returning.
+    /// Readers that already hold a snapshot are unaffected — they continue
+    /// using the previous data. This method is lock-free.
     pub fn invalidate(&self) {
         self.cache_valid.store(false, Ordering::Release);
         self.generation.fetch_add(1, Ordering::Release);
     }
 
-    /// Render a page by URL path.
+    /// Renders a page to HTML by its URL path.
     ///
-    /// Reloads site if needed, looks up the page, and renders it.
+    /// Looks up the page in the site structure, computes breadcrumbs, and
+    /// runs the markdown rendering pipeline (or returns a cached result if
+    /// the source file has not changed).
     ///
-    /// # Arguments
-    ///
-    /// * `path` - URL path without leading slash (e.g., "guide", "domain/page", "" for root)
-    ///
-    /// # Returns
-    ///
-    /// `PageRenderResult` with HTML, title, table of contents, and metadata.
+    /// `path` is a URL path without leading slash (e.g., `"guide"`,
+    /// `"domain/billing"`, `""` for root).
     ///
     /// # Errors
     ///
-    /// Returns `RenderError::PageNotFound` if page doesn't exist in site.
-    /// Returns `RenderError::FileNotFound` if source file doesn't exist.
-    /// Returns `RenderError::Io` if file cannot be read.
+    /// Returns [`RenderError::PageNotFound`] if no page with this path
+    /// exists in the site structure.
+    /// Returns [`RenderError::FileNotFound`] if the page exists but its
+    /// markdown source is missing from storage.
+    /// Returns [`RenderError::Storage`] if the storage backend itself fails.
     pub fn render(&self, path: &str) -> Result<PageRenderResult, RenderError> {
         let snapshot = self.reload_if_needed().map_err(RenderError::Storage)?;
         let page = snapshot

--- a/crates/rw-site/src/site_state.rs
+++ b/crates/rw-site/src/site_state.rs
@@ -1,16 +1,12 @@
-//! Site state for document hierarchy.
+//! Immutable site state and navigation tree building.
 //!
-//! Provides the core document site state with efficient path lookups
-//! and traversal operations. This is the pure data representation of
-//! the site structure, separate from the active [`SiteState`](crate::SiteState) type
-//! which handles loading and rendering.
+//! [`SiteState`] is the pure data representation of the document hierarchy —
+//! a flat `Vec<Page>` with parent/child relationships tracked by indices.
+//! It provides O(1) page lookups by URL path and O(d) breadcrumb building
+//! (where d is the page depth).
 //!
-//! # Architecture
-//!
-//! Pages are stored in a flat `Vec<Page>` with parent/children relationships
-//! tracked by indices. This provides:
-//! - O(1) URL path lookups via `path_index` `HashMap`
-//! - O(d) breadcrumb building where d is the page depth
+//! This module also defines the navigation types ([`NavItem`], [`Navigation`],
+//! [`ScopeInfo`]) that the frontend consumes.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -26,33 +22,43 @@ fn last_segment(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
 }
 
-/// Navigation item with children for UI tree.
+/// A node in the navigation tree sent to the frontend.
+///
+/// Each `NavItem` maps to a page. Items that are
+/// [section](crate#sections-and-scoped-navigation) roots have a populated
+/// [`section`](Self::section) field and no children (sections are leaf
+/// nodes in their parent's navigation — the section's own children appear
+/// when navigating into that section).
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct NavItem {
-    /// Display title.
+    /// Display title for this navigation entry.
     pub title: String,
-    /// Link target path.
+    /// URL path without leading slash (e.g., `"guide"`, `"domain/billing"`).
     pub path: String,
-    /// Section identity if this item's path matches a section.
+    /// Present when this item is a section root. Contains the section kind
+    /// and name (e.g., `kind: "domain"`, `name: "billing"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub section: Option<Section>,
-    /// Child navigation items.
+    /// Child navigation items. Empty for section roots and leaf pages.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<NavItem>,
 }
 
-/// Section information for sub-sites or categorized content.
+/// Metadata for a [section](crate#sections-and-scoped-navigation) root page.
 ///
-/// A section is created when a page has a `kind` set in its metadata.
+/// Created when a page's metadata includes a `kind` field. Stored internally
+/// by [`SiteState`] and used to build [`Section`] refs and scoped navigation.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SectionInfo {
-    /// Section title (from page title).
+    /// Display title of the section (taken from the page title).
     pub title: String,
-    /// URL path to the section root (without leading slash).
+    /// URL path to the section root, without leading slash
+    /// (e.g., `"domains/billing"`).
     pub path: String,
-    /// Section kind (from metadata `kind` field).
+    /// Freeform kind string from the page's metadata `kind` field
+    /// (e.g., `"domain"`, `"system"`, `"component"`).
     pub section_kind: String,
-    /// Section description (from metadata `description` field).
+    /// Optional description from the page's metadata `description` field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
@@ -71,38 +77,59 @@ impl From<&SectionInfo> for Section {
     }
 }
 
-/// Information about a navigation scope for the frontend.
+/// Describes which [section](crate#sections-and-scoped-navigation) the
+/// navigation sidebar is currently showing.
+///
+/// Returned as part of [`Navigation`] to tell the frontend which section
+/// is active and where "back" navigation should go.
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct ScopeInfo {
-    /// URL path to the scope (with leading slash for frontend).
+    /// URL path **with** leading slash (e.g., `"/domains/billing"`, `"/"`
+    /// for root).
+    ///
+    /// **Note:** This is the only path field in the crate that includes a
+    /// leading slash — all other path fields (on [`NavItem`], [`BreadcrumbItem`],
+    /// etc.) omit it. The slash is included here for direct use in frontend
+    /// routing URLs.
     pub path: String,
-    /// Display title.
+    /// Display title for the scope header.
     pub title: String,
-    /// Section identity.
+    /// Section identity (kind + name) for this scope.
     pub section: Section,
 }
 
-/// Result of scoped navigation query.
+/// The navigation tree for a single [section](crate#sections-and-scoped-navigation) scope.
+///
+/// Returned by [`Site::navigation`](crate::Site::navigation). Contains the
+/// tree of [`NavItem`]s for the sidebar, the current scope, and the parent
+/// scope for "back" navigation.
+///
+/// At the root scope, `parent_scope` is `None`. At any other scope,
+/// `parent_scope` points to the nearest ancestor section (or root).
 #[derive(Debug, Default, Serialize)]
 pub struct Navigation {
-    /// Navigation items for this scope.
+    /// Top-level navigation items within this scope.
     pub items: Vec<NavItem>,
-    /// Current scope info (implicit root section at root, explicit section otherwise).
+    /// The section this navigation belongs to. `None` only in the
+    /// `Default` value (empty navigation); always `Some` when returned by
+    /// [`Site::navigation`](crate::Site::navigation).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<ScopeInfo>,
-    /// Parent scope for back navigation (None only at root).
+    /// The parent section for "back" navigation. `None` only at the root scope.
     #[serde(rename = "parentScope", skip_serializing_if = "Option::is_none")]
     pub parent_scope: Option<ScopeInfo>,
 }
 
-/// Document site state with efficient path lookups.
+/// Immutable snapshot of the document hierarchy.
 ///
-/// Pure data structure storing pages in a flat list with parent/children
-/// relationships tracked by indices. Provides O(1) URL path and source path
-/// lookups, and O(d) breadcrumb building where d is the page depth.
+/// Stores pages in a flat `Vec` with parent/child relationships tracked by
+/// indices. Provides O(1) page lookup by URL path and O(d) breadcrumb
+/// building (d = page depth). Also indexes sections for scoped navigation
+/// and section ref lookups.
 ///
-/// This is the immutable state representation. For loading and rendering
-/// functionality, see [`Site`](crate::Site).
+/// `SiteState` is the pure data layer — it does not own storage or trigger
+/// reloads. See [`Site`](crate::Site) for the higher-level API that manages
+/// loading and rendering.
 pub struct SiteState {
     pages: Vec<Page>,
     children: Vec<Vec<usize>>,
@@ -185,32 +212,20 @@ impl SiteState {
         }
     }
 
-    /// Get page by URL path.
+    /// Returns the page at `path`, or `None` if no page exists there.
     ///
-    /// # Arguments
-    ///
-    /// * `path` - URL path without leading slash (e.g., "guide", "domain/page", "" for root)
-    ///
-    /// # Returns
-    ///
-    /// Page reference if found, `None` otherwise.
+    /// `path` is a URL path without leading slash (e.g., `"guide"`,
+    /// `"domain/billing"`, `""` for root).
     #[must_use]
     pub fn get_page(&self, path: &str) -> Option<&Page> {
         self.path_index.get(path).map(|&i| &self.pages[i])
     }
 
-    /// Get children of a page that have markdown content in their subtree.
+    /// Returns children of `path` whose subtree contains at least one page
+    /// with markdown content.
     ///
-    /// When `path` is empty and no root page exists, returns root-level pages
-    /// with content as a fallback. This handles sites without an `index.md`.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - URL path without leading slash (e.g., "guide", "" for root)
-    ///
-    /// # Returns
-    ///
-    /// Vector of child page references that have content, empty if page not found or has no children with content.
+    /// When `path` is empty and no root `index.md` exists, returns top-level
+    /// pages as a fallback.
     #[must_use]
     fn get_children_with_content(&self, path: &str) -> Vec<&Page> {
         if let Some(&idx) = self.path_index.get(path) {
@@ -231,24 +246,12 @@ impl SiteState {
         }
     }
 
-    /// Build breadcrumbs for a given path.
+    /// Returns the breadcrumb trail for `path`.
     ///
-    /// Returns breadcrumbs starting with "Home" for non-root pages,
-    /// followed by ancestor pages. The current page is not included.
-    ///
-    /// # Note
-    ///
-    /// For unknown paths, returns `[Home]` to provide minimal navigation
-    /// in UI even when the page doesn't exist in the site structure.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - URL path without leading slash (e.g., "guide/setup", "" for root)
-    ///
-    /// # Returns
-    ///
-    /// Vector of breadcrumb items for ancestor navigation.
-    /// Paths in breadcrumbs are also without leading slash (empty string for root).
+    /// The trail starts with "Home" (path `""`) and includes each ancestor
+    /// up to but not including the page itself. Returns an empty `Vec` for
+    /// the root path (`""`). For unknown paths, returns `[Home]` so the
+    /// frontend always has at least minimal navigation.
     #[must_use]
     pub fn get_breadcrumbs(&self, path: &str) -> Vec<BreadcrumbItem> {
         if path.is_empty() {
@@ -305,11 +308,11 @@ impl SiteState {
         self.roots.iter().map(|&i| &self.pages[i]).collect()
     }
 
-    /// Find sections by raw directory name (last path segment).
+    /// Finds sections whose last path segment matches `name`.
     ///
-    /// Returns section info for pages whose directory name matches.
-    /// For example, `find_sections_by_name("payment-gateway")` finds
-    /// sections at paths like `"domains/billing/systems/payment-gateway"`.
+    /// For example, `find_sections_by_name("payment-gateway")` matches a
+    /// section at `"domains/billing/systems/payment-gateway"`. Returns an
+    /// empty `Vec` if no section has that directory name.
     #[must_use]
     pub fn find_sections_by_name(&self, name: &str) -> Vec<&SectionInfo> {
         self.sections_by_name
@@ -341,15 +344,11 @@ impl SiteState {
         bucket.set_json("structure", etag, &CachedSiteStateRef::from(self));
     }
 
-    /// Build navigation scoped to a section.
+    /// Builds a navigation tree scoped to `scope_path`.
     ///
-    /// If `scope_path` is empty, returns root navigation with an implicit root
-    /// section scope and sections as leaves.
-    /// If `scope_path` points to a section, returns that section's children.
-    ///
-    /// # Arguments
-    ///
-    /// * `scope_path` - Path to scope (without leading slash), empty for root scope.
+    /// Pass `""` for root navigation, or a section root path (e.g.,
+    /// `"domains/billing"`) to get that section's children. Section roots
+    /// appear as leaf nodes — they do not expand their children inline.
     #[must_use]
     pub fn navigation(&self, scope_path: &str) -> Navigation {
         if scope_path.is_empty() {
@@ -397,15 +396,12 @@ impl SiteState {
         }
     }
 
-    /// Get the section ref string for the section a page belongs to.
+    /// Returns the [section ref](crate#sections-and-scoped-navigation) for
+    /// the section containing `page_path`.
     ///
-    /// Returns the ref (e.g., `"domain:default/billing"`) for the nearest section
-    /// ancestor, falling back to the implicit root section (`section:default/root`)
-    /// when no explicit section is found.
-    ///
-    /// # Arguments
-    ///
-    /// * `page_path` - URL path without leading slash.
+    /// Walks up the path hierarchy to find the nearest ancestor that is a
+    /// section root. Falls back to `"section:default/root"` when no explicit
+    /// section is found.
     #[must_use]
     pub fn get_section_ref(&self, page_path: &str) -> String {
         if let Some(section) = self.sections.get(page_path) {
@@ -497,13 +493,11 @@ impl SiteState {
         }
     }
 
-    /// Build a sections map for cross-section link annotation.
+    /// Builds a [`Sections`] map from this state's section index.
     ///
-    /// Always contains at least a root entry (`section:default/root`) so
-    /// embedded consumers always have a `sectionRef` to resolve.
-    ///
-    /// Maps section root paths to `Section` structs containing the section
-    /// kind and name (last path segment).
+    /// The resulting map always contains at least a root entry so that
+    /// embedded consumers always have a section ref to resolve. Maps
+    /// section root URL paths to [`Section`] structs.
     #[must_use]
     pub fn build_sections(&self) -> Arc<Sections> {
         let mut map: HashMap<String, Section> = self


### PR DESCRIPTION
## Summary

- Rewrite crate-level docs with sections on core types, scoped navigation, virtual pages, lazy reload, and crate consumers
- Improve all public type and method docs: remove `# Arguments`/`# Returns` anti-patterns, add doc-test examples, add struct-level docs explaining domain concepts, use intra-doc links throughout
- Add doc comments on re-exported types (`Section`, `SectionPath`, `Sections`, `TocEntry`)

## Test plan

- [x] `cargo test -p rw-site` — 83 unit tests pass
- [x] `cargo test --doc -p rw-site` — 4 doc-tests pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p rw-site` — clean build, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)