### PR TITLE
feat: inline comments for documentation pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Inline comments — select text in the browser and add comments anchored to specific passages; comments persist in `.rw/comments/sqlite.db` and survive content re-renders via multi-selector anchoring (TextQuoteSelector + TextPositionSelector). When the original passage no longer appears verbatim — e.g. after a typo fix or a paragraph split that drops a space — the viewer falls back to fuzzy re-anchoring (diff-match-patch) and marks the comment as **re-anchored** with a softer dashed-underline highlight and an italic label in the thread header, so reviewers can tell when a comment may have moved.
+- Page comments — leave comments on a page without selecting text; page comments appear below the article content with the same threading and resolve/reopen workflow as inline comments
+- Comment REST API (`/api/comments`) for creating, listing, and updating inline annotations
+- Comment authorship — every comment carries an author (`{ id, name, avatarUrl? }`); `rw serve` stamps browser-created comments with "You". Authors with id `local:human` render a person avatar; authors with id `local:ai` render a sparkles avatar (recommended for LLM agents writing via `rw comment`); others fall back to name initials.
+- `rw comment` CLI (list, show, add, reply, resolve) for scripting and LLM agents — reads and writes comments in the project's `.rw/comments/sqlite.db` directly; works whether or not `rw serve` is running. Identity via `RW_COMMENT_AUTHOR_ID` / `RW_COMMENT_AUTHOR_NAME` env vars or `--author-id` / `--author-name` flags; falls back to the default `local:human` / "You" identity when neither is set. Inline anchoring via `--quote "passage text"` — the CLI renders the target page in-process and rejects ambiguous or missing matches.
+
 ### Changed
 
+- Page outline (TOC) sidebar widened from 240px to 320px so that opening a comment no longer narrows the article or shifts text sideways; the sidebar now appears at viewport widths ≥ 1304px instead of ≥ 1224px (narrower viewports get the floating "On this page" popover as before)
 - Page modification times (`lastModified` in API responses) now reflect the git commit time instead of the filesystem modification time — timestamps remain stable across `git checkout`, `git pull`, and branch switching
 - S3-published documentation bundles now include page modification times in the manifest — previously `lastModified` was always epoch zero for Backstage-served pages
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,16 @@ npm -w @rwdocs/viewer run dev
 
 ```
 crates/
+├── rw-comments/           # Inline comment storage + quote anchoring
+│   └── src/
+│       ├── lib.rs            # Public API exports
+│       ├── model.rs          # Comment, Selector, CommentStatus types
+│       ├── error.rs          # StoreError, CreateError
+│       ├── sqlite.rs         # SqliteCommentStore (persistence)
+│       ├── creation.rs       # create_comment() — quote-or-selectors wrapper
+│       ├── anchoring.rs      # Quote → selectors resolver (shared by HTTP + napi)
+│       └── html_text.rs      # HTML → textContent extractor (private, for anchoring)
+│
 ├── rw/                    # CLI binary (clap)
 │   └── src/
 │       ├── main.rs           # Entry point, CLI setup
@@ -46,9 +56,19 @@ crates/
 │           │   ├── mod.rs         # `confluence` subcommand group
 │           │   ├── update.rs      # `confluence update` command
 │           │   └── generate_tokens.rs  # `confluence generate-tokens` command
-│           └── backstage/
-│               ├── mod.rs         # `backstage` subcommand group
-│               └── publish.rs     # `backstage publish` command
+│           ├── backstage/
+│           │   ├── mod.rs         # `backstage` subcommand group
+│           │   └── publish.rs     # `backstage publish` command
+│           └── comment/
+│               ├── mod.rs         # `comment` subcommand group (CommonArgs + dispatch)
+│               ├── context.rs     # Shared store + Site construction
+│               ├── identity.rs    # flag + env resolution for Author
+│               ├── format.rs      # text + JSON output helpers
+│               ├── list.rs        # `comment list`
+│               ├── show.rs        # `comment show`
+│               ├── add.rs         # `comment add`
+│               ├── reply.rs       # `comment reply`
+│               └── resolve.rs     # `comment resolve`
 │
 ├── rw-storage-s3/         # S3 storage backend and bundle publisher
 │   └── src/
@@ -196,9 +216,10 @@ crates/
 └── rw-server/             # Native HTTP server (axum)
     └── src/
         ├── lib.rs            # Server configuration and entry point
-        ├── handlers/         # API endpoints (config, pages, navigation)
+        ├── handlers/         # API endpoints (config, pages, navigation, comments)
         ├── live_reload/      # File watching and WebSocket broadcasting
-        └── static_files.rs   # Static file serving with SPA fallback
+        ├── static_files.rs   # Static file serving with SPA fallback
+        └── testing.rs        # TestServer harness (feature = "test-utils")
 
 packages/
 ├── viewer/                # @rwdocs/viewer — Svelte 5 SPA (Vite + Tailwind)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.128.0"
+version = "1.127.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99304b64672e0d81a3c100a589b93d9ef5e9c0ce12e21c848fd39e50f493c2a1"
+checksum = "151783f64e0dcddeb4965d08e36c276b4400a46caa88805a2e36d497deaf031a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -690,6 +699,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -906,6 +918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1338,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -1351,7 +1390,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1408,6 +1469,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1463,6 +1536,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -1483,8 +1584,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -2502,6 +2605,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2514,6 +2619,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2539,12 +2653,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -2720,7 +2861,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -3011,7 +3152,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3106,9 +3247,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libflate"
@@ -3149,6 +3290,17 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3282,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -3442,6 +3594,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3707,6 +3865,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -3966,7 +4125,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4052,7 +4211,10 @@ version = "0.1.24"
 dependencies = [
  "clap",
  "console",
+ "pretty_assertions",
  "rw-assets",
+ "rw-cache",
+ "rw-comments",
  "rw-config",
  "rw-confluence",
  "rw-server",
@@ -4060,10 +4222,13 @@ dependencies = [
  "rw-storage",
  "rw-storage-fs",
  "rw-storage-s3",
+ "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -4092,6 +4257,24 @@ dependencies = [
  "rw-cache",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "rw-comments"
+version = "0.1.24"
+dependencies = [
+ "chrono",
+ "html-escape",
+ "pretty_assertions",
+ "rw-cache",
+ "rw-site",
+ "rw-storage",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -4192,6 +4375,7 @@ dependencies = [
  "pretty_assertions",
  "rw-assets",
  "rw-cache",
+ "rw-comments",
  "rw-config",
  "rw-embedded-preview",
  "rw-renderer",
@@ -4201,13 +4385,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tempfile",
  "thiserror",
  "tokio",
  "tokio-test",
  "tower",
  "tower-http",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4421,9 +4605,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -4573,6 +4757,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -4586,12 +4773,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4599,6 +4786,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -4627,6 +4817,194 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.10.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.10.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4637,6 +5015,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -4698,7 +5087,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4798,9 +5187,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -4808,16 +5197,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4893,9 +5282,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4908,27 +5297,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tower"
@@ -5076,6 +5465,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5095,6 +5490,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-width"
@@ -5177,6 +5578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5200,7 +5607,9 @@ version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
+ "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5209,6 +5618,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -5264,6 +5679,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -5364,6 +5785,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5385,7 +5816,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5455,6 +5886,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5478,6 +5918,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5515,6 +5970,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5527,6 +5988,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5536,6 +6003,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5563,6 +6036,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5572,6 +6051,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5587,6 +6072,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5596,6 +6087,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 # Internal crates
 rw-assets = { path = "crates/rw-assets" }
 rw-cache = { path = "crates/rw-cache" }
+rw-comments = { path = "crates/rw-comments" }
 rw-cache-s3 = { path = "crates/rw-cache-s3" }
 rw-config = { path = "crates/rw-config" }
 rw-confluence = { path = "crates/rw-confluence" }
@@ -42,6 +43,8 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["simd
 rayon = "1.10"
 regex = "1.11"
 serde_json = "1"
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 serde_yaml = "0.9"
 sha2 = "0.11"
 static_assertions = "1.1"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See the [configuration guide](docs/configuration.md) for all options.
 | `rw backstage publish` | Publish documentation bundles to S3 for Backstage |
 | `rw confluence update` | Publish markdown to a Confluence page |
 | `rw confluence generate-tokens` | Generate OAuth access tokens |
+| `rw comment` | Read and write inline comments on project docs (for scripts and LLM agents) |
 
 ## Documentation
 
@@ -76,6 +77,7 @@ See the [configuration guide](docs/configuration.md) for all options.
 - [Page Metadata](docs/metadata.md)
 - [Confluence Publishing](docs/confluence.md)
 - [Diagram Rendering](docs/diagrams.md)
+- [Comment CLI](docs/comment-cli.md)
 
 ## License
 

--- a/crates/rw-comments/Cargo.toml
+++ b/crates/rw-comments/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "rw-comments"
+description = "Inline comment storage for RW documentation engine"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+rw-site = { workspace = true }
+
+chrono = "0.4"
+html-escape = "0.2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+rw-cache = { workspace = true }
+rw-storage = { workspace = true, features = ["mock"] }
+
+pretty_assertions = { workspace = true }
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/rw-comments/src/anchoring.rs
+++ b/crates/rw-comments/src/anchoring.rs
@@ -1,0 +1,239 @@
+//! Resolve a `quote` string to a pair of [`Selector`]s by rendering the page
+//! and searching its textContent-equivalent output. Mirrors the viewer's
+//! browser-side anchoring so offsets line up with what the DOM sees.
+
+use rw_site::{RenderError, Site};
+use thiserror::Error;
+
+use crate::Selector;
+use crate::html_text::html_to_text_content;
+
+/// Errors returned when resolving a quote into selectors.
+#[derive(Debug, Error)]
+pub enum QuoteResolutionError {
+    /// The requested document does not exist in the site.
+    #[error("document '{document_id}' does not exist")]
+    DocumentNotFound { document_id: String },
+    /// The quote did not appear in the rendered text.
+    #[error("quote not found in document '{document_id}'")]
+    NotFound { document_id: String },
+    /// The quote appeared more than once; caller must add surrounding context.
+    #[error(
+        "quote matches {count} times in document '{document_id}' — add more surrounding context to disambiguate"
+    )]
+    Ambiguous { document_id: String, count: usize },
+    /// Page rendering failed for some other reason.
+    #[error("failed to render document '{document_id}': {reason}")]
+    RenderFailed { document_id: String, reason: String },
+}
+
+/// Characters of prefix / suffix context stored alongside the quote. Matches
+/// the viewer's `rangeToSelectors` (32 chars on either side).
+const CONTEXT_CHARS: usize = 32;
+
+/// Resolve a quote string into a pair of selectors by rendering the page's
+/// textContent and locating the quote inside it.
+///
+/// Returns a two-element vector: a [`Selector::TextQuoteSelector`] with
+/// `exact`, `prefix` (up to 32 chars), and `suffix` (up to 32 chars), plus a
+/// [`Selector::TextPositionSelector`] whose offsets are UTF-16 code units —
+/// the same representation the viewer produces from `Range.toString().length`.
+///
+/// # Errors
+///
+/// Returns [`QuoteResolutionError`] when the document is missing, the quote
+/// does not match, matches more than once, or rendering fails.
+pub(crate) fn resolve_quote(
+    site: &Site,
+    document_id: &str,
+    quote: &str,
+) -> Result<Vec<Selector>, QuoteResolutionError> {
+    let result = site.render(document_id).map_err(|err| match err {
+        RenderError::PageNotFound(_) | RenderError::FileNotFound(_) => {
+            QuoteResolutionError::DocumentNotFound {
+                document_id: document_id.to_owned(),
+            }
+        }
+        other => QuoteResolutionError::RenderFailed {
+            document_id: document_id.to_owned(),
+            reason: other.to_string(),
+        },
+    })?;
+
+    let text = html_to_text_content(&result.html);
+
+    let mut occurrences = text.match_indices(quote);
+    let byte_start = occurrences
+        .next()
+        .ok_or_else(|| QuoteResolutionError::NotFound {
+            document_id: document_id.to_owned(),
+        })?
+        .0;
+    if occurrences.next().is_some() {
+        return Err(QuoteResolutionError::Ambiguous {
+            document_id: document_id.to_owned(),
+            count: 2 + occurrences.count(),
+        });
+    }
+
+    let byte_end = byte_start + quote.len();
+
+    let start = text[..byte_start].encode_utf16().count();
+    let end = start + quote.encode_utf16().count();
+
+    let prefix_start = text[..byte_start]
+        .char_indices()
+        .nth_back(CONTEXT_CHARS - 1)
+        .map_or(0, |(idx, _)| idx);
+    let prefix = text[prefix_start..byte_start].to_owned();
+    let suffix: String = text[byte_end..].chars().take(CONTEXT_CHARS).collect();
+
+    Ok(vec![
+        Selector::TextQuoteSelector {
+            exact: quote.to_owned(),
+            prefix,
+            suffix,
+        },
+        Selector::TextPositionSelector { start, end },
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
+    use rw_cache::NullCache;
+    use rw_site::PageRendererConfig;
+    use rw_storage::MockStorage;
+
+    use super::*;
+
+    fn seeded_site(path: &str, markdown: &str) -> Site {
+        let storage = Arc::new(
+            MockStorage::new()
+                .with_file(path, path, markdown)
+                .with_mtime(path, 0.0),
+        );
+        Site::new(storage, Arc::new(NullCache), PageRendererConfig::default())
+    }
+
+    #[test]
+    fn single_match_returns_both_selectors() {
+        let site = seeded_site(
+            "guide",
+            "# Guide\n\nThe quick brown fox jumps over the lazy dog.\n",
+        );
+
+        let selectors = resolve_quote(&site, "guide", "brown fox jumps").unwrap();
+        assert_eq!(selectors.len(), 2);
+
+        match &selectors[0] {
+            Selector::TextQuoteSelector {
+                exact,
+                prefix,
+                suffix,
+            } => {
+                assert_eq!(exact, "brown fox jumps");
+                assert!(prefix.ends_with("quick "));
+                assert!(suffix.starts_with(" over"));
+            }
+            other => panic!("expected TextQuoteSelector, got {other:?}"),
+        }
+
+        match &selectors[1] {
+            Selector::TextPositionSelector { start, end } => {
+                assert!(end > start);
+                assert_eq!(end - start, "brown fox jumps".len());
+            }
+            other => panic!("expected TextPositionSelector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_returns_error() {
+        let site = seeded_site("guide", "# Guide\n\nSome body text.\n");
+
+        let err = resolve_quote(&site, "guide", "missing quote").unwrap_err();
+        assert!(matches!(err, QuoteResolutionError::NotFound { .. }));
+    }
+
+    #[test]
+    fn ambiguous_quote_returns_count() {
+        let site = seeded_site("guide", "# Guide\n\nfoo bar foo baz foo.\n");
+
+        let err = resolve_quote(&site, "guide", "foo").unwrap_err();
+        match err {
+            QuoteResolutionError::Ambiguous { count, .. } => assert_eq!(count, 3),
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_document_returns_document_not_found() {
+        let site = seeded_site("guide", "# Guide\n");
+
+        let err = resolve_quote(&site, "nope", "anything").unwrap_err();
+        assert!(matches!(err, QuoteResolutionError::DocumentNotFound { .. }));
+    }
+
+    #[test]
+    fn match_at_start_has_empty_prefix() {
+        let site = seeded_site("guide", "Hello world, this is the body.\n");
+
+        let selectors = resolve_quote(&site, "guide", "Hello").unwrap();
+        match &selectors[0] {
+            Selector::TextQuoteSelector { prefix, .. } => {
+                assert!(prefix.is_empty(), "expected empty prefix, got {prefix:?}");
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn markdown_syntax_in_quote_not_found_in_rendered_text() {
+        // Quote includes raw markdown `**bold**` that gets rendered to
+        // `<strong>bold</strong>` — textContent is just `bold`, so the
+        // literal `**bold**` quote should not match.
+        let site = seeded_site("guide", "This is **bold** text.\n");
+
+        let err = resolve_quote(&site, "guide", "**bold**").unwrap_err();
+        assert!(matches!(err, QuoteResolutionError::NotFound { .. }));
+    }
+
+    #[test]
+    fn non_ascii_page_uses_utf16_code_units() {
+        // `TextPositionSelector` offsets are UTF-16 code units so the viewer
+        // (which computes positions via `String.length`) can resolve them
+        // directly.
+        let site = seeded_site("guide", "Привет, world! More text here.\n");
+
+        let selectors = resolve_quote(&site, "guide", "world").unwrap();
+        match &selectors[1] {
+            Selector::TextPositionSelector { start, end } => {
+                // "Привет, " is 8 UTF-16 code units (6 BMP Cyrillic chars
+                // + ", ").
+                assert_eq!(*start, 8);
+                assert_eq!(*end, 13); // 8 + "world".len()
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn non_bmp_char_counts_as_two_utf16_units() {
+        // Surrogate pairs (emoji, etc.) occupy 2 UTF-16 code units — matches
+        // what `String.prototype.length` returns in the browser.
+        let site = seeded_site("guide", "🚀 hello world here.\n");
+
+        let selectors = resolve_quote(&site, "guide", "world").unwrap();
+        match &selectors[1] {
+            Selector::TextPositionSelector { start, end } => {
+                // "🚀 hello " = 2 (rocket surrogate pair) + 1 + 5 + 1 = 9.
+                assert_eq!(*start, 9);
+                assert_eq!(*end, 14); // 9 + "world".len()
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/rw-comments/src/creation.rs
+++ b/crates/rw-comments/src/creation.rs
@@ -1,0 +1,125 @@
+use rw_site::Site;
+
+use crate::anchoring::resolve_quote;
+use crate::error::CreateError;
+use crate::model::{CreateComment, NewComment};
+use crate::sqlite::SqliteCommentStore;
+use crate::{Comment, Selector};
+
+/// Create a comment, turning a `quote` into selectors first if one was given.
+///
+/// - `input.selectors = Some(non-empty)` and `input.quote = None` — the
+///   selectors are used verbatim.
+/// - `input.quote = Some(_)` and `input.selectors` is `None` or an empty list
+///   — the quote is resolved against `site` into a `TextQuote` +
+///   `TextPosition` selector pair.
+/// - Both set — [`CreateError::BothQuoteAndSelectors`].
+/// - Neither set — the comment is created with no anchor (page-level comment).
+///
+/// # Errors
+///
+/// Returns [`CreateError::BothQuoteAndSelectors`] when the caller supplies
+/// both `quote` and `selectors`, [`CreateError::Quote`] when the quote cannot
+/// be resolved, and [`CreateError::Store`] for underlying storage failures.
+pub async fn create_comment(
+    store: &SqliteCommentStore,
+    site: &Site,
+    input: NewComment,
+) -> Result<Comment, CreateError> {
+    let NewComment {
+        document_id,
+        parent_id,
+        author,
+        body,
+        selectors,
+        quote,
+    } = input;
+
+    let selectors = resolve_selectors(site, &document_id, selectors, quote)?;
+
+    store
+        .create(CreateComment {
+            document_id,
+            parent_id,
+            author,
+            body,
+            selectors,
+        })
+        .await
+        .map_err(Into::into)
+}
+
+fn resolve_selectors(
+    site: &Site,
+    document_id: &str,
+    selectors: Option<Vec<Selector>>,
+    quote: Option<String>,
+) -> Result<Vec<Selector>, CreateError> {
+    match (quote, selectors) {
+        (Some(_), Some(s)) if !s.is_empty() => Err(CreateError::BothQuoteAndSelectors),
+        (Some(quote), _) => Ok(resolve_quote(site, document_id, &quote)?),
+        (None, Some(s)) => Ok(s),
+        (None, None) => Ok(Vec::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use pretty_assertions::assert_eq;
+    use rw_cache::NullCache;
+    use rw_site::PageRendererConfig;
+    use rw_storage::MockStorage;
+
+    use super::*;
+    use crate::model::Author;
+
+    fn empty_site() -> Site {
+        Site::new(
+            Arc::new(MockStorage::new()),
+            Arc::new(NullCache),
+            PageRendererConfig::default(),
+        )
+    }
+
+    fn new_comment(author: Option<Author>) -> NewComment {
+        NewComment {
+            document_id: "guide".to_owned(),
+            parent_id: None,
+            author,
+            body: "hi".to_owned(),
+            selectors: None,
+            quote: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn stamps_local_human_when_author_omitted() {
+        let store = SqliteCommentStore::open_memory().await.unwrap();
+        let site = empty_site();
+
+        let comment = create_comment(&store, &site, new_comment(None))
+            .await
+            .unwrap();
+
+        assert_eq!(comment.author, Author::local_human());
+    }
+
+    #[tokio::test]
+    async fn preserves_supplied_author() {
+        let store = SqliteCommentStore::open_memory().await.unwrap();
+        let site = empty_site();
+
+        let claimed = Author {
+            id: "local:claude-code".to_owned(),
+            name: "Claude Code".to_owned(),
+            avatar_url: None,
+        };
+        let comment = create_comment(&store, &site, new_comment(Some(claimed.clone())))
+            .await
+            .unwrap();
+
+        assert_eq!(comment.author, claimed);
+    }
+}

--- a/crates/rw-comments/src/error.rs
+++ b/crates/rw-comments/src/error.rs
@@ -1,0 +1,45 @@
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::anchoring::QuoteResolutionError;
+use crate::model::ParseCommentStatusError;
+
+/// Errors returned by comment store operations.
+#[derive(Debug, Error)]
+pub enum StoreError {
+    /// No comment exists with the requested id.
+    #[error("comment not found: {0}")]
+    NotFound(Uuid),
+    /// Parent id is missing, resolved, or belongs to a different document.
+    #[error("invalid parent comment: {0}")]
+    InvalidParent(String),
+    /// Database operation failed.
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    /// I/O error while preparing the store on disk.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// JSON (de)serialization failed for a persisted column.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    /// Stored UUID failed to parse.
+    #[error(transparent)]
+    Uuid(#[from] uuid::Error),
+    /// Stored row contains an unknown comment status.
+    #[error(transparent)]
+    CorruptStatus(#[from] ParseCommentStatusError),
+}
+
+/// Errors returned by the high-level [`crate::create_comment`] flow.
+#[derive(Debug, Error)]
+pub enum CreateError {
+    /// Underlying storage operation failed.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    /// Resolving the supplied `quote` against the rendered document failed.
+    #[error(transparent)]
+    Quote(#[from] QuoteResolutionError),
+    /// Caller supplied both `selectors` and `quote`; only one is allowed.
+    #[error("quote and selectors are mutually exclusive")]
+    BothQuoteAndSelectors,
+}

--- a/crates/rw-comments/src/html_text.rs
+++ b/crates/rw-comments/src/html_text.rs
@@ -1,0 +1,109 @@
+//! Extract the textContent-equivalent string from rendered HTML.
+//!
+//! The viewer's anchoring algorithm (`packages/viewer/src/lib/anchoring.ts`)
+//! matches quotes against `article.textContent` — the flattened text stream
+//! of the rendered HTML. The quote resolver needs the same stream so the
+//! offsets it computes line up with what the browser sees.
+
+/// Flatten rendered HTML to a textContent-equivalent string.
+///
+/// Concatenates all descendant text nodes in document order, matching the
+/// DOM `Node.textContent` specification: tags and HTML comments are
+/// stripped, entities are decoded, and whitespace between blocks is kept
+/// as-is.
+///
+/// The input is trusted — it comes from our own pulldown-cmark renderer,
+/// so tags are well-formed and `<` never appears inside an attribute.
+pub(crate) fn html_to_text_content(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+
+    while let Some(lt) = rest.find('<') {
+        push_decoded(&mut out, &rest[..lt]);
+        rest = &rest[lt..];
+
+        if rest.starts_with("<!--") {
+            rest = rest.find("-->").map_or("", |end| &rest[end + 3..]);
+            continue;
+        }
+
+        rest = rest.find('>').map_or("", |end| &rest[end + 1..]);
+    }
+    push_decoded(&mut out, rest);
+    out
+}
+
+fn push_decoded(out: &mut String, chunk: &str) {
+    if chunk.contains('&') {
+        out.push_str(&html_escape::decode_html_entities(chunk));
+    } else {
+        out.push_str(chunk);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn plain_text_passes_through() {
+        assert_eq!(html_to_text_content("hello world"), "hello world");
+    }
+
+    #[test]
+    fn tags_are_stripped() {
+        assert_eq!(
+            html_to_text_content("<p>hello <strong>world</strong></p>"),
+            "hello world"
+        );
+    }
+
+    #[test]
+    fn multiple_paragraphs_preserve_whitespace_between() {
+        let html = "<p>foo</p>\n<p>bar</p>";
+        let text = html_to_text_content(html);
+        assert!(text.contains("foo"));
+        assert!(text.contains("bar"));
+        assert_ne!(text.find("foo"), text.find("bar"));
+    }
+
+    #[test]
+    fn nested_inline_formatting_flattens() {
+        let html = "<p>The <em>foo</em> does <code>X</code>, Y, Z.</p>";
+        assert_eq!(html_to_text_content(html), "The foo does X, Y, Z.");
+    }
+
+    #[test]
+    fn code_block_content_is_included() {
+        let html =
+            r#"<pre><code class="language-rust"><span>let</span> <span>x</span> = 1;</code></pre>"#;
+        assert_eq!(html_to_text_content(html), "let x = 1;");
+    }
+
+    #[test]
+    fn empty_input_produces_empty_output() {
+        assert_eq!(html_to_text_content(""), "");
+    }
+
+    #[test]
+    fn html_comments_are_skipped() {
+        assert_eq!(
+            html_to_text_content("<p>foo <!-- hidden --> baz</p>"),
+            "foo  baz"
+        );
+    }
+
+    #[test]
+    fn named_entities_are_decoded() {
+        assert_eq!(
+            html_to_text_content("<p>Tom &amp; Jerry</p>"),
+            "Tom & Jerry"
+        );
+    }
+
+    #[test]
+    fn numeric_entities_are_decoded() {
+        assert_eq!(html_to_text_content("<p>rocket &#x1F680;</p>"), "rocket 🚀");
+    }
+}

--- a/crates/rw-comments/src/lib.rs
+++ b/crates/rw-comments/src/lib.rs
@@ -1,0 +1,17 @@
+//! Inline comment storage for RW documentation engine.
+
+mod anchoring;
+mod creation;
+mod error;
+mod html_text;
+mod model;
+mod sqlite;
+
+pub use anchoring::QuoteResolutionError;
+pub use creation::create_comment;
+pub use error::{CreateError, StoreError};
+pub use model::{
+    Author, Comment, CommentFilter, CommentStatus, CreateComment, NewComment,
+    ParseCommentStatusError, Selector, UpdateComment,
+};
+pub use sqlite::SqliteCommentStore;

--- a/crates/rw-comments/src/model.rs
+++ b/crates/rw-comments/src/model.rs
@@ -1,0 +1,148 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Identity of a comment's author.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Author {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+}
+
+impl Author {
+    /// The default identity stamped on comments when the caller doesn't supply
+    /// one — shared across `rw serve`, the `rw comment` CLI, and any other
+    /// in-process consumer.
+    #[must_use]
+    pub fn local_human() -> Self {
+        Self {
+            id: "local:human".to_owned(),
+            name: "You".to_owned(),
+            avatar_url: None,
+        }
+    }
+}
+
+/// A selector that identifies a text range within a document.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum Selector {
+    TextQuoteSelector {
+        exact: String,
+        prefix: String,
+        suffix: String,
+    },
+    TextPositionSelector {
+        start: usize,
+        end: usize,
+    },
+    CSSSelector {
+        value: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CommentStatus {
+    Open,
+    Resolved,
+}
+
+impl CommentStatus {
+    /// The canonical string form stored in the database and used in query
+    /// parameters. Matches the lowercase serde representation.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CommentStatus::Open => "open",
+            CommentStatus::Resolved => "resolved",
+        }
+    }
+}
+
+/// Returned when a string does not match any [`CommentStatus`] variant.
+#[derive(Debug, thiserror::Error)]
+#[error("unknown comment status: {0}")]
+pub struct ParseCommentStatusError(pub String);
+
+impl FromStr for CommentStatus {
+    type Err = ParseCommentStatusError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "open" => Ok(CommentStatus::Open),
+            "resolved" => Ok(CommentStatus::Resolved),
+            other => Err(ParseCommentStatusError(other.to_owned())),
+        }
+    }
+}
+
+/// A comment attached to a document.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Comment {
+    pub id: Uuid,
+    pub document_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    pub author: Author,
+    pub body: String,
+    pub selectors: Vec<Selector>,
+    pub status: CommentStatus,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Input for creating a new comment at the storage layer. Selectors are
+/// already resolved; see [`NewComment`] for the higher-level flow that takes a
+/// `quote` string instead. When `author` is `None` the store stamps
+/// [`Author::local_human`].
+#[derive(Debug)]
+pub struct CreateComment {
+    pub document_id: String,
+    pub parent_id: Option<Uuid>,
+    pub author: Option<Author>,
+    pub body: String,
+    pub selectors: Vec<Selector>,
+}
+
+/// Input for the high-level creation flow ([`crate::create_comment`]). Accepts
+/// either a pre-resolved `selectors` vector *or* a `quote` string that the
+/// flow resolves against a rendered [`Site`](rw_site::Site); supplying both is
+/// a client error.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewComment {
+    pub document_id: String,
+    pub parent_id: Option<Uuid>,
+    pub author: Option<Author>,
+    pub body: String,
+    pub selectors: Option<Vec<Selector>>,
+    pub quote: Option<String>,
+}
+
+/// Input for updating an existing comment.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateComment {
+    pub body: Option<String>,
+    pub status: Option<CommentStatus>,
+    pub selectors: Option<Vec<Selector>>,
+}
+
+/// Filter criteria for listing comments. `parent_id` wins over
+/// `top_level_only` when both are set; leave both at their defaults to include
+/// every comment regardless of depth.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentFilter {
+    pub document_id: Option<String>,
+    pub status: Option<CommentStatus>,
+    pub parent_id: Option<Uuid>,
+    #[serde(default)]
+    pub top_level_only: bool,
+}

--- a/crates/rw-comments/src/sqlite.rs
+++ b/crates/rw-comments/src/sqlite.rs
@@ -1,0 +1,458 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::Utc;
+use sqlx::sqlite::{
+    SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
+    SqliteSynchronous,
+};
+use sqlx::{Row, query};
+use uuid::Uuid;
+
+use crate::error::StoreError;
+use crate::model::{
+    Author, Comment, CommentFilter, CommentStatus, CreateComment, Selector, UpdateComment,
+};
+
+pub struct SqliteCommentStore {
+    pool: SqlitePool,
+}
+
+impl SqliteCommentStore {
+    /// Default on-disk location for the comment store relative to a project's
+    /// `.rw/` directory — `<project_dir>/comments/sqlite.db`.
+    #[must_use]
+    pub fn default_path(project_dir: &Path) -> PathBuf {
+        project_dir.join("comments").join("sqlite.db")
+    }
+
+    /// Opens (or creates) a `SQLite` database at `path` and runs migrations.
+    pub async fn open(path: &Path) -> Result<Self, StoreError> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let opts = SqliteConnectOptions::new()
+            .filename(path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(Duration::from_secs(5));
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect_with(opts)
+            .await?;
+
+        Self::migrate(&pool).await?;
+
+        Ok(Self { pool })
+    }
+
+    /// Opens an in-memory `SQLite` database.
+    ///
+    /// Useful for tests and for ephemeral scratch stores that don't need to
+    /// persist between runs. The pool is capped at one connection because
+    /// in-memory `SQLite` databases are bound to the connection that created
+    /// them — multiple connections would see independent databases.
+    pub async fn open_memory() -> Result<Self, StoreError> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await?;
+
+        Self::migrate(&pool).await?;
+
+        Ok(Self { pool })
+    }
+
+    async fn migrate(pool: &SqlitePool) -> Result<(), StoreError> {
+        query(
+            "CREATE TABLE IF NOT EXISTS comments (
+                id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                parent_id TEXT,
+                body TEXT NOT NULL,
+                selectors TEXT NOT NULL,
+                author TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .execute(pool)
+        .await?;
+
+        query("CREATE INDEX IF NOT EXISTS idx_comments_document_id ON comments (document_id)")
+            .execute(pool)
+            .await?;
+
+        query("CREATE INDEX IF NOT EXISTS idx_comments_parent_id ON comments (parent_id)")
+            .execute(pool)
+            .await?;
+
+        query(
+            "CREATE INDEX IF NOT EXISTS idx_comments_document_status
+             ON comments (document_id, status)",
+        )
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    fn row_to_comment(row: &SqliteRow) -> Result<Comment, StoreError> {
+        let id_str: String = row.get("id");
+        let id: Uuid = id_str.parse()?;
+
+        let parent_id_str: Option<String> = row.get("parent_id");
+        let parent_id = parent_id_str.map(|s| s.parse::<Uuid>()).transpose()?;
+
+        let selectors_json: String = row.get("selectors");
+        let selectors: Vec<Selector> = serde_json::from_str(&selectors_json)?;
+
+        let author_json: String = row.get("author");
+        let author: Author = serde_json::from_str(&author_json)?;
+
+        let status_str: String = row.get("status");
+        let status: CommentStatus = status_str.parse()?;
+
+        Ok(Comment {
+            id,
+            document_id: row.get("document_id"),
+            parent_id,
+            author,
+            body: row.get("body"),
+            selectors,
+            status,
+            created_at: row.get("created_at"),
+            updated_at: row.get("updated_at"),
+        })
+    }
+
+    /// Create a new comment and return it with generated `id` and timestamps.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::InvalidParent`] if `parent_id` is set but the
+    /// parent does not exist or belongs to a different document.
+    pub async fn create(&self, input: CreateComment) -> Result<Comment, StoreError> {
+        if let Some(parent_id) = input.parent_id {
+            let row = query("SELECT document_id FROM comments WHERE id = ?")
+                .bind(parent_id.to_string())
+                .fetch_optional(&self.pool)
+                .await?;
+            match row {
+                Some(row) => {
+                    let parent_doc: String = row.get("document_id");
+                    if parent_doc != input.document_id {
+                        return Err(StoreError::InvalidParent(format!(
+                            "parent {parent_id} belongs to a different document"
+                        )));
+                    }
+                }
+                None => {
+                    return Err(StoreError::InvalidParent(format!(
+                        "parent {parent_id} does not exist"
+                    )));
+                }
+            }
+        }
+
+        let id = Uuid::new_v4();
+        let now = Utc::now().to_rfc3339();
+        let author = input.author.unwrap_or_else(Author::local_human);
+        let selectors_json = serde_json::to_string(&input.selectors)?;
+        let author_json = serde_json::to_string(&author)?;
+        let parent_id_str = input.parent_id.map(|id| id.to_string());
+
+        query(
+            "INSERT INTO comments (id, document_id, parent_id, body, selectors, author, status, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(id.to_string())
+        .bind(&input.document_id)
+        .bind(&parent_id_str)
+        .bind(&input.body)
+        .bind(&selectors_json)
+        .bind(&author_json)
+        .bind(CommentStatus::Open.as_str())
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(Comment {
+            id,
+            document_id: input.document_id,
+            parent_id: input.parent_id,
+            author,
+            body: input.body,
+            selectors: input.selectors,
+            status: CommentStatus::Open,
+            created_at: now.clone(),
+            updated_at: now,
+        })
+    }
+
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotFound`] if no comment with `id` exists.
+    pub async fn get(&self, id: Uuid) -> Result<Comment, StoreError> {
+        let row = query("SELECT * FROM comments WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_optional(&self.pool)
+            .await?
+            .ok_or(StoreError::NotFound(id))?;
+
+        Self::row_to_comment(&row)
+    }
+
+    /// List comments matching the given filter criteria.
+    pub async fn list(&self, filter: CommentFilter) -> Result<Vec<Comment>, StoreError> {
+        let parent_id_str = filter.parent_id.map(|id| id.to_string());
+        let top_level_only = filter.parent_id.is_none() && filter.top_level_only;
+
+        let rows = query(
+            "SELECT * FROM comments
+             WHERE (?1 IS NULL OR document_id = ?1)
+               AND (?2 IS NULL OR status = ?2)
+               AND (?3 IS NULL OR parent_id = ?3)
+               AND (?4 = 0 OR parent_id IS NULL)
+             ORDER BY created_at ASC",
+        )
+        .bind(filter.document_id.as_deref())
+        .bind(filter.status.map(CommentStatus::as_str))
+        .bind(parent_id_str.as_deref())
+        .bind(i64::from(top_level_only))
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(Self::row_to_comment).collect()
+    }
+
+    /// Update a comment's fields and return the updated comment. Unset fields
+    /// in `input` are left unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotFound`] if no comment with `id` exists.
+    pub async fn update(&self, id: Uuid, input: UpdateComment) -> Result<Comment, StoreError> {
+        let now = Utc::now().to_rfc3339();
+        let selectors_json = input
+            .selectors
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
+
+        let row = query(
+            "UPDATE comments
+                SET body = COALESCE(?, body),
+                    status = COALESCE(?, status),
+                    selectors = COALESCE(?, selectors),
+                    updated_at = ?
+              WHERE id = ?
+          RETURNING *",
+        )
+        .bind(input.body.as_deref())
+        .bind(input.status.map(CommentStatus::as_str))
+        .bind(selectors_json.as_deref())
+        .bind(&now)
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(StoreError::NotFound(id))?;
+
+        Self::row_to_comment(&row)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::error::StoreError;
+    use crate::model::{
+        Author, CommentFilter, CommentStatus, CreateComment, Selector, UpdateComment,
+    };
+
+    async fn store() -> SqliteCommentStore {
+        SqliteCommentStore::open_memory().await.unwrap()
+    }
+
+    fn seed(doc: &str, body: &str) -> CreateComment {
+        CreateComment {
+            document_id: doc.to_owned(),
+            parent_id: None,
+            author: Some(Author::local_human()),
+            body: body.to_owned(),
+            selectors: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_comment() {
+        let store = store().await;
+
+        let input = CreateComment {
+            selectors: vec![Selector::TextQuoteSelector {
+                exact: "some text".to_owned(),
+                prefix: "before ".to_owned(),
+                suffix: " after".to_owned(),
+            }],
+            ..seed("docs/guide.md", "This needs clarification.")
+        };
+
+        let created = store.create(input).await.unwrap();
+        assert_eq!(created.document_id, "docs/guide.md");
+        assert_eq!(created.body, "This needs clarification.");
+        assert_eq!(created.status, CommentStatus::Open);
+        assert_eq!(created.selectors.len(), 1);
+        assert!(created.parent_id.is_none());
+
+        let fetched = store.get(created.id).await.unwrap();
+        assert_eq!(fetched.id, created.id);
+        assert_eq!(fetched.document_id, created.document_id);
+        assert_eq!(fetched.body, created.body);
+        assert_eq!(fetched.selectors, created.selectors);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_document() {
+        let store = store().await;
+
+        store.create(seed("docs/a.md", "Comment A")).await.unwrap();
+        store.create(seed("docs/b.md", "Comment B")).await.unwrap();
+
+        let results = store
+            .list(CommentFilter {
+                document_id: Some("docs/a.md".to_owned()),
+                ..CommentFilter::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].body, "Comment A");
+    }
+
+    #[tokio::test]
+    async fn list_top_level_only_drops_replies() {
+        let store = store().await;
+
+        let parent = store.create(seed("docs/a.md", "root")).await.unwrap();
+        store
+            .create(CreateComment {
+                parent_id: Some(parent.id),
+                ..seed("docs/a.md", "reply")
+            })
+            .await
+            .unwrap();
+
+        let top_level = store
+            .list(CommentFilter {
+                document_id: Some("docs/a.md".to_owned()),
+                top_level_only: true,
+                ..CommentFilter::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(top_level.len(), 1);
+        assert_eq!(top_level[0].body, "root");
+
+        let thread = store
+            .list(CommentFilter {
+                parent_id: Some(parent.id),
+                ..CommentFilter::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(thread.len(), 1);
+        assert_eq!(thread[0].body, "reply");
+    }
+
+    #[tokio::test]
+    async fn test_update_status() {
+        let store = store().await;
+
+        let created = store
+            .create(seed("docs/guide.md", "Fix this."))
+            .await
+            .unwrap();
+
+        assert_eq!(created.status, CommentStatus::Open);
+
+        let updated = store
+            .update(
+                created.id,
+                UpdateComment {
+                    body: None,
+                    status: Some(CommentStatus::Resolved),
+                    selectors: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(updated.status, CommentStatus::Resolved);
+        assert_eq!(updated.body, "Fix this.");
+        assert_eq!(updated.author, Author::local_human());
+    }
+
+    #[tokio::test]
+    async fn test_get_not_found() {
+        let store = store().await;
+        let result = store.get(Uuid::new_v4()).await;
+
+        assert!(matches!(result, Err(StoreError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_author_round_trips_through_create_get_list() {
+        let store = store().await;
+
+        let author = Author {
+            id: "user:default/mike".to_owned(),
+            name: "Mike Yumatov".to_owned(),
+            avatar_url: Some("https://example.com/a.png".to_owned()),
+        };
+
+        let created = store
+            .create(CreateComment {
+                author: Some(author.clone()),
+                ..seed("docs/guide.md", "Hello")
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(created.author, author);
+
+        let fetched = store.get(created.id).await.unwrap();
+        assert_eq!(fetched.author, author);
+
+        let listed = store
+            .list(CommentFilter {
+                document_id: Some("docs/guide.md".to_owned()),
+                ..CommentFilter::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].author, author);
+
+        let created_no_avatar = store.create(seed("docs/guide.md", "Hi")).await.unwrap();
+        assert_eq!(created_no_avatar.author.avatar_url, None);
+        let re_fetched = store.get(created_no_avatar.id).await.unwrap();
+        assert_eq!(re_fetched.author.avatar_url, None);
+    }
+
+    #[test]
+    fn default_path_joins_project_dir() {
+        let p = SqliteCommentStore::default_path(Path::new("/proj/.rw"));
+        assert_eq!(p, PathBuf::from("/proj/.rw/comments/sqlite.db"));
+    }
+}

--- a/crates/rw-server/Cargo.toml
+++ b/crates/rw-server/Cargo.toml
@@ -21,6 +21,7 @@ rw-site = { workspace = true }
 rw-config = { workspace = true }
 rw-embedded-preview = { workspace = true, optional = true }
 rw-renderer = { workspace = true, features = ["serde"] }
+rw-comments = { workspace = true }
 rw-storage = { workspace = true }
 rw-storage-fs = { workspace = true }
 
@@ -42,13 +43,13 @@ serde_json = { workspace = true }
 
 # Utilities
 thiserror = "2"
+uuid = { workspace = true }
 tracing = { workspace = true }
 md-5 = "0.11"
 hex = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 pretty_assertions = { workspace = true }
 tokio-test = "0.4"
 serde_urlencoded = "0.7"

--- a/crates/rw-server/src/app.rs
+++ b/crates/rw-server/src/app.rs
@@ -20,14 +20,19 @@ use crate::static_files;
 ///
 /// * `state` - Shared application state
 pub(crate) fn create_router(state: Arc<AppState>) -> Router {
-    // API routes
-    let api_routes = Router::new()
+    let mut router = Router::new()
         .route("/api/config", get(handlers::config::get_config))
         .route("/api/navigation", get(handlers::navigation::get_navigation))
         .route("/api/pages/", get(handlers::pages::get_root_page))
-        .route("/api/pages/{*path}", get(handlers::pages::get_page));
-
-    let mut router = Router::new().merge(api_routes);
+        .route("/api/pages/{*path}", get(handlers::pages::get_page))
+        .route(
+            "/api/comments",
+            get(handlers::comments::list_comments).post(handlers::comments::create_comment),
+        )
+        .route(
+            "/api/comments/{id}",
+            get(handlers::comments::get_comment).patch(handlers::comments::update_comment),
+        );
 
     // WebSocket for live reload
     if state.live_reload.is_some() {

--- a/crates/rw-server/src/error.rs
+++ b/crates/rw-server/src/error.rs
@@ -21,6 +21,10 @@ pub enum ServerError {
     /// I/O error (bind or serve failure).
     #[error("{0}")]
     Io(#[from] std::io::Error),
+
+    /// Failed to initialize comment store.
+    #[error("failed to initialize comment store: {0}")]
+    CommentStore(#[from] rw_comments::StoreError),
 }
 
 /// Handler error type (internal).

--- a/crates/rw-server/src/handlers/comments.rs
+++ b/crates/rw-server/src/handlers/comments.rs
@@ -1,0 +1,156 @@
+//! Comments API endpoints.
+//!
+//! CRUD handlers for inline comments on documentation pages.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use rw_comments::{
+    Comment, CommentFilter, CreateError, NewComment, QuoteResolutionError, StoreError,
+    UpdateComment,
+};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::state::AppState;
+
+/// HTTP error wrapper for the comments API.
+///
+/// Needed because axum's [`IntoResponse`] can't be implemented directly on the
+/// upstream error types (orphan rule).
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CommentApiError {
+    #[error(transparent)]
+    Store(#[from] StoreError),
+    #[error(transparent)]
+    Create(#[from] CreateError),
+}
+
+impl CommentApiError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::Store(err) | Self::Create(CreateError::Store(err)) => match err {
+                StoreError::NotFound(_) => StatusCode::NOT_FOUND,
+                StoreError::InvalidParent(_) => StatusCode::BAD_REQUEST,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            Self::Create(CreateError::Quote(quote)) => match quote {
+                QuoteResolutionError::DocumentNotFound { .. } => StatusCode::NOT_FOUND,
+                QuoteResolutionError::NotFound { .. } | QuoteResolutionError::Ambiguous { .. } => {
+                    StatusCode::BAD_REQUEST
+                }
+                QuoteResolutionError::RenderFailed { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            Self::Create(CreateError::BothQuoteAndSelectors) => StatusCode::BAD_REQUEST,
+        }
+    }
+}
+
+impl IntoResponse for CommentApiError {
+    fn into_response(self) -> Response {
+        (self.status_code(), Json(json!({"error": self.to_string()}))).into_response()
+    }
+}
+
+/// Handle `GET /api/comments?documentId=...&status=...`.
+pub(crate) async fn list_comments(
+    State(state): State<Arc<AppState>>,
+    Query(filter): Query<CommentFilter>,
+) -> Result<Json<Vec<Comment>>, CommentApiError> {
+    Ok(Json(state.comment_store.list(filter).await?))
+}
+
+/// Handle `POST /api/comments`.
+pub(crate) async fn create_comment(
+    State(state): State<Arc<AppState>>,
+    Json(input): Json<NewComment>,
+) -> Result<(StatusCode, Json<Comment>), CommentApiError> {
+    let comment = rw_comments::create_comment(&state.comment_store, &state.site, input).await?;
+    Ok((StatusCode::CREATED, Json(comment)))
+}
+
+/// Handle `GET /api/comments/{id}`.
+pub(crate) async fn get_comment(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Comment>, CommentApiError> {
+    Ok(Json(state.comment_store.get(id).await?))
+}
+
+/// Handle `PATCH /api/comments/{id}`.
+pub(crate) async fn update_comment(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+    Json(input): Json<UpdateComment>,
+) -> Result<Json<Comment>, CommentApiError> {
+    Ok(Json(state.comment_store.update(id, input).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[test]
+    fn status_code_mapping_covers_all_variants() {
+        use rw_comments::QuoteResolutionError as Quote;
+
+        let from_store = |e: StoreError| CommentApiError::Store(e).status_code();
+        let from_create = |e: CreateError| CommentApiError::Create(e).status_code();
+        let missing_doc = || "doc".to_owned();
+
+        assert_eq!(
+            from_store(StoreError::NotFound(Uuid::nil())),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            from_store(StoreError::InvalidParent("bad parent".to_owned())),
+            StatusCode::BAD_REQUEST,
+        );
+        assert_eq!(
+            from_store(StoreError::CorruptStatus(
+                "bogus".parse::<rw_comments::CommentStatus>().unwrap_err(),
+            )),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
+        assert_eq!(
+            from_create(CreateError::Store(StoreError::NotFound(Uuid::nil()))),
+            StatusCode::NOT_FOUND,
+        );
+        assert_eq!(
+            from_create(CreateError::Quote(Quote::DocumentNotFound {
+                document_id: missing_doc(),
+            })),
+            StatusCode::NOT_FOUND,
+        );
+        assert_eq!(
+            from_create(CreateError::Quote(Quote::NotFound {
+                document_id: missing_doc(),
+            })),
+            StatusCode::BAD_REQUEST,
+        );
+        assert_eq!(
+            from_create(CreateError::Quote(Quote::Ambiguous {
+                document_id: missing_doc(),
+                count: 3,
+            })),
+            StatusCode::BAD_REQUEST,
+        );
+        assert_eq!(
+            from_create(CreateError::Quote(Quote::RenderFailed {
+                document_id: missing_doc(),
+                reason: "boom".to_owned(),
+            })),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        );
+        assert_eq!(
+            from_create(CreateError::BothQuoteAndSelectors),
+            StatusCode::BAD_REQUEST,
+        );
+    }
+}

--- a/crates/rw-server/src/handlers/config.rs
+++ b/crates/rw-server/src/handlers/config.rs
@@ -11,17 +11,23 @@ use serde::Serialize;
 use crate::state::AppState;
 
 /// Response for GET /api/config.
+///
+/// Other backends that share this schema (e.g. the Backstage backend plugin)
+/// set `commentsEnabled` to `false` to opt out.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConfigResponse {
     /// Whether live reload is enabled.
     live_reload_enabled: bool,
+    /// Whether the comments API is available.
+    comments_enabled: bool,
 }
 
 /// Handle GET /api/config.
 pub(crate) async fn get_config(State(state): State<Arc<AppState>>) -> Json<ConfigResponse> {
     Json(ConfigResponse {
         live_reload_enabled: state.live_reload_enabled(),
+        comments_enabled: true,
     })
 }
 
@@ -33,10 +39,12 @@ mod tests {
     fn test_config_response_serialization() {
         let response = ConfigResponse {
             live_reload_enabled: true,
+            comments_enabled: false,
         };
 
         let json = serde_json::to_value(&response).unwrap();
 
         assert_eq!(json["liveReloadEnabled"], true);
+        assert_eq!(json["commentsEnabled"], false);
     }
 }

--- a/crates/rw-server/src/handlers/mod.rs
+++ b/crates/rw-server/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 //! HTTP request handlers.
 
+pub(crate) mod comments;
 pub(crate) mod config;
 pub(crate) mod navigation;
 pub(crate) mod pages;

--- a/crates/rw-server/src/lib.rs
+++ b/crates/rw-server/src/lib.rs
@@ -29,6 +29,7 @@
 //!         live_reload_enabled: true,
 //!         verbose: false,
 //!         version: "1.0.0".to_owned(),
+//!         comments_db: PathBuf::from(".rw/comments/sqlite.db"),
 //!         ..Default::default()
 //!     };
 //!
@@ -63,10 +64,11 @@ mod static_files;
 pub use error::ServerError;
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
+use rw_comments::SqliteCommentStore;
 use rw_site::{PageRendererConfig, Site};
 use rw_storage_fs::FsStorage;
 use state::AppState;
@@ -97,6 +99,8 @@ pub struct ServerConfig {
     pub version: String,
     /// Metadata file name (default: "meta.yaml").
     pub meta_filename: String,
+    /// Path to `SQLite` database for comments.
+    pub comments_db: PathBuf,
     /// Enable embedded preview mode (serves Backstage-like shell at /).
     /// Only available when the `embedded-preview` feature is enabled.
     #[cfg(feature = "embedded-preview")]
@@ -117,6 +121,7 @@ impl Default for ServerConfig {
             verbose: false,
             version: String::new(),
             meta_filename: "meta.yaml".to_owned(),
+            comments_db: SqliteCommentStore::default_path(Path::new(".rw")),
             #[cfg(feature = "embedded-preview")]
             embedded_preview: false,
         }
@@ -164,12 +169,14 @@ pub async fn run_server(config: ServerConfig) -> Result<(), ServerError> {
         None
     };
 
-    // Create app state
+    let comment_store = Arc::new(SqliteCommentStore::open(&config.comments_db).await?);
+
     let state = Arc::new(AppState {
         site,
         live_reload,
         verbose: config.verbose,
         version: config.version.clone(),
+        comment_store,
         #[cfg(feature = "embedded-preview")]
         embedded_preview: config.embedded_preview,
     });
@@ -227,6 +234,7 @@ pub fn server_config_from_rw_config(
         verbose,
         version,
         meta_filename: config.metadata.name.clone(),
+        comments_db: SqliteCommentStore::default_path(&config.docs_resolved.project_dir),
         ..Default::default()
     }
 }

--- a/crates/rw-server/src/state.rs
+++ b/crates/rw-server/src/state.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use rw_comments::SqliteCommentStore;
 use rw_site::Site;
 
 use crate::live_reload::LiveReloadManager;
@@ -18,6 +19,8 @@ pub(crate) struct AppState {
     pub(crate) verbose: bool,
     /// Application version for cache invalidation.
     pub(crate) version: String,
+    /// Comment store.
+    pub(crate) comment_store: Arc<SqliteCommentStore>,
     /// Enable embedded preview page at /.
     #[cfg(feature = "embedded-preview")]
     pub(crate) embedded_preview: bool,

--- a/crates/rw/Cargo.toml
+++ b/crates/rw/Cargo.toml
@@ -21,6 +21,7 @@ embedded-preview = ["rw-server/embedded-preview"]
 
 [dependencies]
 rw-assets = { workspace = true }
+rw-cache = { workspace = true }
 rw-storage-s3 = { workspace = true, features = ["publish"] }
 rw-config = { workspace = true }
 rw-confluence = { workspace = true }
@@ -34,3 +35,10 @@ thiserror = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+rw-comments = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/crates/rw/src/commands/comment/add.rs
+++ b/crates/rw/src/commands/comment/add.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use clap::Args;
+use rw_cache::NullCache;
+use rw_comments::{NewComment, create_comment};
+use rw_config::Config;
+use rw_site::{PageRendererConfig, Site};
+use rw_storage_fs::FsStorage;
+
+use super::{AuthorArgs, Context, OutputArgs, format, identity};
+use crate::error::CliError;
+
+#[derive(Args, Debug)]
+pub(crate) struct AddArgs {
+    #[command(flatten)]
+    pub output: OutputArgs,
+
+    #[command(flatten)]
+    pub author: AuthorArgs,
+
+    /// Document id (URL path without leading slash, e.g. "guide" or
+    /// "domain/billing/overview").
+    #[arg(long)]
+    pub document: String,
+
+    /// Comment body.
+    #[arg(long)]
+    pub body: String,
+
+    /// Anchor text for inline comments. Omit for a page-level comment.
+    #[arg(long)]
+    pub quote: Option<String>,
+}
+
+pub(crate) async fn run(ctx: &Context, args: AddArgs) -> Result<(), CliError> {
+    let AddArgs {
+        output,
+        author,
+        document,
+        body,
+        quote,
+    } = args;
+
+    let author =
+        identity::resolve_author(author.author_id.as_deref(), author.author_name.as_deref())?;
+    let site = build_site(&ctx.config);
+
+    let input = NewComment {
+        document_id: document,
+        parent_id: None,
+        author,
+        body,
+        selectors: None,
+        quote,
+    };
+
+    let comment = create_comment(&ctx.store, &site, input).await?;
+
+    format::print(
+        output.format,
+        |out| {
+            writeln!(
+                out,
+                "Created comment {} on document '{}'.",
+                comment.id, comment.document_id
+            )
+        },
+        &comment,
+    )?;
+
+    Ok(())
+}
+
+fn build_site(config: &Config) -> Site {
+    let storage: Arc<dyn rw_storage::Storage> = Arc::new(FsStorage::with_meta_filename(
+        config.docs_resolved.source_dir.clone(),
+        &config.metadata.name,
+    ));
+    let cache: Arc<dyn rw_cache::Cache> = Arc::new(NullCache);
+    let renderer_config = PageRendererConfig {
+        kroki_url: config.diagrams_resolved.kroki_url.clone(),
+        include_dirs: config.diagrams_resolved.include_dirs.clone(),
+        dpi: config.diagrams_resolved.dpi,
+        ..PageRendererConfig::default()
+    };
+    Site::new(storage, cache, renderer_config)
+}

--- a/crates/rw/src/commands/comment/context.rs
+++ b/crates/rw/src/commands/comment/context.rs
@@ -1,0 +1,19 @@
+use rw_comments::SqliteCommentStore;
+use rw_config::Config;
+
+use crate::error::CliError;
+
+/// Per-invocation context shared across subcommands.
+pub(super) struct Context {
+    pub config: Config,
+    pub store: SqliteCommentStore,
+}
+
+impl Context {
+    pub(super) async fn load() -> Result<Self, CliError> {
+        let config = Config::load(None, None)?;
+        let path = SqliteCommentStore::default_path(&config.docs_resolved.project_dir);
+        let store = SqliteCommentStore::open(&path).await?;
+        Ok(Self { config, store })
+    }
+}

--- a/crates/rw/src/commands/comment/format.rs
+++ b/crates/rw/src/commands/comment/format.rs
@@ -1,0 +1,100 @@
+use std::io::{self, Write};
+
+use rw_comments::{Comment, Selector};
+use serde::Serialize;
+
+use super::OutputFormat;
+
+pub(super) fn print<T: Serialize + ?Sized>(
+    format: OutputFormat,
+    text_writer: impl FnOnce(&mut dyn Write) -> io::Result<()>,
+    json_value: &T,
+) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    match format {
+        OutputFormat::Text => text_writer(&mut out),
+        OutputFormat::Json => {
+            serde_json::to_writer_pretty(&mut out, json_value).map_err(io::Error::other)?;
+            writeln!(out)
+        }
+    }
+}
+
+pub(super) fn write_list(out: &mut dyn Write, comments: &[Comment]) -> io::Result<()> {
+    for comment in comments {
+        writeln!(
+            out,
+            "{:<10}{:<22}{:<10}{:<18}  {}",
+            short_id(comment),
+            comment.document_id,
+            comment.status.as_str(),
+            short_timestamp(&comment.created_at),
+            comment.author.name,
+        )?;
+        if let Some(quote) = first_quote(&comment.selectors) {
+            writeln!(out, "          \"{quote}…\"")?;
+        } else {
+            writeln!(out, "          (page comment)")?;
+        }
+        writeln!(out, "          > {}", comment.body)?;
+        writeln!(out)?;
+    }
+    Ok(())
+}
+
+pub(super) fn write_show(
+    out: &mut dyn Write,
+    parent: &Comment,
+    replies: &[Comment],
+) -> io::Result<()> {
+    writeln!(out, "Thread {} ({})", parent.id, parent.status.as_str())?;
+    writeln!(out, "Document: {}", parent.document_id)?;
+    writeln!(out, "Author:   {}", parent.author.name)?;
+    writeln!(out, "Created:  {}", parent.created_at)?;
+    if let Some(quote) = first_quote(&parent.selectors) {
+        writeln!(out, "Quote:    \"{quote}\"")?;
+    } else {
+        writeln!(out, "(page comment)")?;
+    }
+    writeln!(out)?;
+    writeln!(out, "{}", parent.body)?;
+    for reply in replies {
+        writeln!(out)?;
+        writeln!(
+            out,
+            "  └─ {} ({}) — {}",
+            reply.author.name,
+            reply.created_at,
+            reply.status.as_str()
+        )?;
+        for line in reply.body.lines() {
+            writeln!(out, "     {line}")?;
+        }
+    }
+    Ok(())
+}
+
+fn short_id(comment: &Comment) -> String {
+    format!("{:.8}", comment.id)
+}
+
+/// Trim an RFC-3339 timestamp like `2026-04-17T13:22:54.757497+00:00` down to
+/// `2026-04-17 13:22` for the list view. Falls back to the raw value if the
+/// prefix doesn't look right.
+fn short_timestamp(raw: &str) -> String {
+    if raw.len() >= 16 && raw.as_bytes().get(10) == Some(&b'T') {
+        format!("{} {}", &raw[..10], &raw[11..16])
+    } else {
+        raw.to_owned()
+    }
+}
+
+fn first_quote(selectors: &[Selector]) -> Option<String> {
+    selectors.iter().find_map(|s| match s {
+        Selector::TextQuoteSelector { exact, .. } => {
+            Some(exact.chars().take(60).collect::<String>())
+        }
+        _ => None,
+    })
+}

--- a/crates/rw/src/commands/comment/identity.rs
+++ b/crates/rw/src/commands/comment/identity.rs
@@ -1,0 +1,69 @@
+use rw_comments::Author;
+
+use crate::error::CliError;
+
+/// Resolve an optional author claim.
+///
+/// Returns:
+/// - `Ok(Some(Author))` when both id and name are provided.
+/// - `Ok(None)` when neither is provided (callers fall back to
+///   [`Author::local_human`]).
+/// - `Err(CliError::Validation)` when exactly one of the two is provided.
+pub(crate) fn resolve_author(
+    id: Option<&str>,
+    name: Option<&str>,
+) -> Result<Option<Author>, CliError> {
+    match (id, name) {
+        (Some(id), Some(name)) => Ok(Some(Author {
+            id: id.to_owned(),
+            name: name.to_owned(),
+            avatar_url: None,
+        })),
+        (None, None) => Ok(None),
+        _ => Err(CliError::Validation(
+            "--author-id and --author-name must be set together (or both left unset \
+             to use the default `local:human` identity)"
+                .to_owned(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn both_set_returns_author() {
+        let author = resolve_author(Some("local:claude-code"), Some("Claude Code")).unwrap();
+        assert_eq!(
+            author,
+            Some(Author {
+                id: "local:claude-code".to_owned(),
+                name: "Claude Code".to_owned(),
+                avatar_url: None,
+            })
+        );
+    }
+
+    #[test]
+    fn neither_set_returns_none() {
+        assert_eq!(resolve_author(None, None).unwrap(), None);
+    }
+
+    #[test]
+    fn id_without_name_is_error() {
+        assert!(matches!(
+            resolve_author(Some("local:claude-code"), None),
+            Err(CliError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn name_without_id_is_error() {
+        assert!(matches!(
+            resolve_author(None, Some("Claude Code")),
+            Err(CliError::Validation(_))
+        ));
+    }
+}

--- a/crates/rw/src/commands/comment/list.rs
+++ b/crates/rw/src/commands/comment/list.rs
@@ -1,0 +1,78 @@
+use clap::Args;
+use rw_comments::{CommentFilter, CommentStatus};
+use uuid::Uuid;
+
+use super::{Context, OutputArgs, format};
+use crate::error::CliError;
+
+#[derive(Args, Debug)]
+pub(crate) struct ListArgs {
+    #[command(flatten)]
+    pub output: OutputArgs,
+
+    /// Filter by document id.
+    #[arg(long)]
+    pub document: Option<String>,
+
+    /// Status filter. Default: `open`. Use `all` for no filter.
+    #[arg(long, default_value = "open")]
+    pub status: StatusFilter,
+
+    /// Filter to replies of a specific parent (pass a comment UUID).
+    /// Use `all` to include every comment regardless of depth. Omit the
+    /// flag to keep only top-level threads (no replies).
+    #[arg(long)]
+    pub parent: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+pub(crate) enum StatusFilter {
+    Open,
+    Resolved,
+    All,
+}
+
+impl StatusFilter {
+    fn as_store_filter(self) -> Option<CommentStatus> {
+        match self {
+            StatusFilter::Open => Some(CommentStatus::Open),
+            StatusFilter::Resolved => Some(CommentStatus::Resolved),
+            StatusFilter::All => None,
+        }
+    }
+}
+
+pub(crate) async fn run(ctx: &Context, args: ListArgs) -> Result<(), CliError> {
+    let ListArgs {
+        output,
+        document,
+        status,
+        parent,
+    } = args;
+
+    let mut filter = CommentFilter {
+        document_id: document,
+        status: status.as_store_filter(),
+        ..CommentFilter::default()
+    };
+    match parent.as_deref() {
+        None => filter.top_level_only = true,
+        Some("all") => {}
+        Some(raw) => {
+            filter.parent_id = Some(
+                Uuid::parse_str(raw)
+                    .map_err(|_| CliError::Validation(format!("invalid --parent uuid: {raw}")))?,
+            );
+        }
+    }
+
+    let comments = ctx.store.list(filter).await?;
+
+    format::print(
+        output.format,
+        |out| format::write_list(out, &comments),
+        &comments,
+    )?;
+
+    Ok(())
+}

--- a/crates/rw/src/commands/comment/mod.rs
+++ b/crates/rw/src/commands/comment/mod.rs
@@ -1,0 +1,74 @@
+mod add;
+mod context;
+mod format;
+mod identity;
+mod list;
+mod reply;
+mod resolve;
+mod show;
+
+use clap::{Args, Subcommand};
+
+use crate::error::CliError;
+use context::Context;
+
+/// Output options shared by every `rw comment` subcommand.
+#[derive(Args, Clone, Debug)]
+pub(crate) struct OutputArgs {
+    /// Output format.
+    #[arg(long, default_value = "text")]
+    pub format: OutputFormat,
+}
+
+/// Author claim for subcommands that create new comments.
+#[derive(Args, Clone, Debug)]
+pub(crate) struct AuthorArgs {
+    /// Author id for new comments (omit to use the default `local:human`
+    /// identity).
+    #[arg(long, env = "RW_COMMENT_AUTHOR_ID")]
+    pub author_id: Option<String>,
+
+    /// Author display name for new comments (omit to use the default `You`
+    /// identity).
+    #[arg(long, env = "RW_COMMENT_AUTHOR_NAME")]
+    pub author_name: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, Default, clap::ValueEnum)]
+pub(crate) enum OutputFormat {
+    #[default]
+    Text,
+    Json,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum CommentCommand {
+    /// List comment threads.
+    List(list::ListArgs),
+    /// Show a single comment and its replies.
+    Show(show::ShowArgs),
+    /// Create a new comment.
+    Add(add::AddArgs),
+    /// Reply to an existing comment thread.
+    Reply(reply::ReplyArgs),
+    /// Resolve a comment thread.
+    Resolve(resolve::ResolveArgs),
+}
+
+impl CommentCommand {
+    pub(crate) fn execute(self) -> Result<(), CliError> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        rt.block_on(async move {
+            let ctx = Context::load().await?;
+            match self {
+                Self::List(args) => list::run(&ctx, args).await,
+                Self::Show(args) => show::run(&ctx, args).await,
+                Self::Add(args) => add::run(&ctx, args).await,
+                Self::Reply(args) => reply::run(&ctx, args).await,
+                Self::Resolve(args) => resolve::run(&ctx, args).await,
+            }
+        })
+    }
+}

--- a/crates/rw/src/commands/comment/reply.rs
+++ b/crates/rw/src/commands/comment/reply.rs
@@ -1,0 +1,54 @@
+use clap::Args;
+use rw_comments::CreateComment;
+use uuid::Uuid;
+
+use super::{AuthorArgs, Context, OutputArgs, format, identity};
+use crate::error::CliError;
+
+#[derive(Args, Debug)]
+pub(crate) struct ReplyArgs {
+    #[command(flatten)]
+    pub output: OutputArgs,
+
+    #[command(flatten)]
+    pub author: AuthorArgs,
+
+    /// Id of the comment to reply to.
+    pub parent_id: Uuid,
+
+    /// Reply body.
+    #[arg(long)]
+    pub body: String,
+}
+
+pub(crate) async fn run(ctx: &Context, args: ReplyArgs) -> Result<(), CliError> {
+    let ReplyArgs {
+        output,
+        author,
+        parent_id,
+        body,
+    } = args;
+
+    let author =
+        identity::resolve_author(author.author_id.as_deref(), author.author_name.as_deref())?;
+    let parent = ctx.store.get(parent_id).await?;
+
+    let reply = ctx
+        .store
+        .create(CreateComment {
+            document_id: parent.document_id.clone(),
+            parent_id: Some(parent.id),
+            author,
+            body,
+            selectors: Vec::new(),
+        })
+        .await?;
+
+    format::print(
+        output.format,
+        |out| writeln!(out, "Replied to {} on '{}'.", parent.id, parent.document_id),
+        &reply,
+    )?;
+
+    Ok(())
+}

--- a/crates/rw/src/commands/comment/resolve.rs
+++ b/crates/rw/src/commands/comment/resolve.rs
@@ -1,0 +1,39 @@
+use clap::Args;
+use rw_comments::{CommentStatus, UpdateComment};
+use uuid::Uuid;
+
+use super::{Context, OutputArgs, format};
+use crate::error::CliError;
+
+#[derive(Args, Debug)]
+pub(crate) struct ResolveArgs {
+    #[command(flatten)]
+    pub output: OutputArgs,
+
+    /// Comment id to resolve.
+    pub id: Uuid,
+}
+
+pub(crate) async fn run(ctx: &Context, args: ResolveArgs) -> Result<(), CliError> {
+    let ResolveArgs { output, id } = args;
+
+    let comment = ctx
+        .store
+        .update(
+            id,
+            UpdateComment {
+                body: None,
+                status: Some(CommentStatus::Resolved),
+                selectors: None,
+            },
+        )
+        .await?;
+
+    format::print(
+        output.format,
+        |out| writeln!(out, "Resolved {}.", comment.id),
+        &comment,
+    )?;
+
+    Ok(())
+}

--- a/crates/rw/src/commands/comment/show.rs
+++ b/crates/rw/src/commands/comment/show.rs
@@ -1,0 +1,46 @@
+use clap::Args;
+use rw_comments::{Comment, CommentFilter};
+use serde::Serialize;
+use uuid::Uuid;
+
+use super::{Context, OutputArgs, format};
+use crate::error::CliError;
+
+#[derive(Args, Debug)]
+pub(crate) struct ShowArgs {
+    #[command(flatten)]
+    pub output: OutputArgs,
+
+    /// Comment id to show.
+    pub id: Uuid,
+}
+
+#[derive(Debug, Serialize)]
+struct ShowPayload<'a> {
+    comment: &'a Comment,
+    replies: &'a [Comment],
+}
+
+pub(crate) async fn run(ctx: &Context, args: ShowArgs) -> Result<(), CliError> {
+    let ShowArgs { output, id } = args;
+
+    let parent = ctx.store.get(id).await?;
+    let replies = ctx
+        .store
+        .list(CommentFilter {
+            parent_id: Some(parent.id),
+            ..CommentFilter::default()
+        })
+        .await?;
+
+    format::print(
+        output.format,
+        |out| format::write_show(out, &parent, &replies),
+        &ShowPayload {
+            comment: &parent,
+            replies: &replies,
+        },
+    )?;
+
+    Ok(())
+}

--- a/crates/rw/src/commands/mod.rs
+++ b/crates/rw/src/commands/mod.rs
@@ -1,9 +1,11 @@
 //! CLI command implementations.
 
 pub(crate) mod backstage;
+pub(crate) mod comment;
 pub(crate) mod confluence;
 pub(crate) mod serve;
 pub(crate) use backstage::BackstageCommand;
+pub(crate) use comment::CommentCommand;
 pub(crate) use confluence::ConfluenceCommand;
 pub(crate) use serve::ServeArgs;
 

--- a/crates/rw/src/error.rs
+++ b/crates/rw/src/error.rs
@@ -1,5 +1,6 @@
 //! CLI error types.
 
+use rw_comments::{CreateError, QuoteResolutionError, StoreError};
 use rw_config::ConfigError;
 use rw_confluence::{ConfluenceError, UpdateError};
 use rw_server::ServerError;
@@ -27,4 +28,39 @@ pub(crate) enum CliError {
 
     #[error("{0}")]
     Validation(String),
+
+    #[error(transparent)]
+    Store(#[from] StoreError),
+
+    #[error(transparent)]
+    QuoteResolution(#[from] QuoteResolutionError),
+}
+
+impl From<CreateError> for CliError {
+    fn from(err: CreateError) -> Self {
+        match err {
+            CreateError::Store(e) => CliError::Store(e),
+            CreateError::Quote(e) => CliError::QuoteResolution(e),
+            e @ CreateError::BothQuoteAndSelectors => CliError::Validation(e.to_string()),
+        }
+    }
+}
+
+impl CliError {
+    /// Exit code category:
+    /// - `3` — validation / caller error (bad flags, ambiguous quote, etc.)
+    /// - `2` — referenced entity does not exist
+    /// - `1` — anything else
+    pub(crate) fn exit_code(&self) -> i32 {
+        match self {
+            CliError::Validation(_)
+            | CliError::Store(StoreError::InvalidParent(_))
+            | CliError::QuoteResolution(
+                QuoteResolutionError::NotFound { .. } | QuoteResolutionError::Ambiguous { .. },
+            ) => 3,
+            CliError::Store(StoreError::NotFound(_))
+            | CliError::QuoteResolution(QuoteResolutionError::DocumentNotFound { .. }) => 2,
+            _ => 1,
+        }
+    }
 }

--- a/crates/rw/src/main.rs
+++ b/crates/rw/src/main.rs
@@ -5,6 +5,7 @@
 //! - `backstage publish`: Publish documentation bundles to S3 for Backstage
 //! - `confluence update`: Update Confluence pages from markdown
 //! - `confluence generate-tokens`: Generate OAuth access tokens
+//! - `comment`: Read and write comments directly against the local `SQLite` store
 
 mod commands;
 mod error;
@@ -13,7 +14,7 @@ mod output;
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
-use commands::{BackstageCommand, ConfluenceCommand, ServeArgs};
+use commands::{BackstageCommand, CommentCommand, ConfluenceCommand, ServeArgs};
 use output::Output;
 
 /// Application version from Cargo.toml.
@@ -37,6 +38,9 @@ enum Commands {
     /// Confluence publishing commands.
     #[command(subcommand)]
     Confluence(ConfluenceCommand),
+    /// Read and write inline comments on project docs (for scripts and LLM agents).
+    #[command(subcommand)]
+    Comment(CommentCommand),
 }
 
 fn main() {
@@ -62,10 +66,11 @@ fn main() {
         }
         Commands::Backstage(cmd) => cmd.execute(),
         Commands::Confluence(cmd) => cmd.execute(),
+        Commands::Comment(cmd) => cmd.execute(),
     };
 
     if let Err(err) = result {
         output.error(&format!("Error: {err}"));
-        std::process::exit(1);
+        std::process::exit(err.exit_code());
     }
 }

--- a/docs/comment-cli.md
+++ b/docs/comment-cli.md
@@ -1,0 +1,114 @@
+# `rw comment` CLI
+
+Read and write comments in a project's `.rw/comments/sqlite.db` from scripts and LLM agents (Claude Code, Cursor, etc.). The CLI opens the SQLite store directly — `rw serve` can be running or not; both processes can safely share the database (SQLite WAL).
+
+## Subcommands
+
+### `rw comment list`
+
+List comment threads. Defaults to **open only**; client-side filter keeps top-level threads only (no replies) unless you pass `--parent`.
+
+```
+rw comment list [--document DOC] [--status open|resolved|all] [--parent ID|all]
+```
+
+Example:
+
+```
+rw comment list --document guide --status open
+```
+
+### `rw comment show`
+
+Print a single thread — parent plus all replies — in text or JSON.
+
+```
+rw comment show <id>
+```
+
+### `rw comment add`
+
+Create a new top-level comment. Page-level by default; pass `--quote "passage text"` to anchor it inline to a passage in the rendered page (see Anchoring below).
+
+```
+rw comment add --document DOC --body BODY [--quote "anchor text"]
+```
+
+Example:
+
+```
+rw comment add --document guide --quote "The quick brown fox" \
+               --body "Can we add an example here?"
+```
+
+### `rw comment reply`
+
+Reply to an existing thread. You only need the parent id — the CLI looks up the thread's document.
+
+```
+rw comment reply <parent-id> --body BODY
+```
+
+### `rw comment resolve`
+
+Mark a thread resolved.
+
+```
+rw comment resolve <id>
+```
+
+## Identity
+
+New comments carry an `author` stamp. Resolution order:
+
+1. `--author-id` and `--author-name` flags on the subcommand.
+2. `$RW_COMMENT_AUTHOR_ID` and `$RW_COMMENT_AUTHOR_NAME` env vars.
+3. If both are unset, the CLI writes the comment with the default identity `{ id: "local:human", name: "You" }`. (This is the same default `rw serve` uses when the browser writes a comment — viewer and CLI stay aligned.)
+
+Set both or neither — a partial identity (e.g. id without name) is rejected before the request leaves the CLI.
+
+Recommended for LLM agents: export the env vars once (in `.claude/settings.json` or your shell profile) and let every `rw comment` invocation pick them up:
+
+```
+export RW_COMMENT_AUTHOR_ID=local:claude-code
+export RW_COMMENT_AUTHOR_NAME="Claude Code"
+```
+
+## Anchoring with `--quote`
+
+When you pass `--quote "..."` to `rw comment add`, the CLI:
+
+1. Renders the referenced page.
+2. Flattens the rendered HTML to a `textContent`-equivalent string (matches what the browser anchoring sees).
+3. Searches for the quote as an **exact substring**.
+4. Builds a `TextQuoteSelector` (with 32 chars of prefix/suffix context) plus a `TextPositionSelector`.
+
+**Zero matches** → exit code 3, error `"quote not found in document 'X'"`. The quote must appear as rendered text — `**bold**` is not in the rendered output, `bold` is.
+
+**Multiple matches** → exit code 3, error `"quote matches N times in document 'X' — add more surrounding context to disambiguate"`. Quote more surrounding text to pin the occurrence you want.
+
+`--quote` and explicit selectors are mutually exclusive.
+
+## Output format
+
+`--format text` (default) is human-readable. `--format json` emits the raw API shape — for `show`, `{ "comment": Comment, "replies": [Comment, …] }`.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | Success |
+| 1    | Internal error (store I/O, render failure, unexpected) |
+| 2    | Comment not found (`show`, `resolve`, `reply <missing-parent>`) |
+| 3    | Validation error (quote not found or ambiguous, document not found, invalid --parent uuid, mutually exclusive flags, partial identity) |
+
+Shell example:
+
+```
+if ! rw comment add --document guide --quote "foo" --body "…"; then
+  case $? in
+    3) echo "bad quote, missing document, or invalid flags — see stderr" ;;
+    *) echo "something went wrong — see stderr" ;;
+  esac
+fi
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -4032,6 +4032,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -5108,6 +5114,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.6.3",
@@ -8084,7 +8096,9 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/roboto": "^5.2.9"
+        "@fontsource/roboto": "^5.2.9",
+        "@types/diff-match-patch": "^1.0.36",
+        "diff-match-patch": "^1.0.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -8108,7 +8122,7 @@
         "tailwindcss": "^4.0.0",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.56.1",
-        "vite": "^8.0.7",
+        "vite": "^8.0.0",
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^4.0.15"
       },

--- a/packages/viewer/e2e/comments.spec.ts
+++ b/packages/viewer/e2e/comments.spec.ts
@@ -1,0 +1,629 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Wide viewport so the right sidebar (TOC / comments) is visible
+test.use({ viewport: { width: 1400, height: 800 } });
+
+// All comment tests share a single SQLite DB and operate on the homepage
+// (documentId ""), so running describe blocks in parallel would let one block's
+// beforeEach `resolveAllComments` close another block's in-flight comments.
+// Serialize everything in this file to keep tests isolated.
+test.describe.configure({ mode: "serial" });
+
+/** Select a text range inside the article and trigger the selection popover. */
+async function selectText(page: Page, text: string) {
+  await page.evaluate((targetText) => {
+    const article = document.querySelector("article");
+    if (!article) throw new Error("no article");
+    const walker = document.createTreeWalker(article, NodeFilter.SHOW_TEXT);
+    while (walker.nextNode()) {
+      const content = walker.currentNode.textContent ?? "";
+      const idx = content.indexOf(targetText);
+      if (idx === -1) continue;
+
+      const range = document.createRange();
+      range.setStart(walker.currentNode, idx);
+      range.setEnd(walker.currentNode, idx + targetText.length);
+      const selection = window.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+
+      const rect = range.getBoundingClientRect();
+      article.dispatchEvent(
+        new MouseEvent("mouseup", {
+          bubbles: true,
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + rect.height / 2,
+        }),
+      );
+      return;
+    }
+    throw new Error(`text "${targetText}" not found in article`);
+  }, text);
+}
+
+/** Activate comments sidebar by clicking the highlighted text. */
+async function clickHighlight(page: Page, text: string) {
+  // Wait for highlights to be registered first
+  await waitForHighlights(page);
+
+  // Scroll the target text into view — comment creation may have scrolled the page
+  await page.evaluate((targetText) => {
+    const article = document.querySelector("article");
+    if (!article) throw new Error("no article");
+    const walker = document.createTreeWalker(article, NodeFilter.SHOW_TEXT);
+    while (walker.nextNode()) {
+      const content = walker.currentNode.textContent ?? "";
+      const idx = content.indexOf(targetText);
+      if (idx === -1) continue;
+      const node = walker.currentNode;
+      const range = document.createRange();
+      range.setStart(node, idx);
+      range.setEnd(node, idx + targetText.length);
+      // Scroll into viewport center
+      const el = range.startContainer.parentElement;
+      el?.scrollIntoView({ block: "center" });
+      return;
+    }
+    throw new Error(`text "${targetText}" not found`);
+  }, text);
+
+  // Small delay for scroll to settle, then get viewport coordinates
+  await page.waitForTimeout(100);
+
+  const clickCoords = await page.evaluate((targetText) => {
+    const article = document.querySelector("article");
+    if (!article) throw new Error("no article");
+    const walker = document.createTreeWalker(article, NodeFilter.SHOW_TEXT);
+    while (walker.nextNode()) {
+      const content = walker.currentNode.textContent ?? "";
+      const idx = content.indexOf(targetText);
+      if (idx === -1) continue;
+      const range = document.createRange();
+      range.setStart(walker.currentNode, idx + 1);
+      range.setEnd(walker.currentNode, idx + 2);
+      const rect = range.getBoundingClientRect();
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    }
+    throw new Error(`text "${targetText}" not found`);
+  }, text);
+
+  await page.mouse.click(clickCoords.x, clickCoords.y);
+}
+
+/** Wait for CSS Custom Highlights to be registered (comments loaded and anchored). */
+async function waitForHighlights(page: Page) {
+  await expect(async () => {
+    const has = await page.evaluate(
+      () => typeof CSS !== "undefined" && "highlights" in CSS && CSS.highlights.has("rw-comments"),
+    );
+    expect(has).toBe(true);
+  }).toPass({ timeout: 10000 });
+}
+
+/** Create a comment on the given text via the UI (select + popover + form). */
+async function createCommentViaUI(page: Page, targetText: string, body: string) {
+  await selectText(page, targetText);
+  await page.getByRole("button", { name: "Add comment" }).click();
+  const sidebar = page.getByRole("complementary", { name: "Comments" });
+  await sidebar.getByPlaceholder("Write a comment...").fill(body);
+  await sidebar.getByRole("button", { name: "Comment", exact: true }).click();
+  // Wait for form to close
+  await expect(sidebar.getByPlaceholder("Write a comment...")).not.toBeVisible();
+}
+
+/** Resolve all comments for a document via the API so they don't interfere with new tests. */
+async function resolveAllComments(page: Page, documentId: string) {
+  await page.evaluate(async (docId) => {
+    const res = await fetch(`/api/comments?documentId=${encodeURIComponent(docId)}`);
+    const comments = await res.json();
+    for (const c of comments) {
+      if (c.status === "open") {
+        await fetch(`/api/comments/${c.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "resolved" }),
+        });
+      }
+    }
+  }, documentId);
+}
+
+test.describe("Inline comments", () => {
+  // Tests share a single SQLite DB, so run serially to avoid conflicts
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
+    // Resolve all comments from previous test runs so they don't interfere
+    await page.goto("/");
+    await resolveAllComments(page, "");
+  });
+
+  test("selecting text shows the comment popover", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    await selectText(page, "Navigation sidebar");
+
+    const commentButton = page.getByRole("button", { name: "Add comment" });
+    await expect(commentButton).toBeVisible();
+  });
+
+  test("clicking the selected text dismisses the comment popover", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    await selectText(page, "Navigation sidebar");
+
+    const commentButton = page.getByRole("button", { name: "Add comment" });
+    await expect(commentButton).toBeVisible();
+
+    // Real mouse click — Playwright's page.mouse fires native events so the
+    // browser performs its default click-on-selection collapse. The synthetic
+    // event used by selectText() can't reproduce that.
+    const clickPoint = await page.evaluate((targetText) => {
+      const article = document.querySelector("article")!;
+      const walker = document.createTreeWalker(article, NodeFilter.SHOW_TEXT);
+      while (walker.nextNode()) {
+        const idx = (walker.currentNode.textContent ?? "").indexOf(targetText);
+        if (idx === -1) continue;
+        const range = document.createRange();
+        range.setStart(walker.currentNode, idx);
+        range.setEnd(walker.currentNode, idx + targetText.length);
+        const rect = range.getBoundingClientRect();
+        return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+      }
+      throw new Error(`text "${targetText}" not found`);
+    }, "Navigation sidebar");
+
+    await page.mouse.click(clickPoint.x, clickPoint.y);
+
+    await expect(commentButton).not.toBeVisible();
+  });
+
+  test("creating a comment via the popover", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // Select text and open the comment form
+    await selectText(page, "code highlighting");
+    await page.getByRole("button", { name: "Add comment" }).click();
+
+    // Fill in and submit the comment
+    const sidebar = page.getByRole("complementary", { name: "Comments" });
+    const textarea = sidebar.getByPlaceholder("Write a comment...");
+    await expect(textarea).toBeVisible();
+    await textarea.fill("Needs more detail on syntax highlighting");
+    await sidebar.getByRole("button", { name: "Comment", exact: true }).click();
+
+    // Form should disappear
+    await expect(textarea).not.toBeVisible();
+
+    // Thread card shows the server-stamped author
+    await expect(sidebar.getByText("You", { exact: true })).toBeVisible();
+
+    // Comment should be persisted via the API
+    const comments = await page.evaluate(async () => {
+      const res = await fetch("/api/comments?documentId=&status=open");
+      return res.json();
+    });
+    const created = comments.find(
+      (c: { body: string }) => c.body === "Needs more detail on syntax highlighting",
+    );
+    expect(created).toBeTruthy();
+    expect(created.selectors).toHaveLength(2);
+  });
+
+  test("comment created via UI has correct selectors and is retrievable", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // Create a comment via the UI
+    await selectText(page, "code highlighting");
+    await page.getByRole("button", { name: "Add comment" }).click();
+    const sidebar = page.getByRole("complementary", { name: "Comments" });
+    await sidebar.getByPlaceholder("Write a comment...").fill("Check highlight");
+    await sidebar.getByRole("button", { name: "Comment", exact: true }).click();
+
+    // Verify via API that the comment has both selector types
+    const comments = await page.evaluate(async () => {
+      const res = await fetch("/api/comments?documentId=&status=open");
+      return res.json();
+    });
+    const created = comments.find((c: { body: string }) => c.body === "Check highlight");
+    expect(created).toBeTruthy();
+    const types = created.selectors.map((s: { type: string }) => s.type);
+    expect(types).toContain("TextQuoteSelector");
+    expect(types).toContain("TextPositionSelector");
+
+    // Verify the TextQuoteSelector captured the right text
+    const quote = created.selectors.find((s: { type: string }) => s.type === "TextQuoteSelector");
+    expect(quote.exact).toBe("code highlighting");
+  });
+
+  test("clicking a highlight replaces TOC with comments sidebar", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // TOC should be visible initially
+    const tocSidebar = page.getByRole("complementary", { name: "Page outline" });
+    await expect(tocSidebar).toBeVisible();
+
+    // Create a comment via UI. Creation activates the new thread, so dismiss
+    // it via the close button to restore the TOC before we test click-to-activate.
+    await createCommentViaUI(page, "code highlighting", "Review this section");
+    const commentsSidebar = page.getByRole("complementary", { name: "Comments" });
+    await expect(commentsSidebar).toBeVisible();
+    await commentsSidebar.getByRole("button", { name: "Close comment", exact: true }).click();
+    await expect(tocSidebar).toBeVisible();
+
+    // Click on the highlighted text
+    await clickHighlight(page, "code highlighting");
+
+    // Comments sidebar should replace TOC
+    await expect(commentsSidebar).toBeVisible();
+    await expect(commentsSidebar).toContainText("Review this section");
+
+    // TOC should be gone
+    await expect(tocSidebar).not.toBeVisible();
+  });
+
+  test("close button dismisses comments and restores TOC", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // createCommentViaUI leaves the new thread active — sidebar is already visible.
+    await createCommentViaUI(page, "code highlighting", "Some comment");
+    const commentsSidebar = page.getByRole("complementary", { name: "Comments" });
+    await expect(commentsSidebar).toBeVisible();
+
+    // Click the close button on the comment card
+    await commentsSidebar.getByRole("button", { name: "Close comment", exact: true }).click();
+
+    // TOC should be restored
+    const tocSidebar = page.getByRole("complementary", { name: "Page outline" });
+    await expect(tocSidebar).toBeVisible();
+    await expect(commentsSidebar).not.toBeVisible();
+  });
+
+  test("resolving a comment updates its status", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // createCommentViaUI leaves the new thread active — sidebar is already visible.
+    await createCommentViaUI(page, "code highlighting", "Fix this text");
+    const commentsSidebar = page.getByRole("complementary", { name: "Comments" });
+    await expect(commentsSidebar).toBeVisible();
+
+    // Click Resolve
+    await commentsSidebar.getByRole("button", { name: "Resolve", exact: true }).click();
+
+    // Should now show Reopen instead of Resolve
+    await expect(
+      commentsSidebar.getByRole("button", { name: "Reopen", exact: true }),
+    ).toBeVisible();
+  });
+
+  test("cancel button dismisses the comment form", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    await selectText(page, "Navigation sidebar");
+    await page.getByRole("button", { name: "Add comment" }).click();
+
+    const sidebar = page.getByRole("complementary", { name: "Comments" });
+    const textarea = sidebar.getByPlaceholder("Write a comment...");
+    await expect(textarea).toBeVisible();
+
+    // Focus the textarea so the Cancel/Comment buttons render (the form collapses
+    // those actions when idle; autofocus doesn't fire reliably in headless).
+    await textarea.focus();
+    await sidebar.getByRole("button", { name: "Cancel" }).click();
+    await expect(textarea).not.toBeVisible();
+  });
+
+  test("replying to a comment shows the reply in the thread", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // Create a top-level comment — leaves the new thread active, sidebar visible.
+    await createCommentViaUI(page, "code highlighting", "Parent comment");
+    const commentsSidebar = page.getByRole("complementary", { name: "Comments" });
+    await expect(commentsSidebar).toContainText("Parent comment");
+
+    // Submit a reply
+    const replyTextarea = commentsSidebar.getByPlaceholder("Write a reply...");
+    await replyTextarea.fill("Reply to parent");
+    await replyTextarea.press("Meta+Enter");
+
+    // Reply should appear in the thread
+    await expect(commentsSidebar).toContainText("Reply to parent");
+
+    // Verify via API that the reply has the correct parentId
+    const comments = await page.evaluate(async () => {
+      const res = await fetch("/api/comments?documentId=&status=open");
+      return res.json();
+    });
+    const parent = comments.find((c: { body: string }) => c.body === "Parent comment");
+    const reply = comments.find((c: { body: string }) => c.body === "Reply to parent");
+    expect(parent).toBeTruthy();
+    expect(reply).toBeTruthy();
+    expect(reply.parentId).toBe(parent.id);
+  });
+
+  test("comments persist in the database", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // createCommentViaUI leaves the new thread active — sidebar is already visible.
+    await createCommentViaUI(page, "code highlighting", "Persistent comment");
+    await expect(page.getByRole("complementary", { name: "Comments" })).toContainText(
+      "Persistent comment",
+    );
+
+    // Verify the comment survives in the database after a full page load
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    const comments = await page.evaluate(async () => {
+      const res = await fetch("/api/comments?documentId=&status=open");
+      return res.json();
+    });
+    const persisted = comments.find((c: { body: string }) => c.body === "Persistent comment");
+    expect(persisted).toBeTruthy();
+    expect(persisted.selectors).toHaveLength(2);
+  });
+});
+
+test.describe("Page comments", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await resolveAllComments(page, "");
+  });
+
+  test("page comments section is visible below article", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    const section = page.getByRole("region", { name: "Page comments" });
+    await expect(section).toBeVisible();
+    await expect(section.getByPlaceholder("Write a comment...")).toBeVisible();
+  });
+
+  test("creating a page comment via the form", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    const section = page.getByRole("region", { name: "Page comments" });
+    await section.getByPlaceholder("Write a comment...").fill("A page-level comment");
+    await section.getByRole("button", { name: "Comment", exact: true }).click();
+
+    // Comment should appear in the section
+    await expect(section).toContainText("A page-level comment");
+    await expect(section.getByText("You", { exact: true })).toBeVisible();
+
+    // Verify via API — should have no selectors
+    const comments = await page.evaluate(async () => {
+      const res = await fetch("/api/comments?documentId=&status=open");
+      return res.json();
+    });
+    const created = comments.find((c: { body: string }) => c.body === "A page-level comment");
+    expect(created).toBeTruthy();
+    expect(created.selectors).toHaveLength(0);
+    expect(created.parentId).toBeUndefined();
+  });
+
+  test("replying to a page comment", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // Create a page comment
+    const section = page.getByRole("region", { name: "Page comments" });
+    await section.getByPlaceholder("Write a comment...").fill("Top-level page comment");
+    await section.getByRole("button", { name: "Comment", exact: true }).click();
+    await expect(section).toContainText("Top-level page comment");
+
+    // Reply to it
+    const replyInput = section.getByPlaceholder("Write a reply...");
+    await replyInput.fill("Reply to page comment");
+    await replyInput.press("Meta+Enter");
+
+    // Reply should appear
+    await expect(section).toContainText("Reply to page comment");
+
+    // Verify via API — find the reply and check its parentId
+    const comments = await page.evaluate(async () => {
+      const res = await fetch("/api/comments?documentId=");
+      return res.json();
+    });
+    const reply = comments.find(
+      (c: { body: string; parentId?: string }) => c.body === "Reply to page comment" && c.parentId,
+    );
+    expect(reply).toBeTruthy();
+    // The parent should exist and be a page comment (no selectors)
+    const parent = comments.find((c: { id: string }) => c.id === reply.parentId);
+    expect(parent).toBeTruthy();
+    expect(parent.body).toBe("Top-level page comment");
+    expect(parent.selectors).toHaveLength(0);
+  });
+
+  test("resolving a page comment hides it", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // Create a page comment
+    const section = page.getByRole("region", { name: "Page comments" });
+    await section.getByPlaceholder("Write a comment...").fill("Comment to resolve");
+    await section.getByRole("button", { name: "Comment", exact: true }).click();
+    await expect(section).toContainText("Comment to resolve");
+
+    // Resolve it
+    await section.getByRole("button", { name: "Resolve", exact: true }).click();
+
+    // Should no longer be visible (resolved threads are hidden)
+    await expect(section.getByText("Comment to resolve")).not.toBeVisible();
+  });
+
+  test("inline comment whose passage is gone surfaces in the page comments timeline", async ({
+    page,
+  }) => {
+    // Simulate a comment whose stored passage no longer exists in the doc by
+    // POSTing explicit selectors with an `exact` string that doesn't match any
+    // text on the page. This is what live-reload after a content edit looks
+    // like to the viewer: stored selectors that can't be re-anchored.
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    await page.evaluate(async () => {
+      await fetch("/api/comments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          documentId: "",
+          body: "This paragraph needs a rewrite",
+          selectors: [
+            {
+              type: "TextQuoteSelector",
+              exact: "a sentence that definitely is not on this page",
+              prefix: "context before ",
+              suffix: " context after",
+            },
+          ],
+        }),
+      });
+    });
+
+    // Reload so the viewer picks up the new comment via its load path.
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    const section = page.getByRole("region", { name: "Page comments" });
+    await expect(section).toContainText("This paragraph needs a rewrite");
+
+    // Quote context is shown with the stored exact text and its surrounding
+    // prefix/suffix, so reviewers can still tell what the comment referred to.
+    const quote = section.getByTestId("orphan-quote");
+    await expect(quote).toBeVisible();
+    await expect(quote).toContainText("context before");
+    await expect(quote).toContainText("a sentence that definitely is not on this page");
+    await expect(quote).toContainText("context after");
+
+    // The orphan must not inflate the inline sidebar's prev/next counter.
+    // Create a real inline comment and check that the sidebar counter is 1/1.
+    await createCommentViaUI(page, "code highlighting", "Real inline");
+    const sidebar = page.getByRole("complementary", { name: "Comments" });
+    await expect(sidebar).toBeVisible();
+    // nav strip only renders when there are 2+ inline threads, so its absence
+    // is the signal that the orphan was excluded from inline navigation.
+    await expect(sidebar.getByRole("button", { name: "Previous comment" })).toHaveCount(0);
+    await expect(sidebar.getByRole("button", { name: "Next comment" })).toHaveCount(0);
+  });
+});
+
+test.describe("Comment anchor alignment", () => {
+  // Tests share a single SQLite DB, so run serially to avoid conflicts
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
+    // Resolve any open comments from previous tests
+    await page.goto("/");
+    await resolveAllComments(page, "");
+  });
+
+  test("activated thread: avatar row vertical center aligns with highlight first-line center", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // Seed an inline comment — createCommentViaUI leaves it active afterward,
+    // so the active-highlight is already set when we measure below.
+    await createCommentViaUI(page, "code highlighting", "Alignment check");
+
+    // Confirm the comments sidebar is showing an active thread
+    const sidebar = page.getByRole("complementary", { name: "Comments" });
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar.getByTestId("comment-avatar-row").first()).toBeVisible();
+
+    const highlightMiddle = await page.evaluate(() => {
+      const highlights = CSS.highlights as unknown as Map<string, Highlight>;
+      const highlight = highlights.get("rw-comment-active");
+      if (!highlight) throw new Error("no active highlight");
+      const range = [...highlight][0] as Range;
+      const firstLine = range.getClientRects()[0] ?? range.getBoundingClientRect();
+      return firstLine.top + firstLine.height / 2;
+    });
+
+    const rowBox = await page.getByTestId("comment-avatar-row").first().boundingBox();
+    if (!rowBox) throw new Error("no avatar row bbox");
+    const center = rowBox.y + rowBox.height / 2;
+
+    expect(Math.abs(center - highlightMiddle)).toBeLessThanOrEqual(2);
+  });
+
+  test("two threads: alignment holds after creating a second comment (nav variant switch)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    // Seed a first inline comment on "code highlighting" — leaves it active afterward
+    await createCommentViaUI(page, "code highlighting", "first");
+
+    // Dismiss the active thread so we can start a fresh selection
+    await page
+      .getByRole("complementary", { name: "Comments" })
+      .getByRole("button", {
+        name: "Close comment",
+        exact: true,
+      })
+      .click();
+
+    // Create a second comment on a different phrase — the first thread now gains
+    // a prev/next nav strip (2 inline threads total).
+    await createCommentViaUI(page, "Navigation sidebar", "second");
+
+    // Activate the first comment — its header now has the nav variant.
+    await clickHighlight(page, "code highlighting");
+
+    const highlightMiddle = await page.evaluate(() => {
+      const highlights = CSS.highlights as unknown as Map<string, Highlight>;
+      const highlight = highlights.get("rw-comment-active");
+      if (!highlight) throw new Error("no active highlight");
+      const range = [...highlight][0] as Range;
+      const firstLine = range.getClientRects()[0] ?? range.getBoundingClientRect();
+      return firstLine.top + firstLine.height / 2;
+    });
+
+    const rowBox = await page.getByTestId("comment-avatar-row").first().boundingBox();
+    if (!rowBox) throw new Error("no row bbox after second comment");
+    const center = rowBox.y + rowBox.height / 2;
+
+    expect(Math.abs(center - highlightMiddle)).toBeLessThanOrEqual(2);
+  });
+
+  test("pending form: textarea content-box top aligns with selection top", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("article").waitFor();
+
+    await selectText(page, "Navigation sidebar");
+    const selectionTop = await page.evaluate(() => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) throw new Error("no selection");
+      return sel.getRangeAt(0).getBoundingClientRect().top;
+    });
+    await page.getByRole("button", { name: /add comment/i }).click();
+
+    const textarea = page.getByRole("complementary", { name: "Comments" }).getByRole("textbox");
+    await textarea.waitFor({ state: "visible" });
+
+    const offset = await textarea.evaluate((ta: HTMLTextAreaElement) => {
+      const rect = ta.getBoundingClientRect();
+      const padding = parseFloat(getComputedStyle(ta).paddingTop) || 0;
+      return rect.top + padding;
+    });
+
+    expect(Math.abs(offset - selectionTop)).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/viewer/e2e/embedded-layout.spec.ts
+++ b/packages/viewer/e2e/embedded-layout.spec.ts
@@ -102,8 +102,8 @@ test.describe("Embedded Layout", () => {
   });
 
   test("table of contents is visible on wide viewport", async ({ page }) => {
-    // The TOC shows at container-width >= 1224px. The embedded preview shell
-    // has a 250px sidebar, so we need viewport >= 1224 + 250 = 1474px.
+    // The TOC shows at container-width >= 1304px. The embedded preview shell
+    // has a 250px sidebar, so we need viewport >= 1304 + 250 = 1554px.
     await page.setViewportSize({ width: 1600, height: 800 });
     await page.goto("/");
 

--- a/packages/viewer/e2e/page-content.spec.ts
+++ b/packages/viewer/e2e/page-content.spec.ts
@@ -19,6 +19,9 @@ test.describe("ToC sticky behavior", () => {
 });
 
 test.describe("Page Content", () => {
+  // Wide enough for the ToC sidebar to render (breakpoint: 1304px)
+  test.use({ viewport: { width: 1400, height: 720 } });
+
   test("renders markdown content with headings", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/viewer/e2e/toc-popover.spec.ts
+++ b/packages/viewer/e2e/toc-popover.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 // Viewport wide enough for desktop sidebar (>=952px) but narrow enough
-// to hide the TOC sidebar (<1224px), so the popover button appears.
+// to hide the TOC sidebar (<1304px), so the popover button appears.
 test.use({ viewport: { width: 1100, height: 800 } });
 
 test.describe("TOC Popover", () => {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -64,6 +64,8 @@
   },
   "dependencies": {
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/roboto": "^5.2.9"
+    "@fontsource/roboto": "^5.2.9",
+    "@types/diff-match-patch": "^1.0.36",
+    "diff-match-patch": "^1.0.5"
   }
 }

--- a/packages/viewer/src/App.svelte
+++ b/packages/viewer/src/App.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { untrack } from "svelte";
   import { createApiClient } from "./api/client";
+  import { createCommentApiClient } from "./api/comments";
   import { Router } from "./state/router.svelte";
   import { Page as PageState } from "./state/page.svelte";
   import { Navigation } from "./state/navigation.svelte";
   import { LiveReload } from "./state/liveReload.svelte";
   import { Ui } from "./state/ui.svelte";
+  import { Comments } from "./state/comments.svelte";
   import { setRwContext } from "./lib/context";
   import type { ConfigResponse } from "./types";
   import Layout from "./components/Layout.svelte";
@@ -66,6 +68,11 @@
   }
   const liveReload = new LiveReload({ router });
   const ui = new Ui();
+  const commentApiClient = createCommentApiClient(
+    untrack(() => apiBaseUrl),
+    untrack(() => fetchFn),
+  );
+  const comments = new Comments(commentApiClient);
 
   // Close menus and expand navigation on any path change
   let previousPath = router.path;
@@ -99,6 +106,7 @@
     navigation,
     liveReload,
     ui,
+    comments,
     resolveSectionRefs: untrack(() => resolveSectionRefs),
   });
 
@@ -147,6 +155,10 @@
 
       if (config.liveReloadEnabled && !embedded) {
         liveReload.start();
+      }
+
+      if (config.commentsEnabled) {
+        comments.enabled = true;
       }
     })();
 

--- a/packages/viewer/src/api/comments.ts
+++ b/packages/viewer/src/api/comments.ts
@@ -1,0 +1,52 @@
+import type { Comment, CreateCommentRequest, UpdateCommentRequest } from "../types/comments";
+
+export interface CommentApiClient {
+  list(documentId: string, options?: { signal?: AbortSignal }): Promise<Comment[]>;
+  create(input: CreateCommentRequest): Promise<Comment>;
+  update(id: string, input: UpdateCommentRequest): Promise<Comment>;
+}
+
+export function createCommentApiClient(
+  apiBase: string = "/api",
+  fetchFn?: typeof fetch,
+): CommentApiClient {
+  const doFetch = fetchFn ?? fetch;
+  const base = apiBase.replace(/\/+$/, "");
+
+  return {
+    async list(documentId: string, options?: { signal?: AbortSignal }): Promise<Comment[]> {
+      const params = new URLSearchParams({ documentId });
+      const response = await doFetch(`${base}/comments?${params}`, {
+        signal: options?.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch comments: ${response.status}`);
+      }
+      return response.json();
+    },
+
+    async create(input: CreateCommentRequest): Promise<Comment> {
+      const response = await doFetch(`${base}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to create comment: ${response.status}`);
+      }
+      return response.json();
+    },
+
+    async update(id: string, input: UpdateCommentRequest): Promise<Comment> {
+      const response = await doFetch(`${base}/comments/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to update comment: ${response.status}`);
+      }
+      return response.json();
+    },
+  };
+}

--- a/packages/viewer/src/components/Layout.svelte
+++ b/packages/viewer/src/components/Layout.svelte
@@ -9,6 +9,7 @@
   import MobileDrawer from "./MobileDrawer.svelte";
   import IconButton from "./IconButton.svelte";
   import LoadingBar from "./LoadingBar.svelte";
+  import CommentSidebar from "./comments/CommentSidebar.svelte";
 
   interface Props {
     children: Snippet;
@@ -16,7 +17,7 @@
 
   let { children }: Props = $props();
 
-  const { router, navigation, page, ui } = getRwContext();
+  const { router, navigation, page, ui, comments } = getRwContext();
   const homeHref = router.prefixPath("/");
 
   // Scroll to top when navigating to a new page (without hash)
@@ -28,7 +29,11 @@
   });
 </script>
 
-<div class="layout-container" data-testid="viewer-root">
+<div
+  class="layout-container"
+  data-testid="viewer-root"
+  data-comments-active={comments.activeId || comments.pending ? "" : undefined}
+>
   <LoadingBar loading={page.loading} />
   <!-- Mobile Drawer (before header so the sticky anchor covers it in flow mode) -->
   <MobileDrawer />
@@ -116,17 +121,21 @@
             {@render children()}
           </main>
 
-          <!-- Table of Contents Sidebar -->
-          {#if page.data && page.data.toc.length > 0}
-            <aside aria-label="Page outline" class="layout-toc hidden w-[240px] shrink-0">
-              {#if page.data && page.data.toc.length > 0}
-                <div
-                  class="layout-toc-sticky sticky top-6 overflow-y-auto pl-8"
-                  data-testid="toc-sticky-wrapper"
-                >
-                  <TocSidebar toc={page.data.toc} />
-                </div>
-              {/if}
+          <!-- Right Sidebar: Comments (when active or drafting) or Table of Contents -->
+          {#if comments.activeId || comments.pending}
+            <aside aria-label="Comments" class="layout-comments hidden w-[320px] shrink-0">
+              <div class="pl-8">
+                <CommentSidebar />
+              </div>
+            </aside>
+          {:else if page.data && page.data.toc.length > 0}
+            <aside aria-label="Page outline" class="layout-toc hidden w-[320px] shrink-0">
+              <div
+                class="layout-toc-sticky sticky top-6 overflow-y-auto pl-8"
+                data-testid="toc-sticky-wrapper"
+              >
+                <TocSidebar toc={page.data.toc} />
+              </div>
             </aside>
           {/if}
         </div>
@@ -214,13 +223,34 @@
     }
   }
 
-  /* 1224px = sidebar (280px) + content (~704px) + TOC (240px) */
-  @container (min-width: 1224px) {
+  /* 1304px = sidebar (280px) + content (~704px) + TOC (320px).
+     TOC width matches the comment sidebar so activating a comment
+     doesn't reflow article content. */
+  @container (min-width: 1304px) {
     .layout-toc {
       display: block;
     }
     .layout-toc-popover {
       display: none;
+    }
+  }
+
+  /* When comments are active, prioritize comments over nav sidebar.
+     At medium widths: show comments, hide nav.
+     At wider widths: show both. */
+  @container (min-width: 952px) {
+    :global([data-comments-active]) .layout-sidebar {
+      display: none;
+    }
+    :global([data-comments-active]) .layout-comments {
+      display: block;
+    }
+  }
+
+  /* 1272px = sidebar (280px) + content (~672px) + comments (320px) */
+  @container (min-width: 1272px) {
+    :global([data-comments-active]) .layout-sidebar {
+      display: block;
     }
   }
 </style>

--- a/packages/viewer/src/components/PageContent.svelte
+++ b/packages/viewer/src/components/PageContent.svelte
@@ -2,14 +2,35 @@
   import { getRwContext } from "../lib/context";
   import { initializeTabs } from "../lib/tabs";
   import { rewriteSectionRefLinks } from "../lib/sectionRefs";
+  import { rangeToSelectors, selectorsToRange, type AnchorStrategy } from "../lib/anchoring";
   import { LOADING_SHOW_DELAY } from "../lib/constants";
   import LoadingSkeleton from "./LoadingSkeleton.svelte";
+  import SelectionPopover from "./comments/SelectionPopover.svelte";
+  import PageComments from "./comments/PageComments.svelte";
 
   const ctx = getRwContext();
-  const { page, router } = ctx;
+  const { page, router, comments } = ctx;
 
   let articleRef: HTMLElement | undefined = $state();
   let showSkeleton = $state(false);
+
+  // Comment selection state
+  let selectionRect: { x: number; y: number } | null = $state(null);
+
+  // Dismiss the popover when the selection collapses (e.g. user clicks on the
+  // selected text). Blink runs the click-on-selection collapse as a default
+  // action of `click`, so reading window.getSelection() inside `mouseup`
+  // still returns the active range — handleMouseUp would re-pin the popover
+  // at the same coords and only the highlight would disappear.
+  $effect(() => {
+    if (!selectionRect) return;
+    const handler = () => {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed) selectionRect = null;
+    };
+    document.addEventListener("selectionchange", handler);
+    return () => document.removeEventListener("selectionchange", handler);
+  });
 
   // Show skeleton only if loading takes longer than SHOW_DELAY
   $effect(() => {
@@ -57,7 +78,284 @@
       }
     }
   });
+
+  // Load comments when page data changes or comments become enabled.
+  // On initial load, config may not have arrived yet — reading
+  // comments.enabled ensures the effect re-runs when it flips to true.
+  $effect(() => {
+    if (page.data && comments.enabled) {
+      const docId = page.data.meta.path.replace(/^\//, "");
+      comments.load(docId);
+    } else if (!page.data) {
+      comments.clear();
+    }
+  });
+
+  // Map from comment ID to its anchored Range (for click detection)
+  let commentRanges = $state.raw<Map<string, Range>>(new Map());
+
+  // Apply comment highlights via CSS Custom Highlight API
+  $effect(() => {
+    const items = comments.items;
+    const container = articleRef;
+    if (!container || typeof CSS === "undefined" || !("highlights" in CSS)) return;
+
+    const highlights = CSS.highlights as Map<string, Highlight>;
+    const exactRanges: Range[] = [];
+    const fuzzyRanges: Range[] = [];
+    const rangeMap = new Map<string, Range>();
+    const strategyMap = new Map<string, AnchorStrategy>();
+    const orphanIds = new Set<string>();
+    const anchored: { id: string; range: Range }[] = [];
+
+    for (const comment of items) {
+      if (comment.selectors.length === 0) continue;
+      if (comment.status === "resolved" && comment.id !== comments.activeId) continue;
+      const result = selectorsToRange(comment.selectors, container);
+      if (result) {
+        if (result.strategy === "fuzzy") {
+          fuzzyRanges.push(result.range);
+        } else {
+          exactRanges.push(result.range);
+        }
+        rangeMap.set(comment.id, result.range);
+        strategyMap.set(comment.id, result.strategy);
+        anchored.push({ id: comment.id, range: result.range });
+      } else if (!comment.parentId) {
+        // Top-level inline comment whose stored selectors no longer resolve —
+        // surface it in the page comments timeline below the article instead
+        // of silently dropping it. Replies are kept with whichever parent they
+        // belong to, so only top-level threads get promoted.
+        orphanIds.add(comment.id);
+      }
+    }
+
+    commentRanges = rangeMap;
+    comments.anchorStrategies = strategyMap;
+    comments.orphanIds = orphanIds;
+
+    // If the active thread just lost its anchor (e.g. live-reload rewrote the
+    // page and the passage is gone), drop activeId — the sidebar filters out
+    // orphans, so activeThread would resolve to undefined and leave the panel
+    // open but empty. Clearing sends focus back to the main view; the orphan
+    // is still reachable from the page comments timeline.
+    if (comments.activeId && orphanIds.has(comments.activeId)) {
+      comments.activeId = null;
+    }
+
+    // Order inline threads by their live DOM position, not by stored
+    // TextPositionSelector.start — stored positions reflect the document
+    // as it was at comment creation time and are stale after edits.
+    anchored.sort((a, b) => a.range.compareBoundaryPoints(Range.START_TO_START, b.range));
+    comments.order = anchored.map((a) => a.id);
+
+    if (exactRanges.length > 0) {
+      highlights.set("rw-comments", new Highlight(...exactRanges));
+    } else {
+      highlights.delete("rw-comments");
+    }
+    if (fuzzyRanges.length > 0) {
+      highlights.set("rw-comments-fuzzy", new Highlight(...fuzzyRanges));
+    } else {
+      highlights.delete("rw-comments-fuzzy");
+    }
+
+    return () => {
+      highlights.delete("rw-comments");
+      highlights.delete("rw-comments-fuzzy");
+    };
+  });
+
+  // Keep activeTop in sync with activeId — recomputes whenever either changes.
+  // Article reflow (window resize, font load, sidebar open/close) shifts the
+  // highlight vertically inside the article, so a ResizeObserver re-measures
+  // the offset whenever the article changes size.
+  $effect(() => {
+    const activeId = comments.activeId;
+    const container = articleRef;
+    if (!activeId || !container) {
+      comments.activeTop = null;
+      return;
+    }
+    comments.activeTop = getHighlightTop(activeId);
+
+    const observer = new ResizeObserver(() => {
+      comments.activeTop = getHighlightTop(activeId);
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  });
+
+  // Apply active comment highlight (existing comment or pending new comment)
+  $effect(() => {
+    const activeId = comments.activeId;
+    const pending = comments.pending;
+    const items = comments.items;
+    const container = articleRef;
+    if (!container || typeof CSS === "undefined" || !("highlights" in CSS)) return;
+
+    const highlights = CSS.highlights as Map<string, Highlight>;
+
+    // Pending new comment — highlight the selected text
+    if (pending && pending.selectors.length > 0) {
+      const result = selectorsToRange(pending.selectors, container);
+      if (result) {
+        highlights.set("rw-comment-active", new Highlight(result.range));
+      } else {
+        highlights.delete("rw-comment-active");
+      }
+      return () => {
+        highlights.delete("rw-comment-active");
+      };
+    }
+
+    if (!activeId) {
+      highlights.delete("rw-comment-active");
+      return;
+    }
+
+    const active = items.find((c) => c.id === activeId);
+    if (!active || active.selectors.length === 0) {
+      highlights.delete("rw-comment-active");
+      return;
+    }
+
+    const result = selectorsToRange(active.selectors, container);
+    if (result) {
+      highlights.set("rw-comment-active", new Highlight(result.range));
+    } else {
+      highlights.delete("rw-comment-active");
+    }
+
+    return () => {
+      highlights.delete("rw-comment-active");
+    };
+  });
+
+  function handleMouseUp(event: MouseEvent) {
+    const selection = window.getSelection();
+
+    // If no text selected, check if click landed on a comment highlight
+    if (!selection || selection.isCollapsed) {
+      selectionRect = null;
+
+      // Toggle: click an inactive highlight to activate, click the active one to dismiss.
+      const hitId = findCommentAtPoint(event);
+      if (hitId) comments.activeId = hitId === comments.activeId ? null : hitId;
+      return;
+    }
+
+    const range = selection.getRangeAt(0);
+    if (!articleRef || !articleRef.contains(range.commonAncestorContainer)) {
+      selectionRect = null;
+      return;
+    }
+
+    const rect = range.getBoundingClientRect();
+    selectionRect = { x: rect.left + rect.width / 2, y: rect.top };
+  }
+
+  function handleMouseMove(event: MouseEvent) {
+    if (!articleRef) return;
+    const desired = commentRanges.size > 0 && findCommentAtPoint(event) ? "pointer" : "";
+    if (articleRef.style.cursor !== desired) {
+      articleRef.style.cursor = desired;
+    }
+  }
+
+  /** Find which comment (if any) contains the click point. */
+  function findCommentAtPoint(event: MouseEvent): string | null {
+    if (!articleRef) return null;
+
+    const { clientX, clientY } = event;
+
+    for (const [id, range] of commentRanges) {
+      // getClientRects() returns one rect per line for multi-line ranges
+      const rects = range.getClientRects();
+      for (const rect of rects) {
+        if (
+          clientX >= rect.left &&
+          clientX <= rect.right &&
+          clientY >= rect.top &&
+          clientY <= rect.bottom
+        ) {
+          return id;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /** Vertical offset of the anchor point for a comment's highlight, relative to
+   *  the article element. The anchor point is the vertical middle of the first
+   *  line of highlighted text — multi-line highlights still anchor to the first
+   *  line, which is where the reader's eye lands.
+   *
+   *  When the range's start sits at the boundary between two text nodes (e.g.
+   *  end of an inline element right before a sibling code span), browsers can
+   *  return a leading zero-width rect at the end of the previous line ahead of
+   *  the real highlight — skipping width==0 rects avoids anchoring to that
+   *  invisible artifact. */
+  function getHighlightTop(commentId: string): number | null {
+    const range = commentRanges.get(commentId);
+    if (!range || !articleRef) return null;
+    const rects = range.getClientRects();
+    let firstLineRect: DOMRect | null = null;
+    for (const r of rects) {
+      if (r.width > 0 && r.height > 0) {
+        firstLineRect = r;
+        break;
+      }
+    }
+    firstLineRect ??= range.getBoundingClientRect();
+    const articleRect = articleRef.getBoundingClientRect();
+    return firstLineRect.top + firstLineRect.height / 2 - articleRect.top;
+  }
+
+  // Keep pendingTop in sync — recalculates when the sidebar opens and whenever
+  // the article resizes, since content reflow moves the anchored range.
+  $effect(() => {
+    const pending = comments.pending;
+    const container = articleRef;
+    if (!pending || !container || pending.selectors.length === 0) {
+      comments.pendingTop = null;
+      return;
+    }
+
+    const measure = () => {
+      const result = selectorsToRange(pending.selectors, container);
+      if (result) {
+        const rangeRect = result.range.getBoundingClientRect();
+        const articleRect = container.getBoundingClientRect();
+        comments.pendingTop = rangeRect.top - articleRect.top;
+      }
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+    return () => observer.disconnect();
+  });
+
+  function handleAddComment() {
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed || !articleRef || !page.data) return;
+
+    const range = selection.getRangeAt(0);
+    const selectors = rangeToSelectors(range, articleRef);
+    const docId = page.data.meta.path.replace(/^\//, "");
+
+    comments.pending = { documentId: docId, selectors };
+    comments.activeId = null;
+    selectionRect = null;
+    window.getSelection()?.removeAllRanges();
+  }
 </script>
+
+{#if comments.enabled && selectionRect}
+  <SelectionPopover x={selectionRect.x} y={selectionRect.y} onAdd={handleAddComment} />
+{/if}
 
 {#if page.loading && showSkeleton}
   <LoadingSkeleton />
@@ -85,7 +383,16 @@
     <p class="text-red-600 dark:text-red-400">Error: {page.error}</p>
   </div>
 {:else if page.data}
-  <article bind:this={articleRef} class="prose max-w-none prose-slate dark:prose-invert">
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <article
+    bind:this={articleRef}
+    class="prose max-w-none prose-slate dark:prose-invert"
+    onmouseup={handleMouseUp}
+    onmousemove={handleMouseMove}
+  >
     {@html page.data.content}
   </article>
+  {#if comments.enabled}
+    <PageComments />
+  {/if}
 {/if}

--- a/packages/viewer/src/components/comments/Avatar.svelte
+++ b/packages/viewer/src/components/comments/Avatar.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import type { Author } from "../../types/comments";
+
+  interface Props {
+    author: Author;
+    size?: number;
+  }
+
+  let { author, size = 24 }: Props = $props();
+
+  function initials(name: string): string {
+    const tokens = name.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return "?";
+    if (tokens.length === 1) return tokens[0][0]?.toUpperCase() ?? "?";
+    return (tokens[0][0] + tokens[1][0]).toUpperCase();
+  }
+</script>
+
+{#if author.avatarUrl}
+  <img
+    src={author.avatarUrl}
+    alt=""
+    width={size}
+    height={size}
+    class="rounded-full object-cover"
+    style:width="{size}px"
+    style:height="{size}px"
+  />
+{:else if author.id === "local:human"}
+  <span
+    class="
+      inline-flex items-center justify-center rounded-full bg-gray-200 text-gray-600
+      dark:bg-neutral-700 dark:text-neutral-300
+    "
+    style:width="{size}px"
+    style:height="{size}px"
+    aria-hidden="true"
+  >
+    <!-- Heroicons solid "user" -->
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      style:width="{Math.round(size * 0.7)}px"
+      style:height="{Math.round(size * 0.7)}px"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  </span>
+{:else if author.id === "local:ai"}
+  <span
+    class="
+      inline-flex items-center justify-center rounded-full bg-gray-200 text-gray-600
+      dark:bg-neutral-700 dark:text-neutral-300
+    "
+    style:width="{size}px"
+    style:height="{size}px"
+    aria-hidden="true"
+  >
+    <!-- Heroicons solid "sparkles" -->
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      style:width="{Math.round(size * 0.7)}px"
+      style:height="{Math.round(size * 0.7)}px"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M9 4.5a.75.75 0 0 1 .721.544l.813 2.846a3.75 3.75 0 0 0 2.576 2.576l2.846.813a.75.75 0 0 1 0 1.442l-2.846.813a3.75 3.75 0 0 0-2.576 2.576l-.813 2.846a.75.75 0 0 1-1.442 0l-.813-2.846a3.75 3.75 0 0 0-2.576-2.576l-2.846-.813a.75.75 0 0 1 0-1.442l2.846-.813a3.75 3.75 0 0 0 2.576-2.576L8.279 5.044A.75.75 0 0 1 9 4.5ZM18 1.5a.75.75 0 0 1 .728.568l.258 1.036c.236.94.97 1.674 1.91 1.91l1.036.258a.75.75 0 0 1 0 1.456l-1.036.258c-.94.236-1.674.97-1.91 1.91l-.258 1.036a.75.75 0 0 1-1.456 0l-.258-1.036a2.625 2.625 0 0 0-1.91-1.91l-1.036-.258a.75.75 0 0 1 0-1.456l1.036-.258a2.625 2.625 0 0 0 1.91-1.91l.258-1.036A.75.75 0 0 1 18 1.5ZM16.5 15a.75.75 0 0 1 .712.513l.394 1.183c.15.447.5.799.948.948l1.183.395a.75.75 0 0 1 0 1.422l-1.183.395c-.447.15-.799.5-.948.948l-.395 1.183a.75.75 0 0 1-1.422 0l-.395-1.183a1.5 1.5 0 0 0-.948-.948l-1.183-.395a.75.75 0 0 1 0-1.422l1.183-.395c.447-.15.799-.5.948-.948l.395-1.183A.75.75 0 0 1 16.5 15Z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  </span>
+{:else}
+  <span
+    class="
+      inline-flex items-center justify-center rounded-full bg-gray-200 text-xs font-medium
+      text-gray-700
+      dark:bg-neutral-700 dark:text-neutral-200
+    "
+    style:width="{size}px"
+    style:height="{size}px"
+    aria-hidden="true"
+  >
+    {initials(author.name)}
+  </span>
+{/if}

--- a/packages/viewer/src/components/comments/CommentForm.svelte
+++ b/packages/viewer/src/components/comments/CommentForm.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  interface Props {
+    onSubmit: (body: string) => Promise<void>;
+    onCancel?: () => void;
+    placeholder?: string;
+    autofocus?: boolean;
+    /** When true, the action buttons (Cancel/Comment) are always shown.
+     *  Use for forms the user explicitly summoned (e.g. the pending new
+     *  comment), where hiding the buttons on blur would be surprising. */
+    pinActions?: boolean;
+    /** Called with the vertical distance from the form's outer border to the top of
+     *  the textarea's content box (where the first line of text appears), whenever
+     *  that distance changes. */
+    onAnchor?: (offsetPx: number) => void;
+    /** Extra classes appended to the <form> element — lets callers put their
+     *  border/padding directly on the form so anchor measurements naturally
+     *  include those offsets. */
+    outerClass?: string;
+  }
+
+  let {
+    onSubmit,
+    onCancel,
+    placeholder = "Write a comment...",
+    autofocus = false,
+    pinActions = false,
+    onAnchor,
+    outerClass = "",
+  }: Props = $props();
+
+  let body = $state("");
+  let submitting = $state(false);
+  let focused = $state(false);
+  let textareaRef: HTMLTextAreaElement | undefined = $state();
+  let formRef: HTMLFormElement | undefined = $state();
+
+  let showActions = $derived(pinActions || focused || body.trim().length > 0);
+
+  // Defer to rAF so the parent's visibility-hidden-until-measured wrapper
+  // (CommentSidebar) has flipped to visible before we focus — focus() on a
+  // visibility:hidden element is a spec no-op.
+  $effect(() => {
+    if (!autofocus || !textareaRef) return;
+    const ta = textareaRef;
+    const id = requestAnimationFrame(() => ta.focus({ preventScroll: true }));
+    return () => cancelAnimationFrame(id);
+  });
+
+  $effect(() => {
+    if (!onAnchor || !formRef || !textareaRef) return;
+
+    let lastReported: number | null = null;
+    const measure = () => {
+      if (!formRef || !textareaRef) return;
+      // offsetTop is relative to offsetParent, which isn't guaranteed to be
+      // formRef (form isn't positioned). Use bounding rects so the returned
+      // offset is always relative to the form's outer border.
+      const formRect = formRef.getBoundingClientRect();
+      const taRect = textareaRef.getBoundingClientRect();
+      const paddingTop = parseFloat(getComputedStyle(textareaRef).paddingTop) || 0;
+      const offset = taRect.top - formRect.top + paddingTop;
+      if (lastReported === null || Math.abs(offset - lastReported) > 0.5) {
+        lastReported = offset;
+        onAnchor?.(offset);
+      }
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(formRef);
+    return () => observer.disconnect();
+  });
+
+  function handleFocusOut(event: FocusEvent) {
+    const next = event.relatedTarget as Node | null;
+    const form = event.currentTarget as HTMLElement;
+    if (!next || !form.contains(next)) {
+      focused = false;
+    }
+  }
+
+  // Re-run whenever body changes — including programmatic resets after submit,
+  // which don't fire `oninput` and would otherwise leave the textarea stuck at
+  // its previous grown height.
+  $effect(() => {
+    body;
+    if (!textareaRef) return;
+    textareaRef.style.height = "auto";
+    textareaRef.style.height = `${textareaRef.scrollHeight}px`;
+  });
+
+  async function submit() {
+    if (!body.trim() || submitting) return;
+    submitting = true;
+    try {
+      await onSubmit(body.trim());
+      body = "";
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      submit();
+    } else if (event.key === "Escape" && onCancel) {
+      event.preventDefault();
+      onCancel();
+    }
+  }
+
+  function handleSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    submit();
+  }
+</script>
+
+<form
+  bind:this={formRef}
+  onsubmit={handleSubmit}
+  onfocusin={() => (focused = true)}
+  onfocusout={handleFocusOut}
+  class="flex flex-col gap-2 {outerClass}"
+>
+  <textarea
+    bind:this={textareaRef}
+    bind:value={body}
+    onkeydown={handleKeydown}
+    {placeholder}
+    rows={1}
+    class="
+      w-full resize-none rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900
+      placeholder-gray-400
+      focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none
+      dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:placeholder-neutral-500
+      dark:focus:border-blue-400 dark:focus:ring-blue-400
+    "
+  ></textarea>
+  {#if showActions}
+    <div class="flex justify-end gap-2">
+      {#if onCancel}
+        <button
+          type="button"
+          onclick={onCancel}
+          class="
+            rounded-md px-3 py-1.5 text-sm text-gray-600 transition-colors
+            hover:text-gray-900
+            dark:text-neutral-400
+            dark:hover:text-neutral-100
+          "
+        >
+          Cancel
+        </button>
+      {/if}
+      <button
+        type="submit"
+        disabled={!body.trim() || submitting}
+        class="
+          rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors
+          hover:bg-blue-700
+          disabled:cursor-not-allowed disabled:opacity-50
+          dark:bg-blue-500
+          dark:hover:bg-blue-600
+        "
+      >
+        Comment
+      </button>
+    </div>
+  {/if}
+</form>

--- a/packages/viewer/src/components/comments/CommentSidebar.svelte
+++ b/packages/viewer/src/components/comments/CommentSidebar.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import { tick } from "svelte";
+  import type { Comment } from "../../types/comments";
+  import { getRwContext } from "../../lib/context";
+  import CommentThread from "./CommentThread.svelte";
+  import CommentForm from "./CommentForm.svelte";
+
+  const { comments } = getRwContext();
+
+  let threadAnchor = $state<number | null>(null);
+  let pendingAnchor = $state<number | null>(null);
+
+  // Stale offset would otherwise flash on the next pending form's first paint.
+  $effect(() => {
+    if (!comments.pending) pendingAnchor = null;
+  });
+
+  /** Threads sorted by current document position (live DOM range order from
+   *  `comments.order`). Stored TextPositionSelector offsets can't be trusted
+   *  for ordering: they're captured at comment-creation time, so comments
+   *  created against different edits of the same document live in different
+   *  position coordinate systems. Threads not present in `order` (e.g. not
+   *  yet anchored) are placed last in creation order.
+   *  Resolved threads are hidden unless one is the currently active thread. */
+  const orderedThreads = $derived.by(() => {
+    const filtered = comments.inlineThreads.filter(
+      (t) => t.status !== "resolved" || t.id === comments.activeId,
+    );
+    const rank = new Map(comments.order.map((id, i) => [id, i]));
+    const indexOf = (t: Comment) => rank.get(t.id) ?? Infinity;
+    return filtered.toSorted((a, b) => indexOf(a) - indexOf(b));
+  });
+
+  const activeThread = $derived(orderedThreads.find((t) => t.id === comments.activeId));
+  const activeIndex = $derived(orderedThreads.findIndex((t) => t.id === comments.activeId));
+
+  function goToPrev() {
+    if (activeIndex > 0) {
+      void navigateTo(orderedThreads[activeIndex - 1].id);
+    }
+  }
+
+  function goToNext() {
+    if (activeIndex >= 0 && activeIndex < orderedThreads.length - 1) {
+      void navigateTo(orderedThreads[activeIndex + 1].id);
+    }
+  }
+
+  /** Switch the active thread while keeping the thread visually pinned in place.
+   *  The thread anchors to its highlight's vertical position in the article, so
+   *  simply changing activeId makes the thread (and its nav buttons) jump — rapid
+   *  consecutive prev/next clicks become impossible. Scrolling by the delta
+   *  between old and new highlight positions cancels out the thread's movement,
+   *  so the button the reader just clicked stays under the cursor. */
+  async function navigateTo(nextId: string) {
+    const oldTop = comments.activeTop;
+    comments.activeId = nextId;
+    await tick();
+    const newTop = comments.activeTop;
+    if (oldTop !== null && newTop !== null) {
+      window.scrollBy(0, newTop - oldTop);
+    }
+  }
+
+  async function handleResolve(id: string) {
+    try {
+      await comments.resolve(id);
+    } catch (e) {
+      comments.error = e instanceof Error ? e.message : "Failed to resolve comment";
+    }
+  }
+
+  async function handleReopen(id: string) {
+    try {
+      await comments.reopen(id);
+    } catch (e) {
+      comments.error = e instanceof Error ? e.message : "Failed to reopen comment";
+    }
+  }
+
+  async function handleReply(parentId: string, body: string) {
+    const thread = comments.threads.find((t) => t.id === parentId);
+    if (!thread) return;
+    try {
+      await comments.create({
+        documentId: thread.documentId,
+        parentId,
+        body,
+        selectors: [],
+      });
+    } catch (e) {
+      comments.error = e instanceof Error ? e.message : "Failed to add reply";
+    }
+  }
+
+  async function handleNewCommentSubmit(body: string) {
+    const pending = comments.pending;
+    if (!pending) return;
+
+    try {
+      const created = await comments.create({
+        documentId: pending.documentId,
+        body,
+        selectors: pending.selectors,
+      });
+      comments.clearPending();
+      comments.activeId = created.id;
+    } catch (e) {
+      comments.error = e instanceof Error ? e.message : "Failed to create comment";
+    }
+  }
+
+  function handleNewCommentCancel() {
+    comments.clearPending();
+  }
+</script>
+
+{#if comments.error}
+  <div
+    class="
+      mb-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700
+      dark:border-red-800 dark:bg-red-950 dark:text-red-300
+    "
+    role="alert"
+  >
+    {comments.error}
+    <button
+      class="ml-2 font-medium underline hover:no-underline"
+      onclick={() => {
+        comments.error = null;
+      }}>Dismiss</button
+    >
+  </div>
+{/if}
+
+{#if comments.pending}
+  <div
+    style:padding-top="{Math.max(0, (comments.pendingTop ?? 0) - (pendingAnchor ?? 0))}px"
+    style:visibility={pendingAnchor === null ? "hidden" : "visible"}
+  >
+    <CommentForm
+      onSubmit={handleNewCommentSubmit}
+      onCancel={handleNewCommentCancel}
+      autofocus
+      pinActions
+      onAnchor={(o) => (pendingAnchor = o)}
+      outerClass="rounded-md border border-gray-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-800"
+    />
+  </div>
+{:else if activeThread}
+  <div
+    style:padding-top="{Math.max(0, (comments.activeTop ?? 0) - (threadAnchor ?? 0))}px"
+    style:visibility={threadAnchor === null ? "hidden" : "visible"}
+  >
+    <CommentThread
+      comment={activeThread}
+      replies={comments.replies(activeThread.id)}
+      active={true}
+      onResolve={handleResolve}
+      onReopen={handleReopen}
+      onReply={handleReply}
+      onClose={() => {
+        comments.activeId = null;
+      }}
+      nav={{ index: activeIndex, total: orderedThreads.length, onPrev: goToPrev, onNext: goToNext }}
+      onAnchor={(o) => (threadAnchor = o)}
+      fuzzy={comments.anchorStrategies.get(activeThread.id) === "fuzzy"}
+    />
+  </div>
+{/if}

--- a/packages/viewer/src/components/comments/CommentThread.svelte
+++ b/packages/viewer/src/components/comments/CommentThread.svelte
@@ -1,0 +1,317 @@
+<script lang="ts">
+  import type { Comment } from "../../types/comments";
+  import Avatar from "./Avatar.svelte";
+  import CommentForm from "./CommentForm.svelte";
+
+  interface Props {
+    comment: Comment;
+    replies: Comment[];
+    active: boolean;
+    onResolve: (id: string) => void;
+    onReopen: (id: string) => void;
+    onReply: (parentId: string, body: string) => Promise<void>;
+    onClose?: () => void;
+    /** Navigation between threads (optional). */
+    nav?: { index: number; total: number; onPrev: () => void; onNext: () => void };
+    /** Called with the vertical distance from the thread's outer border to the
+     *  avatar row's vertical center, whenever that distance changes. */
+    onAnchor?: (offsetPx: number) => void;
+    /** True when the comment was anchored via fuzzy matching — the original
+     *  passage no longer appears verbatim, so the highlight may be approximate. */
+    fuzzy?: boolean;
+  }
+
+  let {
+    comment,
+    replies,
+    active,
+    onResolve,
+    onReopen,
+    onReply,
+    onClose,
+    nav,
+    onAnchor,
+    fuzzy = false,
+  }: Props = $props();
+
+  let outerRef: HTMLDivElement | undefined = $state();
+  let avatarRowRef: HTMLDivElement | undefined = $state();
+
+  function formatRelativeTime(dateStr: string): string {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffSec = Math.floor(diffMs / 1000);
+    const diffMin = Math.floor(diffSec / 60);
+    const diffHr = Math.floor(diffMin / 60);
+    const diffDay = Math.floor(diffHr / 24);
+
+    if (diffSec < 60) return "just now";
+    if (diffMin < 60) return `${diffMin}m ago`;
+    if (diffHr < 24) return `${diffHr}h ago`;
+    if (diffDay < 30) return `${diffDay}d ago`;
+    return date.toLocaleDateString();
+  }
+
+  async function handleReply(body: string) {
+    await onReply(comment.id, body);
+  }
+
+  $effect(() => {
+    if (!onAnchor || !outerRef || !avatarRowRef) return;
+
+    let lastReported: number | null = null;
+    const measure = () => {
+      if (!outerRef || !avatarRowRef) return;
+      // offsetTop is relative to offsetParent, which isn't guaranteed to be
+      // outerRef (outer div isn't positioned). Use bounding rects instead so
+      // the returned offset is always relative to the thread's outer border.
+      const outerRect = outerRef.getBoundingClientRect();
+      const rowRect = avatarRowRef.getBoundingClientRect();
+      const offset = rowRect.top - outerRect.top + rowRect.height / 2;
+      if (lastReported === null || Math.abs(offset - lastReported) > 0.5) {
+        lastReported = offset;
+        onAnchor?.(offset);
+      }
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(outerRef);
+    observer.observe(avatarRowRef);
+    return () => observer.disconnect();
+  });
+</script>
+
+<div
+  bind:this={outerRef}
+  class="
+    overflow-hidden rounded-md border px-3 pt-3 transition-colors
+    {active
+    ? 'border-gray-200 bg-white dark:border-neutral-700 dark:bg-neutral-800'
+    : `
+      border-gray-200 bg-white
+      hover:border-gray-300
+      dark:border-neutral-700 dark:bg-neutral-800
+      dark:hover:border-neutral-600
+    `}
+  "
+>
+  <!-- Thread navigation -->
+  {#if onClose}
+    {#if nav && nav.total > 1}
+      <div
+        class="
+          -mx-3 -mt-3 mb-2 flex items-center justify-between border-b border-gray-200 px-3 py-2
+          dark:border-neutral-700
+        "
+      >
+        <span class="text-xs text-gray-500 dark:text-neutral-400">
+          {nav.index + 1} / {nav.total}
+        </span>
+        <div class="flex gap-1">
+          <button
+            type="button"
+            disabled={nav.index <= 0}
+            onclick={nav.onPrev}
+            aria-label="Previous comment"
+            class="
+              cursor-pointer rounded-sm p-0.5 text-gray-500 transition-colors
+              hover:bg-gray-100 hover:text-gray-700
+              disabled:cursor-default disabled:opacity-30
+              disabled:hover:bg-transparent
+              dark:text-neutral-400
+              dark:hover:bg-neutral-700 dark:hover:text-neutral-200
+            "
+          >
+            <svg
+              class="size-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            disabled={nav.index >= nav.total - 1}
+            onclick={nav.onNext}
+            aria-label="Next comment"
+            class="
+              cursor-pointer rounded-sm p-0.5 text-gray-500 transition-colors
+              hover:bg-gray-100 hover:text-gray-700
+              disabled:cursor-default disabled:opacity-30
+              disabled:hover:bg-transparent
+              dark:text-neutral-400
+              dark:hover:bg-neutral-700 dark:hover:text-neutral-200
+            "
+          >
+            <svg
+              class="size-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onclick={onClose}
+            aria-label="Close comment"
+            class="
+              cursor-pointer rounded-sm p-0.5 text-gray-500 transition-colors
+              hover:bg-gray-100 hover:text-gray-700
+              dark:text-neutral-400
+              dark:hover:bg-neutral-700 dark:hover:text-neutral-200
+            "
+          >
+            <svg
+              class="size-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    {:else}
+      <div
+        class="
+          -mx-3 -mt-3 mb-2 flex justify-end border-b border-gray-200 px-3 py-2
+          dark:border-neutral-700
+        "
+      >
+        <button
+          type="button"
+          onclick={onClose}
+          aria-label="Close comment"
+          class="
+            cursor-pointer rounded-sm p-0.5 text-gray-500 transition-colors
+            hover:bg-gray-100 hover:text-gray-700
+            dark:text-neutral-400
+            dark:hover:bg-neutral-700 dark:hover:text-neutral-200
+          "
+        >
+          <svg
+            class="size-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    {/if}
+  {/if}
+
+  <!-- Main comment -->
+  <div class={comment.status === "resolved" ? "opacity-60" : ""}>
+    <div
+      bind:this={avatarRowRef}
+      data-testid="comment-avatar-row"
+      class="mb-2 flex items-center gap-2"
+    >
+      <Avatar author={comment.author} size={24} />
+      <span class="text-sm font-semibold text-gray-900 dark:text-neutral-100">
+        {comment.author.name}
+      </span>
+      {#if fuzzy}
+        <span
+          class="text-xs text-amber-600 italic dark:text-amber-400"
+          title="The exact passage this comment was attached to no longer appears in the page. The highlight is the closest match."
+        >
+          re-anchored
+        </span>
+      {/if}
+      <span class="ml-auto text-xs text-gray-400 dark:text-neutral-500">
+        {formatRelativeTime(comment.createdAt)}
+      </span>
+    </div>
+    <p
+      class="
+        text-sm text-gray-900
+        dark:text-neutral-100
+        {comment.status === 'resolved' ? 'line-through' : ''}
+      "
+    >
+      {comment.body}
+    </p>
+    <div class="my-2 flex items-center gap-2">
+      {#if comment.status === "open"}
+        <button
+          type="button"
+          onclick={() => onResolve(comment.id)}
+          class="
+            cursor-pointer text-xs text-gray-500 transition-colors
+            hover:text-gray-900
+            dark:text-neutral-400
+            dark:hover:text-neutral-100
+          "
+        >
+          Resolve
+        </button>
+      {:else}
+        <button
+          type="button"
+          onclick={() => onReopen(comment.id)}
+          class="
+            cursor-pointer text-xs text-gray-500 transition-colors
+            hover:text-gray-900
+            dark:text-neutral-400
+            dark:hover:text-neutral-100
+          "
+        >
+          Reopen
+        </button>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Replies -->
+  {#if replies.length > 0}
+    <div
+      class="
+        -mx-3 divide-y divide-gray-200 border-t border-gray-200 bg-gray-50
+        dark:divide-neutral-700 dark:border-neutral-700 dark:bg-neutral-900/50
+      "
+    >
+      {#each replies as reply (reply.id)}
+        <div class="px-3 py-2">
+          <div class="mb-1 flex items-center gap-2">
+            <Avatar author={reply.author} size={20} />
+            <span class="text-xs font-semibold text-gray-900 dark:text-neutral-100">
+              {reply.author.name}
+            </span>
+            <span class="ml-auto text-xs text-gray-400 dark:text-neutral-500">
+              {formatRelativeTime(reply.createdAt)}
+            </span>
+          </div>
+          <p class="text-sm text-gray-900 dark:text-neutral-100">
+            {reply.body}
+          </p>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Reply form -->
+  {#if comment.status === "open"}
+    <div
+      class="
+        -mx-3 border-t border-gray-200 bg-gray-50 px-3 py-2
+        dark:border-neutral-700 dark:bg-neutral-900/50
+      "
+    >
+      <CommentForm onSubmit={handleReply} placeholder="Write a reply..." />
+    </div>
+  {/if}
+</div>

--- a/packages/viewer/src/components/comments/PageComments.svelte
+++ b/packages/viewer/src/components/comments/PageComments.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import type { Selector } from "../../types/comments";
+  import { getRwContext } from "../../lib/context";
+  import CommentThread from "./CommentThread.svelte";
+  import CommentForm from "./CommentForm.svelte";
+
+  const { comments, page } = getRwContext();
+
+  const visibleThreads = $derived(
+    comments.pageThreads
+      .filter((t) => t.status !== "resolved")
+      .toSorted((a, b) => a.createdAt.localeCompare(b.createdAt)),
+  );
+
+  function findQuote(
+    selectors: Selector[],
+  ): Extract<Selector, { type: "TextQuoteSelector" }> | null {
+    return (
+      selectors.find(
+        (s): s is Extract<Selector, { type: "TextQuoteSelector" }> =>
+          s.type === "TextQuoteSelector",
+      ) ?? null
+    );
+  }
+
+  async function handleResolve(id: string) {
+    try {
+      await comments.resolve(id);
+    } catch (e) {
+      comments.error = e instanceof Error ? e.message : "Failed to resolve comment";
+    }
+  }
+
+  async function handleReopen(id: string) {
+    try {
+      await comments.reopen(id);
+    } catch (e) {
+      comments.error = e instanceof Error ? e.message : "Failed to reopen comment";
+    }
+  }
+
+  async function handleReply(parentId: string, body: string) {
+    const thread = comments.threads.find((t) => t.id === parentId);
+    if (!thread) return;
+    try {
+      await comments.create({
+        documentId: thread.documentId,
+        parentId,
+        body,
+        selectors: [],
+      });
+    } catch (e) {
+      comments.error = e instanceof Error ? e.message : "Failed to add reply";
+    }
+  }
+
+  async function handleNewComment(body: string) {
+    if (!page.data) return;
+    const documentId = page.data.meta.path.replace(/^\//, "");
+    try {
+      await comments.create({
+        documentId,
+        body,
+        selectors: [],
+      });
+    } catch (e) {
+      comments.error = e instanceof Error ? e.message : "Failed to create comment";
+    }
+  }
+</script>
+
+<section
+  aria-label="Page comments"
+  class="mt-12 border-t border-gray-200 pt-8 dark:border-neutral-700"
+>
+  {#if comments.error}
+    <div
+      class="
+        mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700
+        dark:border-red-800 dark:bg-red-950 dark:text-red-300
+      "
+      role="alert"
+    >
+      {comments.error}
+      <button
+        class="ml-2 font-medium underline hover:no-underline"
+        onclick={() => {
+          comments.error = null;
+        }}>Dismiss</button
+      >
+    </div>
+  {/if}
+
+  {#if visibleThreads.length > 0}
+    <div class="mb-6 space-y-4">
+      {#each visibleThreads as thread (thread.id)}
+        {@const quote = thread.selectors.length > 0 ? findQuote(thread.selectors) : null}
+        <div>
+          {#if quote}
+            <!-- Orphaned inline comment: the stored passage no longer appears
+                 in the page, so we show the quote (with its captured context)
+                 verbatim above the thread. -->
+            <blockquote
+              data-testid="orphan-quote"
+              title="This comment was attached to a passage that no longer appears on the page."
+              class="
+                mb-2 border-l-2 border-amber-300 pl-3 text-sm text-gray-600 italic
+                dark:border-amber-500/60 dark:text-neutral-400
+              "
+            >
+              {#if quote.prefix}<span class="opacity-70">…{quote.prefix}</span>{/if}<mark
+                class="
+                  rounded-sm bg-[rgba(255,212,0,0.4)] px-0.5 text-inherit not-italic
+                  dark:bg-[rgba(255,212,0,0.25)]
+                ">{quote.exact}</mark
+              >{#if quote.suffix}<span class="opacity-70">{quote.suffix}…</span>{/if}
+            </blockquote>
+          {/if}
+          <CommentThread
+            comment={thread}
+            replies={comments.replies(thread.id)}
+            active={false}
+            onResolve={handleResolve}
+            onReopen={handleReopen}
+            onReply={handleReply}
+          />
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <CommentForm onSubmit={handleNewComment} placeholder="Write a comment..." />
+</section>

--- a/packages/viewer/src/components/comments/SelectionPopover.svelte
+++ b/packages/viewer/src/components/comments/SelectionPopover.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  interface Props {
+    x: number;
+    y: number;
+    onAdd: () => void;
+  }
+
+  let { x, y, onAdd }: Props = $props();
+</script>
+
+<div
+  class="
+    fixed z-50 flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5
+    shadow-lg
+    dark:border-neutral-600 dark:bg-neutral-700
+  "
+  style="left: {x}px; top: {y}px; transform: translate(-50%, -100%) translateY(-8px);"
+>
+  <button
+    type="button"
+    onclick={onAdd}
+    class="
+      flex items-center gap-1.5 text-sm font-medium text-gray-700 transition-colors
+      hover:text-blue-600
+      dark:text-neutral-200
+      dark:hover:text-blue-400
+    "
+  >
+    <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
+      />
+    </svg>
+    Add comment
+  </button>
+</div>

--- a/packages/viewer/src/lib/anchoring.test.ts
+++ b/packages/viewer/src/lib/anchoring.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from "vitest";
+import { rangeToSelectors, selectorsToRange } from "./anchoring";
+import type { Selector } from "../types/comments";
+
+function createContainer(html: string): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+function selectText(container: HTMLElement, text: string): Range {
+  const fullText = container.textContent ?? "";
+  const index = fullText.indexOf(text);
+  if (index === -1) throw new Error(`"${text}" not found in container`);
+
+  const range = document.createRange();
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let offset = 0;
+  let startSet = false;
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Text;
+    const len = node.textContent?.length ?? 0;
+
+    if (!startSet && offset + len > index) {
+      range.setStart(node, index - offset);
+      startSet = true;
+    }
+    if (startSet && offset + len >= index + text.length) {
+      range.setEnd(node, index + text.length - offset);
+      break;
+    }
+    offset += len;
+  }
+  return range;
+}
+
+describe("rangeToSelectors", () => {
+  it("returns empty array for collapsed selection", () => {
+    const container = createContainer("<p>Hello world</p>");
+    const range = document.createRange();
+    range.setStart(container.firstChild!.firstChild!, 0);
+    range.collapse(true);
+
+    expect(rangeToSelectors(range, container)).toEqual([]);
+  });
+
+  it("creates TextQuoteSelector and TextPositionSelector", () => {
+    const container = createContainer("<p>The quick brown fox jumps over the lazy dog</p>");
+    const range = selectText(container, "brown fox");
+    const selectors = rangeToSelectors(range, container);
+
+    expect(selectors).toHaveLength(2);
+    expect(selectors[0]).toEqual({
+      type: "TextQuoteSelector",
+      exact: "brown fox",
+      prefix: "The quick ",
+      suffix: " jumps over the lazy dog",
+    });
+    expect(selectors[1]).toEqual({
+      type: "TextPositionSelector",
+      start: 10,
+      end: 19,
+    });
+  });
+
+  it("handles selection at the start of the container", () => {
+    const container = createContainer("<p>Hello world</p>");
+    const range = selectText(container, "Hello");
+    const selectors = rangeToSelectors(range, container);
+
+    const quote = selectors.find((s) => s.type === "TextQuoteSelector")!;
+    expect(quote).toMatchObject({ exact: "Hello", prefix: "" });
+
+    const pos = selectors.find((s) => s.type === "TextPositionSelector")!;
+    expect(pos).toMatchObject({ start: 0, end: 5 });
+  });
+
+  it("handles selection spanning multiple elements", () => {
+    const container = createContainer("<p><b>bold</b> and <i>italic</i> text</p>");
+    const range = selectText(container, "and italic");
+    const selectors = rangeToSelectors(range, container);
+
+    expect(selectors[0]).toMatchObject({
+      type: "TextQuoteSelector",
+      exact: "and italic",
+    });
+  });
+
+  it("truncates prefix/suffix to 32 characters", () => {
+    const long = "a".repeat(50);
+    const container = createContainer(`<p>${long}TARGET${long}</p>`);
+    const range = selectText(container, "TARGET");
+    const selectors = rangeToSelectors(range, container);
+
+    const quote = selectors.find((s) => s.type === "TextQuoteSelector")!;
+    if (quote.type === "TextQuoteSelector") {
+      expect(quote.prefix.length).toBe(32);
+      expect(quote.suffix.length).toBe(32);
+    }
+  });
+});
+
+describe("selectorsToRange", () => {
+  it("re-anchors using position selector when text matches", () => {
+    const container = createContainer("<p>The quick brown fox</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "brown", prefix: "The quick ", suffix: " fox" },
+      { type: "TextPositionSelector", start: 10, end: 15 },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.range.toString()).toBe("brown");
+    expect(result!.strategy).toBe("position");
+  });
+
+  it("falls back to quote selector when position text does not match", () => {
+    const container = createContainer("<p>NEW TEXT The quick brown fox</p>");
+    // Position is stale (points to wrong text), but quote should find it
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "brown", prefix: "The quick ", suffix: " fox" },
+      { type: "TextPositionSelector", start: 10, end: 15 },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.range.toString()).toBe("brown");
+    expect(result!.strategy).toBe("quote");
+  });
+
+  it("works with only TextPositionSelector", () => {
+    const container = createContainer("<p>Hello world</p>");
+    const selectors: Selector[] = [{ type: "TextPositionSelector", start: 6, end: 11 }];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.range.toString()).toBe("world");
+    expect(result!.strategy).toBe("position");
+  });
+
+  it("works with only TextQuoteSelector", () => {
+    const container = createContainer("<p>Hello world</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "world", prefix: "Hello ", suffix: "" },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.range.toString()).toBe("world");
+    expect(result!.strategy).toBe("quote");
+  });
+
+  it("returns null when text is not found and not similar", () => {
+    const container = createContainer("<p>Hello world</p>");
+    const selectors: Selector[] = [
+      {
+        type: "TextQuoteSelector",
+        exact: "completely unrelated phrase",
+        prefix: "",
+        suffix: "",
+      },
+      { type: "TextPositionSelector", start: 100, end: 200 },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty selectors array", () => {
+    const container = createContainer("<p>Hello world</p>");
+    expect(selectorsToRange([], container)).toBeNull();
+  });
+
+  it("disambiguates repeated text using context", () => {
+    const container = createContainer("<p>foo bar baz foo bar qux</p>");
+    // Target the second "foo bar" — suffix "qux" matches only the second occurrence
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "foo bar", prefix: "baz ", suffix: " qux" },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.range.toString()).toBe("foo bar");
+
+    // Verify it picked the second occurrence by checking position
+    const fullText = container.textContent ?? "";
+    const preRange = document.createRange();
+    preRange.setStart(container, 0);
+    preRange.setEnd(result!.range.startContainer, result!.range.startOffset);
+    const startPos = preRange.toString().length;
+    expect(startPos).toBe(fullText.lastIndexOf("foo bar"));
+  });
+
+  it("handles selection spanning multiple DOM nodes", () => {
+    const container = createContainer("<p><b>bold</b> and <i>italic</i></p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "bold and italic", prefix: "", suffix: "" },
+      { type: "TextPositionSelector", start: 0, end: 15 },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.range.toString()).toBe("bold and italic");
+  });
+
+  // Regression for scenario N2 in test-results/comment-stability:
+  // when the document SHRINKS so the original passage moves earlier than the
+  // stored position, AND a duplicate quote appears later, the resolver must
+  // still pick the one whose context matches — even though the original is
+  // before the position-hint window.
+  it("picks the context-matching occurrence even when it is before the position hint", () => {
+    const container = createContainer(
+      "<p>We study the brown fox jumps deeply later on in the chapter.</p>" +
+        "<p>Later note: a quick brown fox jumps for fun.</p>",
+    );
+    const selectors: Selector[] = [
+      {
+        type: "TextQuoteSelector",
+        exact: "brown fox jumps",
+        prefix: "ph here for setup.We study the ", // matches the original position
+        suffix: " deeply later on in the chapter.", // matches the first occurrence
+      },
+      { type: "TextPositionSelector", start: 46, end: 61 }, // stale — original is at 13 now
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.strategy).toBe("quote");
+    const fullText = container.textContent ?? "";
+    const preRange = document.createRange();
+    preRange.setStart(container, 0);
+    preRange.setEnd(result!.range.startContainer, result!.range.startOffset);
+    const startPos = preRange.toString().length;
+    // Should have picked the first occurrence (the one with matching suffix
+    // " deeply later on in the chapter."), not the second one ("for fun.").
+    expect(startPos).toBe(fullText.indexOf("brown fox jumps"));
+  });
+});
+
+describe("fuzzy fallback", () => {
+  it("re-anchors after a single character is deleted from inside the quote", () => {
+    // Original quote was "brown fox jumps" — now the document reads
+    // "brown fx jumps" (one char dropped). Exact match fails; fuzzy succeeds.
+    const container = createContainer("<p>The quick brown fx jumps over the lazy dog.</p>");
+    const selectors: Selector[] = [
+      {
+        type: "TextQuoteSelector",
+        exact: "brown fox jumps",
+        prefix: "The quick ",
+        suffix: " over the lazy dog.",
+      },
+      { type: "TextPositionSelector", start: 10, end: 25 },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.strategy).toBe("fuzzy");
+  });
+
+  it("re-anchors after the renderer drops the space between two paragraphs", () => {
+    // Scenario J2: comment was on "brown fox jumps", then a paragraph break
+    // got inserted between "fox" and "jumps". The renderer concatenates
+    // sibling <p> textContent with no separator, so the post-edit string is
+    // "...brown foxjumps over...". Exact match fails — fuzzy should win.
+    const container = createContainer("<p>The quick brown fox</p><p>jumps over the lazy dog.</p>");
+    const selectors: Selector[] = [
+      {
+        type: "TextQuoteSelector",
+        exact: "brown fox jumps",
+        prefix: "The quick ",
+        suffix: " over the lazy dog.",
+      },
+      { type: "TextPositionSelector", start: 10, end: 25 },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.strategy).toBe("fuzzy");
+  });
+
+  it("returns null instead of throwing when the quote exceeds diff-match-patch's pattern bit width", () => {
+    // diff-match-patch throws "Pattern too long for this browser." when a
+    // pattern longer than Match_MaxBits (default 32) isn't a verbatim match.
+    // An orphaned inline comment with a long stored quote hits that branch
+    // on every re-anchor pass; the exception must not bubble up and break
+    // the caller's anchoring loop (PageContent relies on null to mark the
+    // comment as an orphan).
+    const container = createContainer("<p>totally unrelated content on this page.</p>");
+    const longQuote = "a".repeat(64);
+    const selectors: Selector[] = [
+      {
+        type: "TextQuoteSelector",
+        exact: longQuote,
+        prefix: "before",
+        suffix: "after",
+      },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).toBeNull();
+  });
+
+  it("orphans when the passage was rewritten beyond the similarity threshold", () => {
+    // No "brown fox jumps", and the closest substring ("hens scatter feed")
+    // is too far below the threshold.
+    const container = createContainer(
+      "<p>The rooster crows at dawn while the hens scatter and feed.</p>",
+    );
+    const selectors: Selector[] = [
+      {
+        type: "TextQuoteSelector",
+        exact: "brown fox jumps",
+        prefix: "The quick ",
+        suffix: " over the lazy dog.",
+      },
+      { type: "TextPositionSelector", start: 10, end: 25 },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).toBeNull();
+  });
+});
+
+describe("roundtrip", () => {
+  it("rangeToSelectors -> selectorsToRange preserves the selection", () => {
+    const container = createContainer(
+      "<p>First paragraph with some text.</p><p>Second paragraph here.</p>",
+    );
+    const range = selectText(container, "some text");
+    const selectors = rangeToSelectors(range, container);
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.range.toString()).toBe("some text");
+  });
+
+  it("roundtrip works across element boundaries", () => {
+    const container = createContainer("<p>Start <code>code</code> and <em>emphasis</em> end</p>");
+    const range = selectText(container, "code and emphasis");
+    const selectors = rangeToSelectors(range, container);
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.range.toString()).toBe("code and emphasis");
+  });
+});

--- a/packages/viewer/src/lib/anchoring.ts
+++ b/packages/viewer/src/lib/anchoring.ts
@@ -1,0 +1,255 @@
+import { diff_match_patch } from "diff-match-patch";
+
+import type { Selector } from "../types/comments";
+
+const CONTEXT_LENGTH = 32;
+
+/** Which strategy resolved a comment's stored selectors to a live Range. */
+export type AnchorStrategy = "position" | "quote" | "fuzzy";
+
+/** Result of resolving stored selectors against the live document. */
+export interface AnchorResult {
+  range: Range;
+  strategy: AnchorStrategy;
+}
+
+/** Threshold for fuzzy matching: 0.0 = perfect required, 1.0 = anything. */
+const FUZZY_THRESHOLD = 0.15;
+
+function getTextContent(container: HTMLElement): string {
+  return container.textContent ?? "";
+}
+
+/**
+ * Convert a DOM Range to an array of selectors for storage.
+ * Creates TextQuoteSelector (robust) + TextPositionSelector (fast).
+ */
+export function rangeToSelectors(range: Range, container: HTMLElement): Selector[] {
+  const text = getTextContent(container);
+  const exact = range.toString();
+  if (!exact) return [];
+
+  const preRange = document.createRange();
+  preRange.setStart(container, 0);
+  preRange.setEnd(range.startContainer, range.startOffset);
+  const start = preRange.toString().length;
+  const end = start + exact.length;
+
+  const prefix = text.slice(Math.max(0, start - CONTEXT_LENGTH), start);
+  const suffix = text.slice(end, end + CONTEXT_LENGTH);
+
+  return [
+    { type: "TextQuoteSelector", exact, prefix, suffix },
+    { type: "TextPositionSelector", start, end },
+  ];
+}
+
+function findTextPosition(
+  container: HTMLElement,
+  targetOffset: number,
+): { node: Text; offset: number } | null {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let currentOffset = 0;
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Text;
+    const nodeLength = node.textContent?.length ?? 0;
+    if (currentOffset + nodeLength >= targetOffset) {
+      return { node, offset: targetOffset - currentOffset };
+    }
+    currentOffset += nodeLength;
+  }
+  return null;
+}
+
+/**
+ * Re-anchor stored selectors to a live DOM Range.
+ *
+ * Resolution order:
+ *   1. TextPositionSelector — instant if the offset still points to the
+ *      stored quote (validates against TextQuoteSelector.exact when present).
+ *   2. TextQuoteSelector — exact substring match. Every occurrence in the
+ *      document is scored against the stored prefix/suffix context; the
+ *      highest-scoring occurrence wins. The position selector is a tiebreaker
+ *      (closest to the original offset), not a search constraint — see N2.
+ *   3. Fuzzy match via diff-match-patch — finds an approximate occurrence
+ *      near the position hint when the exact substring no longer appears
+ *      (typo fix, paragraph split that drops a space, etc.). Marked as
+ *      `strategy: 'fuzzy'` so the UI can flag it.
+ */
+export function selectorsToRange(
+  selectors: Selector[],
+  container: HTMLElement,
+): AnchorResult | null {
+  const posSelector = selectors.find(
+    (s): s is Extract<Selector, { type: "TextPositionSelector" }> =>
+      s.type === "TextPositionSelector",
+  );
+  const quoteSelector = selectors.find(
+    (s): s is Extract<Selector, { type: "TextQuoteSelector" }> => s.type === "TextQuoteSelector",
+  );
+
+  if (posSelector) {
+    const range = positionToRange(posSelector, container);
+    if (range && quoteSelector) {
+      if (range.toString() === quoteSelector.exact) {
+        return { range, strategy: "position" };
+      }
+    } else if (range) {
+      return { range, strategy: "position" };
+    }
+  }
+
+  if (quoteSelector) {
+    const range = quoteToRange(quoteSelector, container, posSelector?.start);
+    if (range) return { range, strategy: "quote" };
+
+    const fuzzy = fuzzyToRange(quoteSelector, container, posSelector?.start);
+    if (fuzzy) return { range: fuzzy, strategy: "fuzzy" };
+  }
+
+  return null;
+}
+
+function positionToRange(
+  selector: Extract<Selector, { type: "TextPositionSelector" }>,
+  container: HTMLElement,
+): Range | null {
+  const start = findTextPosition(container, selector.start);
+  const end = findTextPosition(container, selector.end);
+  if (!start || !end) return null;
+
+  try {
+    const range = document.createRange();
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
+    return range;
+  } catch {
+    return null;
+  }
+}
+
+function quoteToRange(
+  selector: Extract<Selector, { type: "TextQuoteSelector" }>,
+  container: HTMLElement,
+  positionHint?: number,
+): Range | null {
+  const text = getTextContent(container);
+  const { exact, prefix, suffix } = selector;
+
+  // Collect ALL occurrences and score each by context. The position hint is a
+  // tiebreaker, not a search constraint — otherwise an occurrence earlier than
+  // the hint would be skipped (the bug uncovered by scenario N2).
+  let bestIndex = -1;
+  let bestScore = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  let index = text.indexOf(exact);
+  while (index !== -1) {
+    const score = scoreContext(text, index, exact.length, prefix, suffix);
+    const distance = positionHint === undefined ? 0 : Math.abs(index - positionHint);
+    if (score > bestScore || (score === bestScore && distance < bestDistance)) {
+      bestScore = score;
+      bestDistance = distance;
+      bestIndex = index;
+    }
+    index = text.indexOf(exact, index + 1);
+  }
+
+  if (bestIndex === -1) return null;
+
+  const start = findTextPosition(container, bestIndex);
+  const end = findTextPosition(container, bestIndex + exact.length);
+  if (!start || !end) return null;
+
+  try {
+    const range = document.createRange();
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
+    return range;
+  } catch {
+    return null;
+  }
+}
+
+function scoreContext(
+  text: string,
+  index: number,
+  length: number,
+  prefix: string,
+  suffix: string,
+): number {
+  let score = 0;
+  const actualPrefix = text.slice(Math.max(0, index - prefix.length), index);
+  const actualSuffix = text.slice(index + length, index + length + suffix.length);
+
+  for (let i = 0; i < Math.min(prefix.length, actualPrefix.length); i++) {
+    if (prefix[prefix.length - 1 - i] === actualPrefix[actualPrefix.length - 1 - i]) {
+      score++;
+    } else {
+      break;
+    }
+  }
+
+  for (let i = 0; i < Math.min(suffix.length, actualSuffix.length); i++) {
+    if (suffix[i] === actualSuffix[i]) {
+      score++;
+    } else {
+      break;
+    }
+  }
+
+  return score;
+}
+
+function fuzzyToRange(
+  selector: Extract<Selector, { type: "TextQuoteSelector" }>,
+  container: HTMLElement,
+  positionHint?: number,
+): Range | null {
+  const text = getTextContent(container);
+  const pattern = selector.exact;
+  if (!pattern || !text) return null;
+
+  // diff-match-patch's match_main works in chunks of 32 chars internally; for
+  // longer patterns it splits and stitches. Anything longer than the document
+  // can't match; bail early.
+  if (pattern.length > text.length) return null;
+
+  const dmp = new diff_match_patch();
+  dmp.Match_Threshold = FUZZY_THRESHOLD;
+  // Allow the match to drift a few quote-lengths from the stored position;
+  // beyond that the position hint stops being meaningful.
+  dmp.Match_Distance = pattern.length * 4;
+
+  const expectedLoc = positionHint ?? 0;
+  // match_main throws "Pattern too long for this browser." when pattern.length
+  // exceeds Match_MaxBits (default 32) and no exact substring equals it at the
+  // hinted offset. Treat that as "no fuzzy match" instead of letting the
+  // exception bubble up and break the caller's anchoring pass.
+  let index: number;
+  try {
+    index = dmp.match_main(text, pattern, expectedLoc);
+  } catch {
+    return null;
+  }
+  if (index === -1) return null;
+
+  // diff-match-patch returns a starting index but not a length — it found a
+  // region "similar to" the pattern. The actual matched substring may be
+  // slightly shorter or longer than `pattern.length`. Anchor to a window of
+  // exactly `pattern.length` starting at `index`; this is what Hypothesis
+  // does and gives a reasonable visible highlight in practice.
+  const start = findTextPosition(container, index);
+  const end = findTextPosition(container, Math.min(index + pattern.length, text.length));
+  if (!start || !end) return null;
+
+  try {
+    const range = document.createRange();
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
+    return range;
+  } catch {
+    return null;
+  }
+}

--- a/packages/viewer/src/lib/context.ts
+++ b/packages/viewer/src/lib/context.ts
@@ -5,6 +5,7 @@ import type { Page } from "../state/page.svelte";
 import type { Navigation } from "../state/navigation.svelte";
 import type { LiveReload } from "../state/liveReload.svelte";
 import type { Ui } from "../state/ui.svelte";
+import type { Comments } from "../state/comments.svelte";
 
 export interface RwContext {
   apiClient: ApiClient;
@@ -13,6 +14,7 @@ export interface RwContext {
   navigation: Navigation;
   liveReload: LiveReload;
   ui: Ui;
+  comments: Comments;
   resolveSectionRefs?: (refs: string[]) => Promise<Record<string, string>>;
 }
 

--- a/packages/viewer/src/state/comments.svelte.ts
+++ b/packages/viewer/src/state/comments.svelte.ts
@@ -1,0 +1,137 @@
+import type { AnchorStrategy } from "../lib/anchoring";
+import type { CommentApiClient } from "../api/comments";
+import type { Comment, CreateCommentRequest, Selector } from "../types/comments";
+
+/** A new comment being drafted — selectors are captured, awaiting body text. */
+export interface PendingComment {
+  documentId: string;
+  selectors: Selector[];
+}
+
+export class Comments {
+  /** Whether the backend supports comments. */
+  enabled = $state(false);
+  items = $state.raw<Comment[]>([]);
+  loading = $state(false);
+  error = $state<string | null>(null);
+  activeId = $state<string | null>(null);
+  /** Vertical offset of the active highlight relative to the content area. */
+  activeTop = $state<number | null>(null);
+  /** Inline thread ids in current document order (by resolved DOM Range).
+   *  Written by PageContent whenever highlights re-anchor; consumed by the
+   *  sidebar to order prev/next navigation. Stored positions are stale when
+   *  the document has been edited between comment creations, so ordering
+   *  must come from the live DOM. */
+  order = $state.raw<string[]>([]);
+  /** Per-comment anchor strategy from the most recent re-anchor pass.
+   *  Comments anchored via 'fuzzy' get a "re-anchored" indicator in the UI. */
+  anchorStrategies = $state.raw<Map<string, AnchorStrategy>>(new Map());
+  /** Ids of inline comments whose stored selectors no longer anchor to any
+   *  text in the current document. The viewer surfaces these in the page
+   *  comments timeline below the article (with their stored quote as context)
+   *  instead of silently hiding them.
+   *  Written by PageContent after each re-anchor pass. */
+  orphanIds = $state.raw<Set<string>>(new Set());
+  /** New comment being drafted (shown in sidebar). */
+  pending = $state<PendingComment | null>(null);
+  /** Vertical offset for the pending comment form. */
+  pendingTop = $state<number | null>(null);
+
+  private apiClient: CommentApiClient;
+  private abortController: AbortController | null = null;
+  private documentId: string | null = null;
+
+  constructor(apiClient: CommentApiClient) {
+    this.apiClient = apiClient;
+  }
+
+  load = async (documentId: string) => {
+    if (!this.enabled) return;
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+    this.abortController = new AbortController();
+    const signal = this.abortController.signal;
+
+    if (documentId !== this.documentId) {
+      this.activeId = null;
+      this.clearPending();
+      this.documentId = documentId;
+    }
+    this.loading = true;
+    this.error = null;
+    try {
+      const items = await this.apiClient.list(documentId, { signal });
+      if (signal.aborted) return;
+      this.items = items;
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      this.error = e instanceof Error ? e.message : "Failed to load comments";
+      this.items = [];
+    } finally {
+      if (this.abortController?.signal === signal) {
+        this.abortController = null;
+      }
+      if (!signal.aborted) {
+        this.loading = false;
+      }
+    }
+  };
+
+  create = async (input: CreateCommentRequest) => {
+    const comment = await this.apiClient.create(input);
+    this.items = [...this.items, comment];
+    return comment;
+  };
+
+  resolve = async (id: string) => {
+    const updated = await this.apiClient.update(id, { status: "resolved" });
+    this.items = this.items.map((c) => (c.id === id ? updated : c));
+  };
+
+  reopen = async (id: string) => {
+    const updated = await this.apiClient.update(id, { status: "open" });
+    this.items = this.items.map((c) => (c.id === id ? updated : c));
+  };
+
+  get threads(): Comment[] {
+    return this.items.filter((c) => !c.parentId);
+  }
+
+  get inlineThreads(): Comment[] {
+    return this.items.filter(
+      (c) => !c.parentId && c.selectors.length > 0 && !this.orphanIds.has(c.id),
+    );
+  }
+
+  /** Top-level threads shown in the page comments timeline below the article.
+   *  Includes native page comments (no selectors) and orphaned inline comments
+   *  whose stored selectors no longer anchor. */
+  get pageThreads(): Comment[] {
+    return this.items.filter(
+      (c) => !c.parentId && (c.selectors.length === 0 || this.orphanIds.has(c.id)),
+    );
+  }
+
+  replies(parentId: string): Comment[] {
+    return this.items.filter((c) => c.parentId === parentId);
+  }
+
+  clearPending = () => {
+    this.pending = null;
+    this.pendingTop = null;
+  };
+
+  clear = () => {
+    this.items = [];
+    this.loading = false;
+    this.error = null;
+    this.activeId = null;
+    this.activeTop = null;
+    this.order = [];
+    this.anchorStrategies = new Map();
+    this.orphanIds = new Set();
+    this.documentId = null;
+    this.clearPending();
+  };
+}

--- a/packages/viewer/src/styles/content.css
+++ b/packages/viewer/src/styles/content.css
@@ -246,3 +246,19 @@
     @apply text-red-600 underline decoration-wavy cursor-not-allowed dark:text-red-400;
   }
 }
+
+/* Comment highlights */
+::highlight(rw-comments) {
+  background-color: rgba(255, 212, 0, 0.25);
+}
+/* Fuzzy-anchored comments — exact text drifted, re-anchor is approximate.
+ * Same yellow at lower opacity so the threading still reads as a comment,
+ * with a dashed underline to signal "may have moved". */
+::highlight(rw-comments-fuzzy) {
+  background-color: rgba(255, 212, 0, 0.15);
+  text-decoration: underline dashed rgba(180, 130, 0, 0.7);
+  text-underline-offset: 2px;
+}
+::highlight(rw-comment-active) {
+  background-color: rgba(255, 212, 0, 0.5);
+}

--- a/packages/viewer/src/types/comments.ts
+++ b/packages/viewer/src/types/comments.ts
@@ -1,0 +1,38 @@
+/** A selector anchoring a comment to text. */
+export type Selector =
+  | { type: "TextQuoteSelector"; exact: string; prefix: string; suffix: string }
+  | { type: "TextPositionSelector"; start: number; end: number }
+  | { type: "CSSSelector"; value: string };
+
+export type CommentStatus = "open" | "resolved";
+
+export interface Author {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+}
+
+export interface Comment {
+  id: string;
+  documentId: string;
+  parentId?: string;
+  author: Author;
+  body: string;
+  selectors: Selector[];
+  status: CommentStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateCommentRequest {
+  documentId: string;
+  parentId?: string;
+  body: string;
+  selectors: Selector[];
+}
+
+export interface UpdateCommentRequest {
+  body?: string;
+  status?: CommentStatus;
+  selectors?: Selector[];
+}

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -93,4 +93,5 @@ export interface ApiError {
 /** Server config from GET /api/config */
 export interface ConfigResponse {
   liveReloadEnabled: boolean;
+  commentsEnabled?: boolean;
 }


### PR DESCRIPTION
## Summary

- Inline comments anchored to text ranges via W3C Web Annotation selectors (TextQuoteSelector + TextPositionSelector, UTF-16 offsets to match `String.length`) with a browser UI: highlight, selection popover, threaded sidebar that replaces the ToC, resolve/reopen, prev/next navigation in live DOM order. Fuzzy re-anchoring (diff-match-patch) marks moved comments as re-anchored; passages that can no longer be located surface as orphans in the page timeline below the article.
- Page-level comments rendered below the article — same thread UI, no selectors.
- `rw comment` CLI (`list` / `show` / `add` / `reply` / `resolve`) that reads and writes the project's comment store directly — no running `rw serve` required. Identity via `--author-id` / `--author-name` or `RW_COMMENT_AUTHOR_{ID,NAME}`; inline anchoring via `--quote` (the CLI renders the target page in-process and rejects ambiguous or missing matches).
- New `rw-comments` crate (SQLite store at `.rw/comments/sqlite.db` with WAL, anchoring resolver, HTML→textContent extractor), `/api/comments` REST endpoints on the axum server, per-request author with `local:human` / `local:ai` avatar variants.

## Test plan

- [x] Playwright e2e tests for inline + page comments: creation, replies, resolve/reopen, prev/next nav, anchor alignment, persistence across reload
- [x] Rust tests for the store, anchoring (exact + fuzzy), HTML→text extractor (incl. surrogate-pair / non-BMP cases), REST handlers, and CLI subcommands
- [x] Manual: select text, add comment, verify highlight + threaded sidebar
- [x] Manual: reply, resolve, verify hidden from highlights and sidebar
- [x] Manual: multi-thread navigation via prev/next arrows
- [x] Manual: persistence across reloads (SQLite)
- [x] Manual: `rw comment add --quote …` lands a correctly anchored inline comment in `.rw/comments/sqlite.db` without `rw serve` running

🤖 Generated with [Claude Code](https://claude.com/claude-code)