### PR TITLE
fix: clear page cache on reload to prevent stale S3 content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pages served from S3 storage (Backstage) no longer show stale content after a new bundle is published — the page cache is now cleared on reload
+
 ## [0.1.24] - 2026-04-10
 
 ### Fixed

--- a/crates/rw-cache-s3/src/lib.rs
+++ b/crates/rw-cache-s3/src/lib.rs
@@ -50,16 +50,21 @@ impl Cache for S3Cache {
     }
 }
 
-/// Build the full S3 key for a cache entry.
+/// Build the S3 key prefix for a cache bucket.
 ///
-/// Layout: `{prefix}/cache/{bucket_name}/{key}`
+/// Layout: `{prefix}/cache/{bucket_name}/`
 /// Empty prefix omits the leading segment.
-fn build_cache_key(prefix: &str, bucket_name: &str, key: &str) -> String {
+fn build_cache_prefix(prefix: &str, bucket_name: &str) -> String {
     if prefix.is_empty() {
-        format!("cache/{bucket_name}/{key}")
+        format!("cache/{bucket_name}/")
     } else {
-        format!("{prefix}/cache/{bucket_name}/{key}")
+        format!("{prefix}/cache/{bucket_name}/")
     }
+}
+
+/// Build the full S3 key for a cache entry.
+fn build_cache_key(prefix: &str, bucket_name: &str, key: &str) -> String {
+    format!("{}{key}", build_cache_prefix(prefix, bucket_name))
 }
 
 /// S3-backed [`CacheBucket`].
@@ -113,11 +118,7 @@ impl CacheBucket for S3CacheBucket {
     }
 
     fn clear(&self) {
-        let prefix = if self.prefix.is_empty() {
-            format!("cache/{}/", self.bucket_name)
-        } else {
-            format!("{}/cache/{}/", self.prefix, self.bucket_name)
-        };
+        let prefix = build_cache_prefix(&self.prefix, &self.bucket_name);
         let _ = self.runtime.block_on(async {
             let mut continuation_token = None;
             loop {

--- a/crates/rw-cache-s3/src/lib.rs
+++ b/crates/rw-cache-s3/src/lib.rs
@@ -6,6 +6,7 @@
 
 use aws_sdk_s3::Client;
 use aws_sdk_s3::operation::get_object::GetObjectError;
+use aws_sdk_s3::types::{Delete, ObjectIdentifier};
 use rw_cache::{Cache, CacheBucket};
 use tokio::runtime::Handle;
 
@@ -109,6 +110,72 @@ impl CacheBucket for S3CacheBucket {
                 .ok()?;
             Some(bytes.into_bytes().to_vec())
         })
+    }
+
+    fn clear(&self) {
+        let prefix = if self.prefix.is_empty() {
+            format!("cache/{}/", self.bucket_name)
+        } else {
+            format!("{}/cache/{}/", self.prefix, self.bucket_name)
+        };
+        let _ = self.runtime.block_on(async {
+            let mut continuation_token = None;
+            loop {
+                let mut req = self
+                    .client
+                    .list_objects_v2()
+                    .bucket(&self.s3_bucket)
+                    .prefix(&prefix);
+                if let Some(token) = continuation_token.take() {
+                    req = req.continuation_token(token);
+                }
+                let resp = req.send().await.map_err(|e| {
+                    tracing::debug!(prefix = %prefix, error = %e, "S3 cache clear list failed");
+                })?;
+
+                let keys: Vec<String> = resp
+                    .contents()
+                    .iter()
+                    .filter_map(|obj| obj.key().map(String::from))
+                    .collect();
+
+                if !keys.is_empty() {
+                    let objects: Vec<ObjectIdentifier> = keys
+                        .into_iter()
+                        .filter_map(|k| ObjectIdentifier::builder().key(k).build().ok())
+                        .collect();
+                    let delete = Delete::builder()
+                        .set_objects(Some(objects))
+                        .quiet(true)
+                        .build()
+                        .map_err(|e| {
+                            tracing::debug!(
+                                prefix = %prefix, error = %e,
+                                "S3 cache clear delete build failed"
+                            );
+                        })?;
+                    self.client
+                        .delete_objects()
+                        .bucket(&self.s3_bucket)
+                        .delete(delete)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            tracing::debug!(
+                                prefix = %prefix, error = %e,
+                                "S3 cache clear delete failed"
+                            );
+                        })?;
+                }
+
+                if resp.is_truncated() == Some(true) {
+                    continuation_token = resp.next_continuation_token().map(String::from);
+                } else {
+                    break;
+                }
+            }
+            Ok::<(), ()>(())
+        });
     }
 
     fn set(&self, key: &str, etag: &str, value: &[u8]) {

--- a/crates/rw-cache/src/file.rs
+++ b/crates/rw-cache/src/file.rs
@@ -130,6 +130,12 @@ impl CacheBucket for FileCacheBucket {
 
         let _ = fs::write(&path, &buf);
     }
+
+    fn clear(&self) {
+        if self.dir.exists() {
+            let _ = fs::remove_dir_all(&self.dir);
+        }
+    }
 }
 
 /// Validate the cache version, wiping the directory on mismatch.
@@ -364,6 +370,54 @@ mod tests {
         fs::write(&path, &corrupt).unwrap();
 
         assert_eq!(bucket.get("key", "etag1"), None);
+    }
+
+    #[test]
+    fn test_file_bucket_clear_removes_all_entries() {
+        let tmp = TempDir::new().unwrap();
+        let cache = FileCache::new(tmp.path().join("cache"), "v1");
+        let bucket = cache.bucket("pages");
+
+        bucket.set("page-a", "etag1", b"data-a");
+        bucket.set("page-b", "etag2", b"data-b");
+
+        assert!(bucket.get("page-a", "etag1").is_some());
+        assert!(bucket.get("page-b", "etag2").is_some());
+
+        bucket.clear();
+
+        assert_eq!(bucket.get("page-a", "etag1"), None);
+        assert_eq!(bucket.get("page-b", "etag2"), None);
+    }
+
+    #[test]
+    fn test_file_bucket_clear_allows_new_entries() {
+        let tmp = TempDir::new().unwrap();
+        let cache = FileCache::new(tmp.path().join("cache"), "v1");
+        let bucket = cache.bucket("pages");
+
+        bucket.set("key", "etag1", b"old");
+        bucket.clear();
+
+        bucket.set("key", "etag2", b"new");
+        assert_eq!(bucket.get("key", "etag2"), Some(b"new".to_vec()));
+    }
+
+    #[test]
+    fn test_file_bucket_clear_does_not_affect_other_buckets() {
+        let tmp = TempDir::new().unwrap();
+        let cache = FileCache::new(tmp.path().join("cache"), "v1");
+
+        let pages = cache.bucket("pages");
+        let diagrams = cache.bucket("diagrams");
+
+        pages.set("key", "etag1", b"page-data");
+        diagrams.set("key", "etag1", b"diagram-data");
+
+        pages.clear();
+
+        assert_eq!(pages.get("key", "etag1"), None);
+        assert_eq!(diagrams.get("key", "etag1"), Some(b"diagram-data".to_vec()));
     }
 
     #[test]

--- a/crates/rw-cache/src/file.rs
+++ b/crates/rw-cache/src/file.rs
@@ -132,9 +132,7 @@ impl CacheBucket for FileCacheBucket {
     }
 
     fn clear(&self) {
-        if self.dir.exists() {
-            let _ = fs::remove_dir_all(&self.dir);
-        }
+        let _ = fs::remove_dir_all(&self.dir);
     }
 }
 

--- a/crates/rw-cache/src/lib.rs
+++ b/crates/rw-cache/src/lib.rs
@@ -60,6 +60,11 @@ pub trait CacheBucket: Send + Sync {
     /// * `etag` - Etag to associate with this entry
     /// * `value` - Raw bytes to cache
     fn set(&self, key: &str, etag: &str, value: &[u8]);
+
+    /// Remove all entries from this bucket.
+    ///
+    /// Best-effort: errors are silently ignored (same as `set`).
+    fn clear(&self);
 }
 
 /// Factory for named cache [`CacheBucket`]s.
@@ -91,6 +96,7 @@ impl CacheBucket for NullCacheBucket {
     }
 
     fn set(&self, _key: &str, _etag: &str, _value: &[u8]) {}
+    fn clear(&self) {}
 }
 
 /// No-op [`Cache`] that always returns [`NullCacheBucket`]s.

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -258,6 +258,14 @@ impl PageRenderer {
         }
     }
 
+    /// Clear all cached rendered pages.
+    ///
+    /// Called on site reload to prevent serving stale content when the
+    /// underlying storage has changed (e.g., new S3 bundle published).
+    pub(crate) fn clear_pages(&self) {
+        self.page_bucket.clear();
+    }
+
     /// Render a page with full pipeline: mtime, metadata, cache check, render, cache write.
     ///
     /// # Errors

--- a/crates/rw-site/src/site.rs
+++ b/crates/rw-site/src/site.rs
@@ -365,6 +365,7 @@ impl Site {
         if !force && !self.storage.has_changed()? {
             return Ok(false);
         }
+        self.renderer.clear_pages();
         self.invalidate();
         self.reload_if_needed()?;
         Ok(true)
@@ -1329,5 +1330,39 @@ mod tests {
         assert_eq!(nav.items[0].path, "getting-started");
         assert_eq!(nav.items[1].path, "configuration");
         assert_eq!(nav.items[2].path, "advanced"); // unlisted, alphabetical
+    }
+
+    #[test]
+    fn test_reload_clears_page_cache() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+
+        // Use mtime 0.0 to simulate S3 storage (always returns zero)
+        let storage = MockStorage::new()
+            .with_file("", "Home", "# Home\n\nWelcome")
+            .with_mtime("", 0.0);
+        let storage = Arc::new(storage);
+
+        let cache: Arc<dyn rw_cache::Cache> =
+            Arc::new(rw_cache::FileCache::new(cache_dir, "1.0.0"));
+        let config = PageRendererConfig::default();
+        let site = Site::new(Arc::clone(&storage) as Arc<dyn Storage>, cache, config);
+
+        // First render: cache miss
+        let result1 = site.render("").unwrap();
+        assert!(!result1.from_cache);
+
+        // Second render: cache hit (mtime is still 0.0, etag matches)
+        let result2 = site.render("").unwrap();
+        assert!(result2.from_cache);
+
+        // Simulate content change and reload
+        storage.set_content("", "# Home\n\nUpdated");
+        site.reload(true).unwrap();
+
+        // Render after reload: cache miss (clear wiped the page cache)
+        let result3 = site.render("").unwrap();
+        assert!(!result3.from_cache);
+        assert!(result3.html.contains("Updated"));
     }
 }

--- a/crates/rw-storage/src/mock.rs
+++ b/crates/rw-storage/src/mock.rs
@@ -277,6 +277,18 @@ impl MockStorage {
         *self.scan_error.write().unwrap() = kind;
     }
 
+    /// Update content for a URL path at runtime (for testing reload scenarios).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal lock is poisoned.
+    pub fn set_content(&self, path: impl Into<String>, content: impl Into<String>) {
+        self.contents
+            .write()
+            .unwrap()
+            .insert(path.into(), content.into());
+    }
+
     /// Override `has_changed()` to return a fixed value or error.
     ///
     /// - `Some(Ok(true))` — report changed


### PR DESCRIPTION
## Summary

- Adds `clear()` to the `CacheBucket` trait so page caches can be wiped on reload
- Calls `clear_pages()` during `Site::reload()` before re-scanning storage, preventing stale S3 content from being served after a new bundle is published
- Implements `clear()` for both `FileCacheBucket` (remove dir) and `S3CacheBucket` (paginated list + batch delete)

## Test plan

- [x] Unit test: `test_reload_clears_page_cache` — verifies cached page is evicted after reload
- [x] Unit tests for `FileCacheBucket::clear()` — removes entries, allows new writes, doesn't affect other buckets
- [x] All existing tests pass (`cargo test -p rw-cache -p rw-site --lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)