### PR TITLE
feat(viewer): add Quote primitive for design kit

### DIFF
--- a/packages/viewer/src/components/comments/PageComments.svelte
+++ b/packages/viewer/src/components/comments/PageComments.svelte
@@ -4,6 +4,7 @@
   import CommentThread from "./CommentThread.svelte";
   import CommentForm from "./CommentForm.svelte";
   import Alert from "../../lib/ui/primitives/Alert.svelte";
+  import Quote from "../../lib/ui/primitives/Quote.svelte";
 
   const { comments, page } = getRwContext();
 
@@ -86,24 +87,14 @@
         {@const quote = thread.selectors.length > 0 ? findQuote(thread.selectors) : null}
         <div>
           {#if quote}
-            <!-- Orphaned inline comment: the stored passage no longer appears
-                 in the page, so we show the quote (with its captured context)
-                 verbatim above the thread. -->
-            <blockquote
+            <Quote
               data-testid="orphan-quote"
               title="This comment was attached to a passage that no longer appears on the page."
-              class="
-                mb-2 border-l-2 border-amber-300 pl-3 text-sm text-gray-600 italic
-                dark:border-amber-500/60 dark:text-neutral-400
-              "
-            >
-              {#if quote.prefix}<span class="opacity-70">…{quote.prefix}</span>{/if}<mark
-                class="
-                  rounded-sm bg-[rgba(255,212,0,0.4)] px-0.5 text-inherit not-italic
-                  dark:bg-[rgba(255,212,0,0.25)]
-                ">{quote.exact}</mark
-              >{#if quote.suffix}<span class="opacity-70">{quote.suffix}…</span>{/if}
-            </blockquote>
+              class="mb-2"
+              prefix={quote.prefix}
+              exact={quote.exact}
+              suffix={quote.suffix}
+            />
           {/if}
           <CommentThread
             comment={thread}

--- a/packages/viewer/src/lib/ui/primitives/Quote.svelte
+++ b/packages/viewer/src/lib/ui/primitives/Quote.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { HTMLAttributes } from "svelte/elements";
+
+  interface Props extends HTMLAttributes<HTMLQuoteElement> {
+    prefix?: string;
+    exact: string;
+    suffix?: string;
+  }
+
+  let { prefix, exact, suffix, class: extraClass = "", ...rest }: Props = $props();
+</script>
+
+<!--
+  Whitespace between {#if} / <span> / <mark> is deliberately collapsed so
+  "…prefix" + exact + "suffix…" concatenate without stray spaces when
+  either context span is present.
+-->
+<blockquote
+  {...rest}
+  class="
+    border-l-2 border-(--highlight-comment-border) pl-3 text-sm text-fg-muted italic
+    {extraClass}
+  "
+>
+  {#if prefix}<span class="opacity-70">…{prefix}</span>{/if}<mark
+    class="rounded-sm bg-(--highlight-comment) px-0.5 text-inherit not-italic">{exact}</mark
+  >{#if suffix}<span class="opacity-70">{suffix}…</span>{/if}
+</blockquote>

--- a/packages/viewer/src/lib/ui/primitives/Quote.test.ts
+++ b/packages/viewer/src/lib/ui/primitives/Quote.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import Quote from "./Quote.svelte";
+
+// Normalize insignificant whitespace (template indentation between the
+// opening <blockquote> tag and its first child) so assertions focus on
+// visible text rather than source formatting.
+const text = (node: Element) => node.textContent?.replace(/\s+/g, " ").trim() ?? "";
+
+describe("Quote", () => {
+  it("renders the exact passage inside a <mark>", () => {
+    const { container } = render(Quote, { exact: "the exact bit" });
+    const mark = container.querySelector("mark");
+    expect(mark?.textContent).toBe("the exact bit");
+  });
+
+  it("renders all three parts in order without stray separators", () => {
+    const { container } = render(Quote, {
+      prefix: "before ",
+      exact: "exact",
+      suffix: " after",
+    });
+    const bq = container.querySelector("blockquote")!;
+    expect(text(bq)).toBe("…before exact after…");
+  });
+
+  it("omits prefix and its ellipsis when prefix is absent", () => {
+    const { container } = render(Quote, { exact: "exact", suffix: " after" });
+    const bq = container.querySelector("blockquote")!;
+    expect(text(bq)).toBe("exact after…");
+  });
+
+  it("omits suffix and its ellipsis when suffix is absent", () => {
+    const { container } = render(Quote, { prefix: "before ", exact: "exact" });
+    const bq = container.querySelector("blockquote")!;
+    expect(text(bq)).toBe("…before exact");
+  });
+
+  it("renders only the exact text when both prefix and suffix are absent", () => {
+    const { container } = render(Quote, { exact: "exact" });
+    const bq = container.querySelector("blockquote")!;
+    expect(text(bq)).toBe("exact");
+  });
+
+  it("renders as a <blockquote>", () => {
+    const { container } = render(Quote, { exact: "x" });
+    expect(container.querySelector("blockquote")).toBeTruthy();
+  });
+
+  it("merges extra class prop onto the root", () => {
+    const { container } = render(Quote, { exact: "x", class: "mb-4" });
+    expect(container.querySelector("blockquote")?.className).toContain("mb-4");
+  });
+
+  it("forwards HTML attributes like title onto the root", () => {
+    const { container } = render(Quote, { exact: "x", title: "tooltip" });
+    expect(container.querySelector("blockquote")?.getAttribute("title")).toBe("tooltip");
+  });
+});

--- a/packages/viewer/src/lib/ui/tokens/highlights.css
+++ b/packages/viewer/src/lib/ui/tokens/highlights.css
@@ -3,6 +3,7 @@
  */
 :root {
   --highlight-comment: color-mix(in srgb, var(--color-yellow-400) 25%, transparent);
+  --highlight-comment-border: color-mix(in srgb, var(--color-yellow-500) 60%, transparent);
   --highlight-comment-fuzzy: color-mix(in srgb, var(--color-yellow-400) 15%, transparent);
   --highlight-comment-fuzzy-underline: color-mix(in srgb, var(--color-yellow-700) 70%, transparent);
   --highlight-comment-active: color-mix(in srgb, var(--color-yellow-400) 50%, transparent);


### PR DESCRIPTION
## Summary

- Adds a `Quote` primitive that renders a TextQuoteSelector-style passage (`prefix · exact · suffix`) as a `<blockquote>`, with the exact span wrapped in `<mark>` using the comment-highlight palette.
- Introduces `--highlight-comment-border` alongside `--highlight-comment` so the border draws from the comment palette rather than from the warning intent (which is also Alert's `warning` color).
- `PageComments` uses the primitive for the orphan-quote case (when a stored passage no longer appears in the rendered page).

## Test plan

- [ ] `npx vitest run` in `packages/viewer/` (224 tests, including 8 new Quote tests)
- [ ] `npx svelte-check` clean
- [ ] In `rw serve`, leave a comment on a passage, then edit the page so the passage no longer matches verbatim — orphan thread should render with the new amber-bordered blockquote
- [ ] Verify both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)