### PR TITLE
fix: prevent browser from serving stale content across server restarts

### DIFF
--- a/crates/rw-server/src/app.rs
+++ b/crates/rw-server/src/app.rs
@@ -66,7 +66,8 @@ pub(crate) fn create_router(state: Arc<AppState>) -> Router {
             ServiceBuilder::new()
                 .layer(security::csp_layer())
                 .layer(security::content_type_options_layer())
-                .layer(security::frame_options_layer()),
+                .layer(security::frame_options_layer())
+                .layer(security::cache_control_layer()),
         )
         .with_state(state)
 }

--- a/crates/rw-server/src/handlers/pages.rs
+++ b/crates/rw-server/src/handlers/pages.rs
@@ -205,7 +205,7 @@ fn get_page_impl(
                     .format("%a, %d %b %Y %H:%M:%S GMT")
                     .to_string(),
             ),
-            (header::CACHE_CONTROL, "private, max-age=60".to_owned()),
+            (header::CACHE_CONTROL, "no-cache".to_owned()),
         ],
         Json(response),
     )

--- a/crates/rw-server/src/middleware/security.rs
+++ b/crates/rw-server/src/middleware/security.rs
@@ -42,6 +42,17 @@ pub(crate) fn frame_options_layer() -> SetResponseHeaderLayer<HeaderValue> {
     )
 }
 
+/// Create layer that adds Cache-Control: no-cache header.
+///
+/// Forces browsers to revalidate every request with the server, preventing
+/// stale content when switching between projects or restarting the server.
+pub(crate) fn cache_control_layer() -> SetResponseHeaderLayer<HeaderValue> {
+    SetResponseHeaderLayer::if_not_present(
+        axum::http::header::CACHE_CONTROL,
+        HeaderValue::from_static("no-cache"),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Add `Cache-Control: no-cache` middleware layer to all HTTP responses, so the browser always revalidates with the server
- Change page API responses from `Cache-Control: private, max-age=60` to `no-cache`
- Pages with ETags still get fast `304 Not Modified` when content hasn't changed

Previously, switching between projects on the same port (or restarting the same project after edits) could show old content until a force-reload.

## Test plan

- [ ] Start `rw serve` in project A, open browser, verify content loads
- [ ] Stop server, start `rw serve` in project B on the same port
- [ ] Refresh browser (no force-reload) — should show project B content immediately
- [ ] Edit a markdown file while server is running — live reload still works
- [ ] Verify `Cache-Control: no-cache` header present on page API, static assets, navigation, and config responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)