### PR TITLE
fix: auto-detect README.md homepage in FsStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Sites using `README.md` as homepage no longer return 500 errors when published to Backstage via S3 — `FsStorage` now auto-detects `README.md` in the parent of `source_dir`, so all code paths (serve, publish, napi) get it automatically
+
 ## [0.1.23] - 2026-04-09
 
 ### Added

--- a/crates/rw-server/src/lib.rs
+++ b/crates/rw-server/src/lib.rs
@@ -63,7 +63,7 @@ mod static_files;
 pub use error::ServerError;
 
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -97,8 +97,6 @@ pub struct ServerConfig {
     pub version: String,
     /// Metadata file name (default: "meta.yaml").
     pub meta_filename: String,
-    /// README.md path to use as homepage fallback.
-    pub readme_path: PathBuf,
     /// Enable embedded preview mode (serves Backstage-like shell at /).
     /// Only available when the `embedded-preview` feature is enabled.
     #[cfg(feature = "embedded-preview")]
@@ -119,7 +117,6 @@ impl Default for ServerConfig {
             verbose: false,
             version: String::new(),
             meta_filename: "meta.yaml".to_owned(),
-            readme_path: PathBuf::from("README.md"),
             #[cfg(feature = "embedded-preview")]
             embedded_preview: false,
         }
@@ -137,10 +134,10 @@ impl Default for ServerConfig {
 /// Returns an error if the server fails to start.
 pub async fn run_server(config: ServerConfig) -> Result<(), ServerError> {
     // Create shared storage backend
-    let storage: Arc<dyn rw_storage::Storage> = Arc::new(
-        FsStorage::with_meta_filename(config.source_dir.clone(), &config.meta_filename)
-            .with_readme(config.readme_path.clone()),
-    );
+    let storage: Arc<dyn rw_storage::Storage> = Arc::new(FsStorage::with_meta_filename(
+        config.source_dir.clone(),
+        &config.meta_filename,
+    ));
 
     // Construct cache
     let cache: Arc<dyn rw_cache::Cache> = match &config.cache_dir {
@@ -213,16 +210,6 @@ pub fn server_config_from_rw_config(
     version: String,
     verbose: bool,
 ) -> ServerConfig {
-    // Auto-detect README.md as homepage fallback (FsStorage checks existence at runtime)
-    let readme_path = config
-        .config_path
-        .as_ref()
-        .and_then(|p| p.parent())
-        .map(Path::to_path_buf)
-        .or_else(|| std::env::current_dir().ok())
-        .unwrap_or_default()
-        .join("README.md");
-
     #[allow(clippy::needless_update)]
     ServerConfig {
         host: config.server.host.clone(),
@@ -240,7 +227,6 @@ pub fn server_config_from_rw_config(
         verbose,
         version,
         meta_filename: config.metadata.name.clone(),
-        readme_path,
         ..Default::default()
     }
 }

--- a/crates/rw-storage-fs/src/lib.rs
+++ b/crates/rw-storage-fs/src/lib.rs
@@ -109,7 +109,7 @@ pub struct FsStorage {
     watch_patterns: Vec<Pattern>,
     /// Metadata file name (e.g., "meta.yaml").
     meta_filename: String,
-    /// Optional path to README.md used as homepage fallback.
+    /// Path to README.md used as homepage fallback (parent of `source_dir`).
     readme_path: Option<PathBuf>,
 }
 
@@ -186,21 +186,17 @@ impl FsStorage {
 
         let scanner = Scanner::new(&source_dir, meta_filename);
 
+        // Auto-detect README.md in parent directory as homepage fallback
+        let readme_path = source_dir.parent().map(|p| p.join("README.md"));
+
         Self {
             source_dir,
             scanner,
             mtime_cache: RwLock::new(HashMap::new()),
             watch_patterns,
             meta_filename: meta_filename.to_owned(),
-            readme_path: None,
+            readme_path,
         }
-    }
-
-    /// Set a README.md path to use as homepage fallback when `docs/index.md` doesn't exist.
-    #[must_use]
-    pub fn with_readme(mut self, readme_path: PathBuf) -> Self {
-        self.readme_path = Some(readme_path);
-        self
     }
 
     /// Validate that a URL path doesn't contain path traversal attempts.
@@ -219,7 +215,7 @@ impl FsStorage {
     ///
     /// For root path (`""`):
     /// 1. `source_dir/index.md`
-    /// 2. `readme_path` (if configured via [`with_readme`](Self::with_readme))
+    /// 2. `readme_path` (README.md in parent directory)
     ///
     /// For other paths:
     /// 1. `{path}/index.md` (directory structure preferred)
@@ -636,7 +632,7 @@ impl Storage for FsStorage {
         // Keep watcher alive in Arc
         let watcher = std::sync::Arc::new(std::sync::Mutex::new(watcher));
 
-        // Optionally set up a second watcher for README.md (outside source_dir)
+        // Set up a second watcher for README.md (outside source_dir)
         let readme_watcher = self
             .readme_path
             .as_deref()
@@ -1580,7 +1576,9 @@ mod tests {
     }
 
     /// Create a test directory with `docs/` subdirectory and README.md,
-    /// returning `(temp_dir, FsStorage with readme)`.
+    /// returning `(temp_dir, project_root, FsStorage)`.
+    ///
+    /// FsStorage auto-detects README.md in `source_dir`'s parent directory.
     fn create_readme_test_dir(readme_content: &str) -> (tempfile::TempDir, PathBuf, FsStorage) {
         let temp_dir = create_test_dir();
         let project_root = temp_dir.path().to_path_buf();
@@ -1588,8 +1586,7 @@ mod tests {
         fs::create_dir(&source_dir).unwrap();
         fs::write(project_root.join("README.md"), readme_content).unwrap();
 
-        let readme_path = project_root.join("README.md");
-        let storage = FsStorage::new(source_dir).with_readme(readme_path);
+        let storage = FsStorage::new(source_dir);
         (temp_dir, project_root, storage)
     }
 


### PR DESCRIPTION
## Summary

- Sites using `README.md` as homepage (no `docs/index.md`) returned 500 errors when published to Backstage via S3 — `backstage publish` and napi `createSite(projectDir)` created `FsStorage` without the README fallback
- Moved README.md auto-detection into `FsStorage` constructor so all code paths (serve, publish, napi) get it automatically, removing `with_readme()` and the manual detection from `ServerConfig`

## Test plan

- [x] Create a project with `README.md` but no `docs/index.md`
- [x] Run `rw backstage publish` and verify `pages/_index.json` is uploaded to S3
- [x] Confirm the docs page loads in Backstage without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)