### PR TITLE
fix: detect directory renames in live reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Directory renames under `docs/` are now detected by live reload — previously, renaming a directory required manually deleting `.rw/cache` and restarting the server
 - Page metadata no longer extracts `#` comments inside fenced code blocks as H1 titles
 - Page metadata now correctly extracts plain text from H1 titles with inline formatting (bold, italic, code, links)
 - Editing a page title inside a section no longer resets the sidebar to root navigation

--- a/crates/rw-storage-fs/src/lib.rs
+++ b/crates/rw-storage-fs/src/lib.rs
@@ -549,7 +549,10 @@ impl Storage for FsStorage {
                             continue;
                         };
 
+                        // Directory events (e.g., renames) signal structural
+                        // changes that must trigger a rescan.
                         let matches_pattern = patterns.is_empty()
+                            || path.is_dir()
                             || patterns
                                 .iter()
                                 .any(|pattern| pattern.matches_path(rel_path));
@@ -1646,6 +1649,37 @@ mod tests {
         assert!(
             home_event.is_some(),
             "Expected event for root path, got: {events:?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "timing-sensitive, can be flaky in test environments"]
+    fn test_watch_detects_directory_rename() {
+        let temp_dir = create_test_dir();
+        // Canonicalize to resolve macOS /var → /private/var symlink,
+        // since notify fires events with canonical paths.
+        let base = fs::canonicalize(temp_dir.path()).unwrap();
+        let old_dir = base.join("old-name");
+        fs::create_dir(&old_dir).unwrap();
+        fs::write(old_dir.join("index.md"), "# Page").unwrap();
+
+        let storage = FsStorage::new(base.clone());
+        let (rx, _handle) = storage.watch().unwrap();
+
+        // Wait for watcher to be ready
+        std::thread::sleep(Duration::from_millis(200));
+
+        // Rename directory
+        let new_dir = base.join("new-name");
+        fs::rename(&old_dir, &new_dir).unwrap();
+
+        // Wait for debounce + processing (generous for rename detection)
+        std::thread::sleep(Duration::from_millis(500));
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv()).collect();
+        assert!(
+            !events.is_empty(),
+            "Expected at least one event for directory rename"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Directory renames under `docs/` were not detected by `rw serve` live reload — the renamed directory never appeared and the old cache persisted until manual cleanup
- Root cause: the file watcher filters events against `**/*.md` patterns, but `notify` fires rename events with directory paths (no extension), so they were silently dropped
- Fix: allow paths without file extensions through the pattern filter, so directory structural changes trigger a site rescan

Fixes #243

## Test plan

- [x] Added `test_watch_detects_directory_rename` test (timing-sensitive, `#[ignore]`)
- [x] All existing tests pass (`make test`)
- [x] Lint and format clean (`make lint`, `make format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)