### PR TITLE
fix: scale Mermaid diagram SVGs with decimal dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Sites using `README.md` as homepage no longer return 500 errors when published to Backstage via S3 — `FsStorage` now auto-detects `README.md` in the parent of `source_dir`, so all code paths (serve, publish, napi) get it automatically
+- Diagrams with decimal SVG dimensions from Kroki (e.g., Mermaid sequence diagrams) now scale correctly instead of rendering at full size and getting squished by the container
 
 ## [0.1.23] - 2026-04-09
 

--- a/crates/rw-diagrams/src/html_embed.rs
+++ b/crates/rw-diagrams/src/html_embed.rs
@@ -18,21 +18,21 @@ static GOOGLE_FONTS_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"@import\s+url\([^)]*fonts\.googleapis\.com[^)]*\)\s*;?").unwrap()
 });
 
-/// Regex to match SVG width attribute with pixel value.
+/// Regex to match SVG width attribute with pixel value (integer or decimal).
 static SVG_WIDTH_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(<svg[^>]*\s)width="(\d+)(?:px)?""#).unwrap());
+    LazyLock::new(|| Regex::new(r#"(<svg[^>]*\s)width="(\d+(?:\.\d+)?)(?:px)?""#).unwrap());
 
-/// Regex to match SVG height attribute with pixel value.
+/// Regex to match SVG height attribute with pixel value (integer or decimal).
 static SVG_HEIGHT_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(<svg[^>]*\s)height="(\d+)(?:px)?""#).unwrap());
+    LazyLock::new(|| Regex::new(r#"(<svg[^>]*\s)height="(\d+(?:\.\d+)?)(?:px)?""#).unwrap());
 
 /// Regex to match width in style attribute (e.g., `width:136px`).
 static STYLE_WIDTH_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(width:\s*)(\d+)(px)").unwrap());
+    LazyLock::new(|| Regex::new(r"(width:\s*)(\d+(?:\.\d+)?)(px)").unwrap());
 
 /// Regex to match height in style attribute (e.g., `height:210px`).
 static STYLE_HEIGHT_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(height:\s*)(\d+)(px)").unwrap());
+    LazyLock::new(|| Regex::new(r"(height:\s*)(\d+(?:\.\d+)?)(px)").unwrap());
 
 /// Scale SVG width and height based on DPI.
 ///
@@ -307,6 +307,17 @@ mod tests {
         assert_eq!(
             result,
             r#"<svg width="68" height="105" style="width:68px;height:105px;background:#FFFFFF;"></svg>"#
+        );
+    }
+
+    #[test]
+    fn test_scale_svg_dimensions_with_decimal_values() {
+        // Mermaid SVGs from Kroki use decimal width/height (e.g., width="1610.5")
+        let svg = r#"<svg width="1610.5" height="633" viewBox="-50 -10 1610.5 633"></svg>"#;
+        let result = scale_svg_dimensions(svg, 192);
+        assert_eq!(
+            result,
+            r#"<svg width="805" height="317" viewBox="-50 -10 1610.5 633"></svg>"#
         );
     }
 


### PR DESCRIPTION
## Summary

- DPI scaling regexes in `scale_svg_dimensions()` only matched integer width/height (`\d+`), so SVGs from Kroki with decimal values (e.g., `width="1610.5"`) skipped scaling entirely
- Unscaled diagrams rendered at full Kroki size then got squished by `max-width: 100%`, making them tiny and unreadable
- Updated all four regex patterns to match decimal values (`\d+(?:\.\d+)?`)

## Test plan

- [x] Existing tests pass
- [x] Added test for decimal dimension scaling
- [ ] Republish a bundle with Mermaid diagrams and verify they render at readable size

🤖 Generated with [Claude Code](https://claude.com/claude-code)