### PR TITLE
feat(viewer): add Badge primitive for design kit

### DIFF
--- a/packages/viewer/src/components/comments/CommentThread.svelte
+++ b/packages/viewer/src/components/comments/CommentThread.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Comment } from "../../types/comments";
+  import Badge from "../../lib/ui/primitives/Badge.svelte";
   import Avatar from "./Avatar.svelte";
   import CommentForm from "./CommentForm.svelte";
 
@@ -106,9 +107,7 @@
           dark:border-neutral-700
         "
       >
-        <span class="text-xs text-gray-500 dark:text-neutral-400">
-          {nav.index + 1} / {nav.total}
-        </span>
+        <Badge intent="neutral" size="sm">{nav.index + 1} / {nav.total}</Badge>
         <div class="flex gap-1">
           <button
             type="button"
@@ -225,12 +224,14 @@
         {comment.author.name}
       </span>
       {#if fuzzy}
-        <span
-          class="text-xs text-amber-600 italic dark:text-amber-400"
+        <Badge
+          intent="warning"
+          size="sm"
+          class="italic"
           title="The exact passage this comment was attached to no longer appears in the page. The highlight is the closest match."
         >
           re-anchored
-        </span>
+        </Badge>
       {/if}
       <span class="ml-auto text-xs text-gray-400 dark:text-neutral-500">
         {formatRelativeTime(comment.createdAt)}

--- a/packages/viewer/src/lib/ui/primitives/Badge.svelte
+++ b/packages/viewer/src/lib/ui/primitives/Badge.svelte
@@ -1,0 +1,54 @@
+<script module lang="ts">
+  type Intent = "neutral" | "info" | "warning" | "attention";
+  type Size = "sm" | "md";
+
+  // Tailwind's JIT needs full class strings present in source to compile them,
+  // so intent/size classes are complete-string lookup tables rather than
+  // interpolated `bg-${intent}-bg` that would fail to generate utilities.
+  const INTENT_CLASSES: Record<Intent, string> = {
+    // Neutral reads from the page's own surface scale rather than the status
+    // triples so it blends in as a secondary/metadata chip (e.g. counters).
+    neutral: "bg-bg-subtle text-fg-muted",
+    info: "bg-info-bg text-info-fg",
+    warning: "bg-warning-bg text-warning-fg",
+    attention: "bg-attention-bg text-attention-fg",
+  };
+
+  const SIZE_CLASSES: Record<Size, string> = {
+    sm: "px-1.5 py-0.5 text-xs",
+    md: "px-2 py-0.5 text-sm",
+  };
+</script>
+
+<script lang="ts">
+  import type { HTMLAttributes } from "svelte/elements";
+  import type { Snippet } from "svelte";
+
+  interface Props extends HTMLAttributes<HTMLSpanElement> {
+    intent?: Intent;
+    size?: Size;
+    children?: Snippet;
+  }
+
+  let {
+    intent = "neutral",
+    size = "sm",
+    class: extraClass = "",
+    children,
+    ...rest
+  }: Props = $props();
+</script>
+
+<span
+  {...rest}
+  class="
+    inline-flex items-center rounded-sm font-medium
+    {INTENT_CLASSES[intent]}
+    {SIZE_CLASSES[size]}
+    {extraClass}
+  "
+>
+  {#if children}
+    {@render children()}
+  {/if}
+</span>

--- a/packages/viewer/src/lib/ui/primitives/Badge.test.ts
+++ b/packages/viewer/src/lib/ui/primitives/Badge.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import Harness from "./__fixtures__/BadgeHarness.svelte";
+
+describe("Badge", () => {
+  it("renders body text", () => {
+    const { getByText } = render(Harness, { body: "beta" });
+    expect(getByText("beta")).toBeTruthy();
+  });
+
+  it("merges extra class prop onto the root", () => {
+    const { getByText } = render(Harness, { body: "x", class: "italic" });
+    expect(getByText("x").className).toContain("italic");
+  });
+
+  it("forwards HTML attributes like title onto the root span", () => {
+    const { getByText } = render(Harness, { body: "x", title: "tooltip" });
+    expect(getByText("x").getAttribute("title")).toBe("tooltip");
+  });
+
+  it("renders as a <span>", () => {
+    const { getByText } = render(Harness, { body: "x" });
+    expect(getByText("x").tagName).toBe("SPAN");
+  });
+});

--- a/packages/viewer/src/lib/ui/primitives/__fixtures__/BadgeHarness.svelte
+++ b/packages/viewer/src/lib/ui/primitives/__fixtures__/BadgeHarness.svelte
@@ -1,0 +1,14 @@
+<!--
+  Minimal harness so tests can render <Badge> with plain text children
+  without plumbing createRawSnippet at every call site.
+-->
+<script lang="ts">
+  import type { ComponentProps } from "svelte";
+  import Badge from "../Badge.svelte";
+
+  type HarnessProps = Omit<ComponentProps<typeof Badge>, "children"> & { body?: string };
+
+  let { body = "Badge", ...rest }: HarnessProps = $props();
+</script>
+
+<Badge {...rest}>{body}</Badge>


### PR DESCRIPTION
## Summary

- Third design-kit primitive (after Button #300 and Alert #301). Small pill/chip component under `packages/viewer/src/lib/ui/primitives/` with `intent` (neutral / info / warning / attention) × `size` (sm / md), rest-spread HTML attrs, and class passthrough.
- Replaces two inlined badge-shaped spans in `CommentThread.svelte`:
  - the `{index}/{total}` thread counter (was `text-xs text-gray-500 dark:text-neutral-400` — now `intent="neutral"`)
  - the `re-anchored` fuzzy-match label (was `text-xs text-amber-600 italic dark:text-amber-400` — now `intent="warning" class="italic"`)
- Consumes the semantic tokens from the two-tier system (`bg-info-bg`, `text-warning-fg`, etc.). The `neutral` intent reads from the surface scale (`bg-bg-subtle` / `text-fg-muted`) rather than a status triple so metadata chips blend in instead of shouting.
- Intent union is intentionally a subset of Alert's (no `success` / `danger` yet) — YAGNI, add when a consumer appears.

No CHANGELOG entry — swapping one span for another in the comment thread is not a user-visible behavior change.

## Test plan

- [x] `npm run test` — 4 Badge tests pass (behavioral only: renders body, merges `class`, forwards HTML attrs, renders as `<span>`); full viewer suite green
- [x] `npm run lint` — clean
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run build` — all 8 Badge intent/size utilities present in the compiled CSS bundle
- [ ] Visual smoke in-browser: thread counter and re-anchored label render in light + dark mode with legible contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)