### PR TITLE
fix: resolve clippy warnings across crates

### DIFF
--- a/crates/rw-diagrams/src/html_embed.rs
+++ b/crates/rw-diagrams/src/html_embed.rs
@@ -150,7 +150,7 @@ pub fn annotate_svg_links(svg: &str, sections: &Sections) -> String {
         )
         .unwrap();
         if !sp.path.is_empty() {
-            write!(result, r#" data-section-path="{}""#, escape_html(&sp.path)).unwrap();
+            write!(result, r#" data-section-path="{}""#, escape_html(sp.path)).unwrap();
         }
         result.push('>');
 

--- a/crates/rw-renderer/src/directive/mod.rs
+++ b/crates/rw-renderer/src/directive/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Directives extend markdown with custom inline, block, and wrapping
 //! elements using a colon-based syntax that does not conflict with standard
-//! CommonMark:
+//! `CommonMark`:
 //!
 //! | Type | Syntax | Trait |
 //! |------|--------|-------|

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -146,6 +146,7 @@ enum WikilinkResolution {
 /// assert_eq!(result.title.as_deref(), Some("Guide"));
 /// assert!(result.html.contains(r#"href="/docs/guide/setup""#));
 /// ```
+#[allow(clippy::struct_excessive_bools)]
 pub struct MarkdownRenderer<B: RenderBackend> {
     output: String,
     list_stack: Vec<bool>,
@@ -492,10 +493,10 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
     /// relative links like `docs/guide.md` include the source directory name.
     /// This strips that prefix so the link resolves correctly in URL space.
     fn strip_origin<'a>(&self, url: &'a str) -> Cow<'a, str> {
-        if let Some(prefix) = &self.origin_prefix {
-            if let Some(stripped) = url.strip_prefix(prefix.as_str()) {
-                return Cow::Owned(stripped.to_owned());
-            }
+        if let Some(prefix) = &self.origin_prefix
+            && let Some(stripped) = url.strip_prefix(prefix.as_str())
+        {
+            return Cow::Owned(stripped.to_owned());
         }
         Cow::Borrowed(url)
     }
@@ -1802,7 +1803,7 @@ Install with apt.
         assert!(
             result
                 .html
-                .contains(r##"href="/domains/billing/overview#pricing""##),
+                .contains(r#"href="/domains/billing/overview#pricing""#),
             "html: {}",
             result.html
         );

--- a/crates/rw-site/src/lib.rs
+++ b/crates/rw-site/src/lib.rs
@@ -11,7 +11,7 @@
 //!   page lookup methods. Designed for shared ownership (`Arc<Site>`) and
 //!   concurrent access.
 //! - [`PageRendererConfig`] — controls title extraction, diagram rendering
-//!   (Kroki URL, DPI), and PlantUML include directories.
+//!   (Kroki URL, DPI), and `PlantUML` include directories.
 //! - [`PageRenderResult`] — the output of rendering a page: HTML, title,
 //!   table of contents, breadcrumbs, and metadata.
 //! - [`Navigation`] — a scoped navigation tree with [`NavItem`] children,

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -62,10 +62,10 @@ pub struct PageRendererConfig {
     pub extract_title: bool,
     /// Base URL of a [Kroki](https://kroki.io) instance for rendering diagrams.
     ///
-    /// When `None`, fenced code blocks for diagram languages (PlantUML,
+    /// When `None`, fenced code blocks for diagram languages (`PlantUML`,
     /// Mermaid, etc.) are rendered as syntax-highlighted code instead of images.
     pub kroki_url: Option<String>,
-    /// Directories to search when resolving PlantUML `!include` directives.
+    /// Directories to search when resolving `PlantUML` `!include` directives.
     /// Defaults to empty (no include resolution).
     pub include_dirs: Vec<PathBuf>,
     /// DPI for rendered diagram images. Defaults to `192` (retina).

--- a/crates/rw-site/src/site.rs
+++ b/crates/rw-site/src/site.rs
@@ -486,10 +486,10 @@ impl Site {
 
         // Apply custom page ordering from `pages` metadata
         for doc in &documents {
-            if let Some(pages) = &doc.pages {
-                if let Some(&idx) = url_to_idx.get(&doc.path) {
-                    builder.reorder_children(idx, pages);
-                }
+            if let Some(pages) = &doc.pages
+                && let Some(&idx) = url_to_idx.get(&doc.path)
+            {
+                builder.reorder_children(idx, pages);
             }
         }
 

--- a/crates/rw-storage-fs/src/lib.rs
+++ b/crates/rw-storage-fs/src/lib.rs
@@ -1578,7 +1578,7 @@ mod tests {
     /// Create a test directory with `docs/` subdirectory and README.md,
     /// returning `(temp_dir, project_root, FsStorage)`.
     ///
-    /// FsStorage auto-detects README.md in `source_dir`'s parent directory.
+    /// `FsStorage` auto-detects README.md in `source_dir`'s parent directory.
     fn create_readme_test_dir(readme_content: &str) -> (tempfile::TempDir, PathBuf, FsStorage) {
         let temp_dir = create_test_dir();
         let project_root = temp_dir.path().to_path_buf();


### PR DESCRIPTION
## Summary
- Fix `doc_markdown`, `collapsible_if`, `needless_borrow`, `needless_raw_string_hashes` clippy warnings across 7 files
- Add `#[allow(clippy::struct_excessive_bools)]` on `MarkdownRenderer` where refactoring would be disproportionate

## Test plan
- [x] `make lint` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)