### PR TITLE
chore: bump Rust toolchain to 1.95.0

### DIFF
--- a/crates/rw-diagrams/src/processor.rs
+++ b/crates/rw-diagrams/src/processor.rs
@@ -1051,7 +1051,7 @@ mod tests {
     fn test_timeout_builder() {
         // Test that timeout builder method works and can be chained
         let processor = DiagramProcessor::new("https://kroki.io")
-            .timeout(Duration::from_secs(60))
+            .timeout(Duration::from_mins(1))
             .dpi(96);
 
         // Verify the processor was created successfully and can process diagrams

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
## Summary

- Bump `rust-toolchain.toml` from 1.93.0 to 1.95.0
- Fix one new `clippy::duration_suboptimal_units` lint in a `rw-diagrams` test (`from_secs(60)` → `from_mins(1)`)

Reviewed 1.94 and 1.95 changelogs — no breaking changes affect this codebase (no `#[macro_use]`, no `use $crate::{self};`, no pre-epoch `SystemTime::checked_sub_duration`, no exotic `dyn` lifetime casts, no gated `mut ref` patterns).

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)