### PR TITLE
feat: git-aware modification times via rw-vcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Page modification times (`lastModified` in API responses) now reflect the git commit time instead of the filesystem modification time — timestamps remain stable across `git checkout`, `git pull`, and branch switching
+- S3-published documentation bundles now include page modification times in the manifest — previously `lastModified` was always epoch zero for Backstage-served pages
+
 ## [0.1.24] - 2026-04-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,10 @@ crates/
 │       ├── storage.rs        # S3Storage (Storage trait implementation)
 │       └── publisher.rs      # BundlePublisher (feature = "publish")
 │
+├── rw-vcs/                # Git-aware file metadata (mtime, future: authors)
+│   └── src/
+│       └── lib.rs            # Vcs struct, gix integration, fs fallback
+│
 ├── rw-assets/             # Frontend asset serving (embedded + filesystem)
 │   └── src/
 │       └── lib.rs            # get(), iter(), mime_for() API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -715,6 +725,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -847,6 +863,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "cmake"
@@ -1048,6 +1073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1158,20 @@ name = "dary_heap"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "data-encoding"
@@ -1282,6 +1330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1378,17 @@ checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1460,6 +1538,871 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.81.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7add20f40d060db8c9b1314d499bac6ed7480f33eb113ce3e1cf5d6ff85d989"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1096b6608fbe5d27fb4984e20f992b4e76fb8c613f6acb87d07c5831b53a6959"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849c65a609f50d02f8a2774fe371650b3384a743c79c2a070ce0da49b7fb7da"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39acf819aa9fee65e4838a2eec5cb2506e47ebb89e02a5ab9918196e491571ea"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "imara-diff 0.1.8",
+ "imara-diff 0.2.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e86d01da904d4a9265def43bd42a18c5e6dc7000a73af512946ba14579c9fbd"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "imara-diff 0.1.8",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be19313dcdb7dff75a3ce2f99be00878458295bcc3b6c7f0005591597573345c"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c31d4373bda7fab9eb01822927b55185a378d6e1bf737e0a54c743ad806658"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68533db71259c8776dd4e770d2b7b98696213ecdc1f5c9e3507119e274e0c578"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf82ae037de9c62850ce67beaa92ec8e3e17785ea307cdde7618edc215603b4f"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+
+[[package]]
+name = "gix-transport"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +2482,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +2514,16 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1907,6 +2875,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
+]
+
+[[package]]
 name = "include-flate"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2963,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2998,47 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -2040,6 +3078,15 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -2101,6 +3148,7 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2161,6 +3209,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,6 +3244,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -2223,6 +3291,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "notify"
@@ -2387,7 +3461,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2485,6 +3559,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,6 +3648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -2703,6 +3801,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3143,6 +4250,7 @@ dependencies = [
  "rayon",
  "rw-meta",
  "rw-storage",
+ "rw-vcs",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -3164,6 +4272,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "rw-vcs"
+version = "0.1.24"
+dependencies = [
+ "gix",
+ "tempfile",
 ]
 
 [[package]]
@@ -3349,6 +4465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,6 +4493,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"
@@ -3639,6 +4771,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,7 +4892,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -3763,7 +4910,7 @@ version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -3918,10 +5065,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -4438,6 +5600,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
@@ -4650,6 +5821,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rw-site = { path = "crates/rw-site" }
 rw-storage = { path = "crates/rw-storage" }
 rw-storage-fs = { path = "crates/rw-storage-fs" }
 rw-storage-s3 = { path = "crates/rw-storage-s3" }
+rw-vcs = { path = "crates/rw-vcs" }
 # External dependencies
 base64 = "0.22"
 glob = "0.3"

--- a/crates/rw-storage-fs/Cargo.toml
+++ b/crates/rw-storage-fs/Cargo.toml
@@ -17,6 +17,7 @@ notify = { workspace = true }
 rw-meta = { workspace = true }
 serde_yaml = { workspace = true }
 rayon = { workspace = true }
+rw-vcs = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rw-storage-fs/src/lib.rs
+++ b/crates/rw-storage-fs/src/lib.rs
@@ -34,12 +34,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use std::sync::mpsc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime};
 
 use glob::Pattern;
 use notify::{RecursiveMode, Watcher};
 use rayon::prelude::*;
 use rw_meta::Meta;
+use rw_vcs::Vcs;
 
 use debouncer::{DebouncedEvent, EventDebouncer, RawEventKind};
 use inheritance::{build_ancestor_chain, merge_metadata};
@@ -111,6 +112,8 @@ pub struct FsStorage {
     meta_filename: String,
     /// Path to README.md used as homepage fallback (parent of `source_dir`).
     readme_path: Option<PathBuf>,
+    /// Git-aware file metadata resolver.
+    vcs: Vcs,
 }
 
 /// Default metadata filename.
@@ -149,6 +152,8 @@ impl FsStorage {
         // Auto-detect README.md in parent directory as homepage fallback
         let readme_path = source_dir.parent().map(|p| p.join("README.md"));
 
+        let vcs = Vcs::new(&source_dir);
+
         Self {
             source_dir,
             scanner,
@@ -156,6 +161,7 @@ impl FsStorage {
             watch_patterns,
             meta_filename: meta_filename.to_owned(),
             readme_path,
+            vcs,
         }
     }
 
@@ -519,19 +525,21 @@ impl Storage for FsStorage {
 
     fn mtime(&self, path: &str) -> Result<f64, StorageError> {
         Self::validate_path(path)?;
-        // Try content file first, fall back to metadata file (for virtual pages)
-        let full_path = self
-            .resolve_content(path)
-            .or_else(|| self.resolve_meta(path))
-            .ok_or_else(|| StorageError::not_found(path).with_backend(BACKEND))?;
-        let metadata = fs::metadata(&full_path)
-            .map_err(|e| StorageError::io(e, Some(PathBuf::from(path))).with_backend(BACKEND))?;
-        let modified = metadata
-            .modified()
-            .map_err(|e| StorageError::io(e, Some(PathBuf::from(path))).with_backend(BACKEND))?;
-        Ok(modified
-            .duration_since(UNIX_EPOCH)
-            .map_or(0.0, |d| d.as_secs_f64()))
+
+        // Collect all file paths that contribute to this page
+        let content_path = self.resolve_content(path);
+        let meta_path = self.resolve_meta(path);
+
+        if content_path.is_none() && meta_path.is_none() {
+            return Err(StorageError::not_found(path).with_backend(BACKEND));
+        }
+
+        let paths: Vec<&Path> = [&content_path, &meta_path]
+            .into_iter()
+            .filter_map(|p| p.as_deref())
+            .collect();
+
+        Ok(self.vcs.mtime(&paths))
     }
 
     fn watch(&self) -> Result<(StorageEventReceiver, WatchHandle), StorageError> {

--- a/crates/rw-storage-s3/src/format.rs
+++ b/crates/rw-storage-s3/src/format.rs
@@ -4,6 +4,8 @@
 //! A bundle consists of a manifest (document index) and per-page bundles
 //! (markdown content + resolved metadata).
 
+use std::collections::HashMap;
+
 use rw_storage::{Document, Metadata};
 use serde::{Deserialize, Serialize};
 
@@ -17,12 +19,16 @@ pub(crate) const MANIFEST_KEY: &str = "manifest.json";
 ///
 /// Stored at `{prefix}/manifest.json` in S3.
 /// Contains everything needed for `Storage::scan()`.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Manifest {
     /// Format version for forward compatibility.
     pub version: u32,
     /// All documents in the site.
     pub documents: Vec<Document>,
+    /// Per-page modification times (seconds since Unix epoch).
+    /// Populated at publish time from git commit timestamps.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub mtimes: HashMap<String, f64>,
 }
 
 /// Per-page bundle containing content and resolved metadata.
@@ -58,6 +64,7 @@ impl Manifest {
         Self {
             version: FORMAT_VERSION,
             documents,
+            mtimes: HashMap::new(),
         }
     }
 }
@@ -165,6 +172,33 @@ mod tests {
             page_bundle_key("domain/billing"),
             "pages/domain/billing.json"
         );
+    }
+
+    #[test]
+    fn test_manifest_without_mtimes_deserializes() {
+        let json =
+            r#"{"version":1,"documents":[{"path":"guide","title":"Guide","has_content":true}]}"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.mtimes.is_empty());
+    }
+
+    #[test]
+    fn test_manifest_with_mtimes_roundtrips() {
+        let mut manifest = Manifest::new(vec![Document {
+            path: "guide".to_owned(),
+            title: "Guide".to_owned(),
+            has_content: true,
+            page_kind: None,
+            description: None,
+            origin: None,
+            pages: None,
+        }]);
+        manifest.mtimes.insert("guide".to_owned(), 1_713_000_000.0);
+
+        let json = serde_json::to_string(&manifest).unwrap();
+        let deserialized: Manifest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.mtimes.get("guide"), Some(&1_713_000_000.0));
     }
 
     #[test]

--- a/crates/rw-storage-s3/src/publisher.rs
+++ b/crates/rw-storage-s3/src/publisher.rs
@@ -3,6 +3,7 @@
 //! Scans local documentation, resolves `PlantUML` includes, builds bundles,
 //! and uploads them to S3. Only available with the `publish` feature.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -102,9 +103,18 @@ impl BundlePublisher {
                 .map_err(BundlePublishError::S3)?;
         }
 
+        // Resolve modification times for each document.
+        let mut mtimes = HashMap::new();
+        for doc in &documents {
+            if let Ok(mtime) = storage.mtime(&doc.path) {
+                mtimes.insert(doc.path.clone(), mtime);
+            }
+        }
+
         // Upload manifest last so readers don't see a manifest referencing
         // pages that haven't been uploaded yet.
-        let manifest = Manifest::new(documents);
+        let mut manifest = Manifest::new(documents);
+        manifest.mtimes = mtimes;
         let manifest_json = serde_json::to_vec(&manifest)?;
         s3::upload(
             &client,

--- a/crates/rw-storage-s3/src/storage.rs
+++ b/crates/rw-storage-s3/src/storage.rs
@@ -3,6 +3,7 @@
 //! Reads documentation bundles from S3 using the format defined in [`crate::format`].
 //! Tracks the manifest `ETag` to support change detection via [`Storage::has_changed`].
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use aws_sdk_s3::Client;
@@ -22,11 +23,14 @@ const BACKEND: &str = "S3";
 ///
 /// Read methods fetch fresh data from S3 on each call. The manifest
 /// `ETag` is tracked across calls to support [`Storage::has_changed`].
+/// Page modification times from the manifest are cached after each
+/// [`Storage::scan`] call to avoid re-fetching the manifest per page.
 pub struct S3Storage {
     client: Client,
     runtime: Arc<Runtime>,
     config: S3Config,
     last_etag: Mutex<Option<String>>,
+    mtimes: Mutex<HashMap<String, f64>>,
 }
 
 impl S3Storage {
@@ -41,6 +45,7 @@ impl S3Storage {
             runtime,
             config,
             last_etag: Mutex::new(None),
+            mtimes: Mutex::new(HashMap::new()),
         })
     }
 
@@ -160,6 +165,7 @@ impl Storage for S3Storage {
     fn scan(&self) -> Result<Vec<Document>, StorageError> {
         let (manifest, etag) = self.fetch_manifest()?;
         *self.last_etag.lock().unwrap() = etag;
+        *self.mtimes.lock().unwrap() = manifest.mtimes;
         Ok(manifest.documents)
     }
 
@@ -177,8 +183,14 @@ impl Storage for S3Storage {
             .any(|d| d.has_content && d.path == path)
     }
 
-    fn mtime(&self, _path: &str) -> Result<f64, StorageError> {
-        Ok(0.0)
+    fn mtime(&self, path: &str) -> Result<f64, StorageError> {
+        Ok(self
+            .mtimes
+            .lock()
+            .unwrap()
+            .get(path)
+            .copied()
+            .unwrap_or(0.0))
     }
 
     fn meta(&self, path: &str) -> Result<Option<Metadata>, StorageError> {

--- a/crates/rw-vcs/Cargo.toml
+++ b/crates/rw-vcs/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rw-vcs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Git-aware file metadata for RW documentation engine"
+
+[lints]
+workspace = true
+
+[dependencies]
+gix = { version = "0.81", default-features = false, features = ["sha1", "revision", "status", "parallel"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/rw-vcs/src/lib.rs
+++ b/crates/rw-vcs/src/lib.rs
@@ -1,0 +1,470 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use gix::bstr::ByteSlice;
+use gix::revision::walk::Sorting;
+use gix::{Repository, ThreadSafeRepository};
+
+/// Git-aware file metadata resolver.
+///
+/// Discovers a git repository from a directory path and provides
+/// metadata about tracked files. Falls back to filesystem metadata
+/// when git is unavailable.
+///
+/// Uses [`ThreadSafeRepository`] internally so that `Vcs` is `Send + Sync`
+/// and can be stored in types shared across threads (e.g., `FsStorage`).
+pub struct Vcs {
+    repo: Option<ThreadSafeRepository>,
+}
+
+impl Vcs {
+    /// Create a new `Vcs` by discovering the git repo from `path`.
+    ///
+    /// Always succeeds — stores `None` internally if `path` is not
+    /// inside a git repository.
+    #[must_use]
+    pub fn new(path: &Path) -> Self {
+        let repo = gix::discover(path).ok().map(Repository::into_sync);
+        Self { repo }
+    }
+
+    /// Returns the most recent modification time across all given paths
+    /// as seconds since Unix epoch.
+    ///
+    /// For each path:
+    /// - Clean tracked file → git commit author timestamp
+    /// - Dirty or untracked file → filesystem mtime
+    /// - No git repo → filesystem mtime
+    ///
+    /// Returns the max across all paths.
+    #[must_use]
+    pub fn mtime(&self, paths: &[&Path]) -> f64 {
+        paths
+            .iter()
+            .filter_map(|p| self.file_mtime(p))
+            .fold(0.0_f64, f64::max)
+    }
+
+    /// Resolve mtime for a single file.
+    fn file_mtime(&self, path: &Path) -> Option<f64> {
+        if let Some(sync_repo) = &self.repo {
+            let repo = sync_repo.to_thread_local();
+            if let Some(rel_path) = Self::repo_relative_path(&repo, path)
+                && !Self::is_dirty(&repo, &rel_path)
+                && let Some(git_mtime) = Self::git_commit_mtime(&repo, &rel_path)
+            {
+                return Some(git_mtime);
+            }
+        }
+        fs_mtime(path)
+    }
+
+    /// Convert absolute path to repo-relative path.
+    fn repo_relative_path(repo: &Repository, path: &Path) -> Option<PathBuf> {
+        let workdir = repo.workdir()?;
+        path.strip_prefix(workdir).ok().map(PathBuf::from)
+    }
+
+    /// Check if a file has uncommitted changes in the working directory.
+    ///
+    /// Returns `true` if the file is modified, staged, or untracked.
+    /// Also returns `true` on any error (conservative fallback to fs mtime).
+    ///
+    /// Note: This compares raw file content against the index entry hash.
+    /// Repositories using git filters (autocrlf, smudge/clean) may see
+    /// clean files reported as dirty because the working tree content
+    /// differs from the filtered content stored in the index. This is a
+    /// conservative failure — the fallback to fs mtime is safe.
+    fn is_dirty(repo: &Repository, rel_path: &Path) -> bool {
+        let rel_path_bstr = gix::bstr::BString::from(rel_path.as_os_str().as_encoded_bytes());
+
+        let Ok(index) = repo.index_or_empty() else {
+            return true;
+        };
+
+        let Some(entry) = index.entry_by_path(rel_path_bstr.as_bstr()) else {
+            // Not in the index = untracked
+            return true;
+        };
+
+        let Some(workdir) = repo.workdir() else {
+            return true;
+        };
+        let abs_path = workdir.join(rel_path);
+        let Ok(content) = fs::read(&abs_path) else {
+            return true;
+        };
+        let Ok(hash) =
+            gix::objs::compute_hash(repo.object_hash(), gix::object::Kind::Blob, &content)
+        else {
+            return true;
+        };
+        hash != entry.id
+    }
+
+    /// Walk commit history to find the most recent commit that touched the file.
+    ///
+    /// Returns the committer timestamp (seconds since epoch) of the most recent
+    /// commit that changed the file's content. Returns `None` if the file
+    /// is not tracked in git history.
+    #[allow(clippy::default_trait_access)] // CommitTimeOrder is not publicly exported by gix
+    fn git_commit_mtime(repo: &Repository, rel_path: &Path) -> Option<f64> {
+        let head = repo.head_commit().ok()?;
+
+        // Check that the file exists in HEAD's tree
+        let head_tree = head.tree().ok()?;
+        let head_entry = head_tree.lookup_entry_by_path(rel_path).ok()??;
+        let head_blob_oid = head_entry.object_id();
+
+        // The HEAD commit's author time is the candidate — if the file
+        // was only ever touched by one commit, this is the answer.
+        let head_time = head.time().ok()?;
+        #[allow(clippy::cast_precision_loss)] // git timestamps are well within f64 range
+        let mut last_change_time = head_time.seconds as f64;
+
+        // Walk backwards from HEAD through first-parent commits only.
+        // First-parent traversal avoids interleaving commits from merged
+        // branches, which would break the "chain of same blob OID" logic.
+        let walk = repo
+            .rev_walk([head.id])
+            .sorting(Sorting::ByCommitTime(Default::default()))
+            .first_parent_only()
+            .all()
+            .ok()?;
+
+        for info in walk {
+            let info = info.ok()?;
+            // Skip HEAD itself — we already processed it
+            if info.id == head.id {
+                continue;
+            }
+
+            let commit = info.object().ok()?;
+            let tree = commit.tree().ok()?;
+
+            let blob_oid = tree
+                .lookup_entry_by_path(rel_path)
+                .ok()
+                .flatten()
+                .map(|e| e.object_id());
+
+            match blob_oid {
+                Some(oid) if oid == head_blob_oid => {
+                    // File exists and has the same content as the child commit.
+                    // The change happened in an earlier commit — keep walking.
+                    let commit_time = commit.time().ok()?;
+                    #[allow(clippy::cast_precision_loss)]
+                    {
+                        last_change_time = commit_time.seconds as f64;
+                    }
+                }
+                _ => {
+                    // File either doesn't exist in this commit or has different
+                    // content. The child commit is the one that last changed it.
+                    // last_change_time already holds the child's timestamp.
+                    return Some(last_change_time);
+                }
+            }
+        }
+
+        // Reached the root of history — the file was introduced in the
+        // oldest commit we saw.
+        Some(last_change_time)
+    }
+}
+
+/// Read filesystem mtime for a file.
+fn fs_mtime(path: &Path) -> Option<f64> {
+    let metadata = fs::metadata(path).ok()?;
+    let modified = metadata.modified().ok()?;
+    Some(
+        modified
+            .duration_since(UNIX_EPOCH)
+            .map_or(0.0, |d| d.as_secs_f64()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    /// Create a temporary git repo with an initial commit.
+    fn create_git_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+
+        Command::new("git")
+            .args(["init", "-b", "test"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+
+        dir
+    }
+
+    fn git_add_commit(dir: &Path, message: &str) {
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", message])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+    }
+
+    /// Get a thread-local Repository from a Vcs instance (for testing internals).
+    fn thread_local_repo(vcs: &Vcs) -> Repository {
+        vcs.repo.as_ref().unwrap().to_thread_local()
+    }
+
+    #[test]
+    fn test_dirty_file_detected() {
+        let dir = create_git_repo();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# Hello").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        let vcs = Vcs::new(dir.path());
+        let rel_path = PathBuf::from("doc.md");
+
+        // File is clean after commit
+        let repo = thread_local_repo(&vcs);
+        assert!(!Vcs::is_dirty(&repo, &rel_path));
+
+        // Modify the file — now dirty
+        fs::write(&file, "# Modified").unwrap();
+        let repo = thread_local_repo(&vcs);
+        assert!(Vcs::is_dirty(&repo, &rel_path));
+    }
+
+    #[test]
+    fn test_git_commit_mtime_for_clean_file() {
+        let dir = create_git_repo();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# Hello").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        let vcs = Vcs::new(dir.path());
+        let repo = thread_local_repo(&vcs);
+        let rel_path = PathBuf::from("doc.md");
+
+        let mtime = Vcs::git_commit_mtime(&repo, &rel_path);
+        assert!(mtime.is_some());
+
+        // Should be a recent timestamp
+        let now = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        let mtime = mtime.unwrap();
+        assert!(mtime > now - 60.0);
+        assert!(mtime <= now);
+    }
+
+    #[test]
+    fn test_git_commit_mtime_uses_latest_commit() {
+        let dir = create_git_repo();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# Version 1").unwrap();
+        git_add_commit(dir.path(), "v1");
+
+        // Small delay to ensure different timestamps
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        fs::write(&file, "# Version 2").unwrap();
+        git_add_commit(dir.path(), "v2");
+
+        let vcs = Vcs::new(dir.path());
+        let repo = thread_local_repo(&vcs);
+        let rel_path = PathBuf::from("doc.md");
+
+        let mtime = Vcs::git_commit_mtime(&repo, &rel_path).unwrap();
+
+        // Get the v1 commit time via git log
+        let v1_output = Command::new("git")
+            .args(["log", "--format=%at", "--skip=1", "-1"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        let v1_time: f64 = String::from_utf8_lossy(&v1_output.stdout)
+            .trim()
+            .parse()
+            .unwrap();
+
+        // mtime should be from v2 (later than v1)
+        assert!(mtime > v1_time);
+    }
+
+    #[test]
+    fn test_git_commit_mtime_none_for_untracked() {
+        let dir = create_git_repo();
+        let initial = dir.path().join("initial.md");
+        fs::write(&initial, "# Init").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        let untracked = dir.path().join("new.md");
+        fs::write(&untracked, "# New").unwrap();
+
+        let vcs = Vcs::new(dir.path());
+        let repo = thread_local_repo(&vcs);
+
+        assert!(Vcs::git_commit_mtime(&repo, &PathBuf::from("new.md")).is_none());
+    }
+
+    #[test]
+    fn test_mtime_clean_file_returns_git_time() {
+        let dir = create_git_repo();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# Hello").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        let vcs = Vcs::new(dir.path());
+        let mtime = vcs.mtime(&[&file]);
+
+        let now = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        assert!(mtime > now - 60.0);
+        assert!(mtime <= now);
+    }
+
+    #[test]
+    fn test_mtime_dirty_file_returns_fs_time() {
+        let dir = create_git_repo();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# Hello").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        // Modify without committing
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        fs::write(&file, "# Modified").unwrap();
+
+        let vcs = Vcs::new(dir.path());
+        let mtime = vcs.mtime(&[&file]);
+
+        // mtime should be the filesystem time (newer than commit time)
+        let git_time_output = Command::new("git")
+            .args(["log", "-1", "--format=%at", "--", "doc.md"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        let git_time: f64 = String::from_utf8_lossy(&git_time_output.stdout)
+            .trim()
+            .parse()
+            .unwrap();
+
+        assert!(mtime > git_time);
+    }
+
+    #[test]
+    fn test_mtime_multiple_paths_returns_max() {
+        let dir = create_git_repo();
+        let file1 = dir.path().join("doc.md");
+        fs::write(&file1, "# Doc").unwrap();
+        git_add_commit(dir.path(), "first");
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let file2 = dir.path().join("meta.yaml");
+        fs::write(&file2, "title: Doc").unwrap();
+        git_add_commit(dir.path(), "second");
+
+        let vcs = Vcs::new(dir.path());
+        let mtime = vcs.mtime(&[&file1, &file2]);
+
+        // Should be the time of the second commit (meta.yaml is newer)
+        let git_time_output = Command::new("git")
+            .args(["log", "-1", "--format=%at", "--", "meta.yaml"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        let meta_time: f64 = String::from_utf8_lossy(&git_time_output.stdout)
+            .trim()
+            .parse()
+            .unwrap();
+
+        assert!((mtime - meta_time).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_mtime_no_git_repo_returns_fs_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# Hello").unwrap();
+
+        let vcs = Vcs::new(dir.path());
+        let mtime = vcs.mtime(&[&file]);
+
+        let now = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
+        assert!(mtime > now - 60.0);
+        assert!(mtime <= now);
+    }
+
+    #[test]
+    fn test_mtime_empty_paths_returns_zero() {
+        let dir = create_git_repo();
+        let vcs = Vcs::new(dir.path());
+        assert!((vcs.mtime(&[]) - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_staged_file_is_not_dirty() {
+        let dir = create_git_repo();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# Hello").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        // Modify and stage, but don't commit
+        fs::write(&file, "# Staged change").unwrap();
+        Command::new("git")
+            .args(["add", "doc.md"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        let vcs = Vcs::new(dir.path());
+        let repo = thread_local_repo(&vcs);
+
+        // Staged file: index hash matches working tree, so is_dirty returns false.
+        // This means mtime() returns the git commit time of the last commit,
+        // not reflecting the staged change. This is acceptable — staged content
+        // is snapshotted in the index but not yet part of history.
+        assert!(!Vcs::is_dirty(&repo, &PathBuf::from("doc.md")));
+    }
+
+    #[test]
+    fn test_untracked_file_is_dirty() {
+        let dir = create_git_repo();
+        let file = dir.path().join("initial.md");
+        fs::write(&file, "# Init").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        let vcs = Vcs::new(dir.path());
+        let repo = thread_local_repo(&vcs);
+
+        // Untracked file should be treated as dirty
+        let untracked = dir.path().join("new.md");
+        fs::write(&untracked, "# New").unwrap();
+        assert!(Vcs::is_dirty(&repo, &PathBuf::from("new.md")));
+    }
+}


### PR DESCRIPTION
## Summary

- New `rw-vcs` crate that resolves git commit timestamps for documentation files using `gix`, falling back to filesystem mtime for dirty/untracked files or non-git directories
- `FsStorage::mtime()` now returns git commit time instead of filesystem mtime, considering both `.md` and `meta.yaml` files
- S3 manifest stores per-page mtimes populated at publish time; `S3Storage::mtime()` reads from manifest instead of returning `0.0`

## Test plan

- [x] `rw-vcs`: 10 unit/integration tests covering dirty detection, git mtime resolution, multi-path max, no-git fallback
- [x] `rw-storage-fs`: all 93 existing tests pass (Vcs falls back to fs mtime in non-git temp dirs)
- [x] `rw-storage-s3`: 11 tests including backwards-compatible manifest deserialization
- [x] Full `make test`, `make lint`, `make format` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)