### PR TITLE
fix(viewer): validate section-ref href schemes (CodeQL alerts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Page modification times (`lastModified` in API responses) now reflect the git commit time instead of the filesystem modification time — timestamps remain stable across `git checkout`, `git pull`, and branch switching
 - S3-published documentation bundles now include page modification times in the manifest — previously `lastModified` was always epoch zero for Backstage-served pages
 
+### Security
+
+- Cross-section link `href` values are now validated against an allowlist of safe URL schemes (`http`, `https`, `mailto`, `tel`, plus relative paths and fragments) — a host-provided `resolveSectionRefs` callback returning `javascript:` or other unsafe schemes is now rendered as `#` instead of producing a clickable XSS sink
+
 ## [0.1.24] - 2026-04-10
 
 ### Fixed

--- a/packages/viewer/src/lib/sectionRefs.test.ts
+++ b/packages/viewer/src/lib/sectionRefs.test.ts
@@ -82,6 +82,34 @@ describe("rewriteSectionRefLinks", () => {
     expect(link.getAttribute("href")).toBe("/catalog/default/domain/billing/docs");
   });
 
+  it("blocks javascript: URLs from a malicious resolver", async () => {
+    const container = createContainer(
+      '<a href="/domains/billing" data-section-ref="domain:default/billing" data-section-path="">Billing</a>',
+    );
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "javascript:alert(1)",
+    });
+
+    await rewriteSectionRefLinks(container, resolver, () => "");
+
+    const link = container.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("#");
+  });
+
+  it("preserves hash fragments in section paths", async () => {
+    const container = createContainer(
+      '<a href="/domains/billing/api" data-section-ref="domain:default/billing" data-section-path="api#install">Install</a>',
+    );
+    const resolver = vi.fn().mockResolvedValue({
+      "domain:default/billing": "/catalog/default/domain/billing/docs",
+    });
+
+    await rewriteSectionRefLinks(container, resolver, () => "");
+
+    const link = container.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("/catalog/default/domain/billing/docs/api#install");
+  });
+
   it("skips container with no section-ref links", async () => {
     const container = createContainer('<a href="/about">About</a>');
     const resolver = vi.fn();

--- a/packages/viewer/src/lib/sectionRefs.ts
+++ b/packages/viewer/src/lib/sectionRefs.ts
@@ -2,6 +2,14 @@ import type { SectionInfo, ScopeInfo, NavItem, Breadcrumb, NavigationTree } from
 
 export type SectionRefResolver = (refs: string[]) => Promise<Record<string, string>>;
 
+// Allowlist matching the Angular/DOMPurify pattern: known safe schemes, or
+// anything that isn't obviously a scheme (relative paths, fragments, queries).
+const SAFE_HREF = /^(?:(?:https?|mailto|tel):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+
+function safeHref(candidate: string): string {
+  return SAFE_HREF.test(candidate) ? candidate : "#";
+}
+
 /**
  * Build a ref string from section info (e.g., "domain:default/billing").
  * Namespace is always "default" — the backend does not expose namespace yet.
@@ -35,7 +43,8 @@ export async function rewriteSectionRefLinks(
     const ref = link.getAttribute("data-section-ref")!;
     const sectionPath = link.getAttribute("data-section-path") ?? "";
     const baseUrl = resolved[ref] ?? getBasePath();
-    link.setAttribute("href", sectionPath ? `${baseUrl}/${sectionPath}` : baseUrl);
+    const href = sectionPath ? `${baseUrl}/${sectionPath}` : baseUrl;
+    link.setAttribute("href", safeHref(href));
   }
 }
 


### PR DESCRIPTION
## Summary

- Guards CodeQL [js/xss-through-dom alert #10](https://github.com/rwdocs/rw/security/code-scanning/10) on `packages/viewer/src/lib/sectionRefs.ts:38`. The viewer reads `data-section-path` from a DOM attribute and concatenates it with a host‑provided `baseUrl` before assigning to `<a href>`. While `data-section-path` itself is filesystem‑shaped (and HTML‑escaped on write by the Rust side), the `baseUrl` comes from the embedder's `resolveSectionRefs` callback — public API on `mountRw`, so a misconfigured host could return `javascript:`/`data:` and produce a clickable XSS sink.
- Adds a `safeHref` allowlist matching the Angular/DOMPurify pattern (`https?`, `mailto`, `tel`, plus relative paths and fragments). Anything else collapses to `#`.
- Branch is named for follow-up CodeQL alerts to land on the same PR or sibling branches.

## Test plan

- [x] `npm -w @rwdocs/viewer run test -- --run src/lib/sectionRefs.test.ts` — all 15 tests pass (13 existing + 2 new)
- [x] 100% coverage on `sectionRefs.ts`
- [ ] CodeQL re-runs on this PR and reports alert #10 resolved
- [ ] Manual smoke: `rw serve --embedded` still resolves cross-section links normally