### PR TITLE
feat(viewer): useActiveHeading hook + lift TOC scroll-spy to Layout

### DIFF
--- a/packages/viewer/src/components/Layout.svelte
+++ b/packages/viewer/src/components/Layout.svelte
@@ -11,6 +11,7 @@
   import LoadingBar from "./LoadingBar.svelte";
   import CommentSidebar from "./comments/CommentSidebar.svelte";
   import Alert from "../lib/ui/primitives/Alert.svelte";
+  import { useActiveHeading } from "../lib/ui/hooks/useActiveHeading.svelte";
 
   interface Props {
     children: Snippet;
@@ -20,6 +21,50 @@
 
   const { router, navigation, page, ui, comments } = getRwContext();
   const homeHref = router.prefixPath("/");
+
+  // h1 is the page title; h4+ makes the sidebar too noisy.
+  let tocEntries = $derived(
+    page.data?.toc.filter((entry) => entry.level >= 2 && entry.level <= 3) ?? [],
+  );
+  let tocIds = $derived(tocEntries.map((entry) => entry.id));
+
+  const activeHeading = useActiveHeading(() => tocIds);
+
+  function onTocNavigate(id: string) {
+    const element = document.getElementById(id);
+    if (!element) return;
+    activeHeading.setActiveId(id);
+    element.scrollIntoView({ behavior: "auto" });
+    history.pushState(null, "", `#${id}`);
+    activeHeading.suppressUntilScrollEnd();
+  }
+
+  // Hash → active heading. Outside embedded mode the browser natively
+  // scrolls on hash change, so hold the observer back until scrollend; in
+  // embedded mode the hash never triggers a scroll (popstate below does).
+  $effect(() => {
+    const hash = router.hash;
+    if (hash && untrack(() => tocIds).includes(hash)) {
+      activeHeading.setActiveId(hash);
+      if (!router.embedded) activeHeading.suppressUntilScrollEnd();
+    }
+  });
+
+  // In embedded mode, the router skips popstate handling so Back/Forward
+  // would otherwise silently leave the page scrolled where it was. Scroll
+  // to the referenced heading ourselves.
+  $effect(() => {
+    if (!router.embedded) return;
+    function onPopState() {
+      const id = decodeURIComponent(window.location.hash.slice(1));
+      if (id && tocIds.includes(id)) {
+        activeHeading.setActiveId(id);
+        document.getElementById(id)?.scrollIntoView({ behavior: "auto" });
+      }
+    }
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  });
 
   // Scroll to top when navigating to a new page (without hash)
   $effect(() => {
@@ -57,9 +102,13 @@
       <div class="min-w-0 flex-1">
         <Breadcrumbs breadcrumbs={page.data.breadcrumbs} compact />
       </div>
-      {#if page.data.toc.length > 0}
+      {#if tocEntries.length > 0}
         <div class="ml-2 shrink-0">
-          <TocPopover toc={page.data.toc} />
+          <TocPopover
+            toc={tocEntries}
+            activeId={activeHeading.activeId}
+            onNavigate={onTocNavigate}
+          />
         </div>
       {/if}
     {/if}
@@ -99,9 +148,13 @@
     <div class="layout-content-area min-w-0" data-testid="content-area">
       <div class="layout-content mx-auto max-w-6xl px-4 pt-6 pb-12">
         {#if page.data}
-          {#if page.data.toc.length > 0}
+          {#if tocEntries.length > 0}
             <div class="layout-toc-popover sticky top-6 z-30 float-right">
-              <TocPopover toc={page.data.toc} />
+              <TocPopover
+                toc={tocEntries}
+                activeId={activeHeading.activeId}
+                onNavigate={onTocNavigate}
+              />
             </div>
           {/if}
           <div class="layout-desktop-breadcrumbs">
@@ -124,13 +177,17 @@
                 <CommentSidebar />
               </div>
             </aside>
-          {:else if page.data && page.data.toc.length > 0}
+          {:else if page.data && tocEntries.length > 0}
             <aside aria-label="Page outline" class="layout-toc hidden w-[320px] shrink-0">
               <div
                 class="layout-toc-sticky sticky top-6 overflow-y-auto pl-8"
                 data-testid="toc-sticky-wrapper"
               >
-                <TocSidebar toc={page.data.toc} />
+                <TocSidebar
+                  toc={tocEntries}
+                  activeId={activeHeading.activeId}
+                  onNavigate={onTocNavigate}
+                />
               </div>
             </aside>
           {/if}

--- a/packages/viewer/src/components/TocPopover.svelte
+++ b/packages/viewer/src/components/TocPopover.svelte
@@ -7,9 +7,11 @@
 
   interface Props {
     toc: TocEntry[];
+    activeId: string | null;
+    onNavigate: (id: string) => void;
   }
 
-  let { toc }: Props = $props();
+  let { toc, activeId, onNavigate }: Props = $props();
 
   const { router } = getRwContext();
 
@@ -54,6 +56,13 @@
       dark:border-neutral-600 dark:bg-neutral-800
     "
   >
-    <TocSidebar {toc} onnavigate={() => (open = false)} />
+    <TocSidebar
+      {toc}
+      {activeId}
+      onNavigate={(id) => {
+        onNavigate(id);
+        open = false;
+      }}
+    />
   </nav>
 </Popover>

--- a/packages/viewer/src/components/TocSidebar.svelte
+++ b/packages/viewer/src/components/TocSidebar.svelte
@@ -1,144 +1,13 @@
 <script lang="ts">
-  import { getRwContext } from "../lib/context";
   import type { TocEntry } from "../types";
 
   interface Props {
     toc: TocEntry[];
-    onnavigate?: () => void;
+    activeId: string | null;
+    onNavigate: (id: string) => void;
   }
 
-  let { toc, onnavigate }: Props = $props();
-
-  const { router } = getRwContext();
-
-  // Filter to only show h2 and h3 (two levels deep, excludes h1)
-  let filteredToc = $derived(toc.filter((entry) => entry.level >= 2 && entry.level <= 3));
-
-  let activeId = $state<string | null>(null);
-  let isUserScrolling = false;
-
-  /** Mark scroll in progress and reset after the browser finishes scrolling. */
-  function waitForScrollEnd() {
-    isUserScrolling = true;
-    const scrollBefore = window.scrollY;
-    requestAnimationFrame(() => {
-      if (window.scrollY === scrollBefore) {
-        isUserScrolling = false;
-      } else {
-        const fallback = setTimeout(() => {
-          isUserScrolling = false;
-        }, 500);
-        window.addEventListener(
-          "scrollend",
-          () => {
-            clearTimeout(fallback);
-            isUserScrolling = false;
-          },
-          { once: true },
-        );
-      }
-    });
-  }
-
-  // React to hash changes (e.g., when page loads with #hash or when clicking links)
-  $effect(() => {
-    const currentHash = router.hash;
-    if (currentHash && filteredToc.some((entry) => entry.id === currentHash)) {
-      activeId = currentHash;
-
-      if (!router.embedded) {
-        waitForScrollEnd();
-      }
-    }
-  });
-
-  function scrollToHeading(event: MouseEvent, id: string) {
-    event.preventDefault();
-    const element = document.getElementById(id);
-    if (element) {
-      activeId = id;
-      element.scrollIntoView({ behavior: "auto" });
-      history.pushState(null, "", `#${id}`);
-      waitForScrollEnd();
-    }
-  }
-
-  $effect(() => {
-    if (filteredToc.length === 0) return;
-
-    // Track visible headings
-    const visibleHeadings = new Set<string>();
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            visibleHeadings.add(entry.target.id);
-          } else {
-            visibleHeadings.delete(entry.target.id);
-          }
-        }
-
-        // Skip updates during programmatic scrolling
-        if (isUserScrolling) {
-          return;
-        }
-
-        // Find the topmost visible heading based on ToC order
-        for (const tocEntry of filteredToc) {
-          if (visibleHeadings.has(tocEntry.id)) {
-            activeId = tocEntry.id;
-            return;
-          }
-        }
-
-        // If no headings are visible, keep the last active one
-      },
-      {
-        // Trigger when heading enters the top 20% of viewport
-        rootMargin: "-10% 0px -80% 0px",
-        threshold: 0,
-      },
-    );
-
-    // Observe all headings from ToC
-    for (const entry of filteredToc) {
-      const element = document.getElementById(entry.id);
-      if (element) {
-        observer.observe(element);
-      }
-    }
-
-    // Set initial active heading to first one (only if no hash-based selection)
-    if (filteredToc.length > 0 && !activeId) {
-      activeId = filteredToc[0].id;
-    }
-
-    // In embedded mode, the router skips popstate handling. Listen here so
-    // browser Back/Forward after TOC clicks scrolls to the correct heading.
-    const handlePopState = router.embedded
-      ? () => {
-          const id = decodeURIComponent(window.location.hash.slice(1));
-          if (id && filteredToc.some((entry) => entry.id === id)) {
-            activeId = id;
-            const element = document.getElementById(id);
-            if (element) {
-              element.scrollIntoView({ behavior: "auto" });
-            }
-          }
-        }
-      : null;
-    if (handlePopState) {
-      window.addEventListener("popstate", handlePopState);
-    }
-
-    return () => {
-      observer.disconnect();
-      if (handlePopState) {
-        window.removeEventListener("popstate", handlePopState);
-      }
-    };
-  });
+  let { toc, activeId, onNavigate }: Props = $props();
 </script>
 
 <div>
@@ -148,13 +17,13 @@
     On this page
   </h3>
   <ul class="space-y-1.5">
-    {#each filteredToc as entry (entry.id)}
+    {#each toc as entry (entry.id)}
       <li class={entry.level === 3 ? "ml-3" : ""}>
         <a
           href="#{entry.id}"
           onclick={(e) => {
-            scrollToHeading(e, entry.id);
-            onnavigate?.();
+            e.preventDefault();
+            onNavigate(entry.id);
           }}
           class="
             block text-sm/snug transition-colors

--- a/packages/viewer/src/lib/ui/hooks/__fixtures__/ActiveHeadingHarness.svelte
+++ b/packages/viewer/src/lib/ui/hooks/__fixtures__/ActiveHeadingHarness.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { useActiveHeading, type ActiveHeading } from "../useActiveHeading.svelte";
+
+  interface Props {
+    headingIds: string[];
+    onInit?: (handle: ActiveHeading) => void;
+  }
+
+  let { headingIds, onInit }: Props = $props();
+
+  const handle = useActiveHeading(() => headingIds);
+  // svelte-ignore state_referenced_locally
+  onInit?.(handle);
+</script>
+
+<div data-testid="active-heading" data-active={handle.activeId ?? ""}></div>

--- a/packages/viewer/src/lib/ui/hooks/useActiveHeading.svelte.ts
+++ b/packages/viewer/src/lib/ui/hooks/useActiveHeading.svelte.ts
@@ -1,0 +1,115 @@
+import { untrack } from "svelte";
+
+/**
+ * Scroll-spy: track which heading the reader is currently on, based on
+ * IntersectionObserver visibility.
+ *
+ * Given a reactive list of heading ids (document order), returns a handle
+ * whose `activeId` stays in sync with the topmost visible heading as the user
+ * scrolls. Consumers that perform programmatic scrolls — click-to-anchor,
+ * hash navigation, popstate — own the imperative side: they call
+ * `setActiveId` to update the handle immediately, then
+ * `suppressUntilScrollEnd` to hold the observer at bay until the browser
+ * finishes scrolling, so the observer's own callback does not overwrite the
+ * newly selected id mid-flight.
+ *
+ * The hook re-subscribes whenever `headingIds()` returns a different set;
+ * when the list changes and the current `activeId` is no longer in it, it
+ * resets to the first id so the UI never points at a heading that is no
+ * longer rendered.
+ */
+export interface ActiveHeading {
+  readonly activeId: string | null;
+  setActiveId(id: string | null): void;
+  suppressUntilScrollEnd(): void;
+}
+
+export function useActiveHeading(headingIds: () => string[]): ActiveHeading {
+  let activeId = $state<string | null>(null);
+  let suppressed = false;
+
+  function suppressUntilScrollEnd(): void {
+    suppressed = true;
+    const scrollBefore = window.scrollY;
+    requestAnimationFrame(() => {
+      if (window.scrollY === scrollBefore) {
+        suppressed = false;
+        return;
+      }
+      // `scrollend` is the reliable signal but it is missing in some browsers
+      // and can be skipped when the scroll is interrupted; the 500ms fallback
+      // guarantees the suppression always releases.
+      const fallback = setTimeout(() => {
+        suppressed = false;
+      }, 500);
+      window.addEventListener(
+        "scrollend",
+        () => {
+          clearTimeout(fallback);
+          suppressed = false;
+        },
+        { once: true },
+      );
+    });
+  }
+
+  $effect(() => {
+    const ids = headingIds();
+    if (ids.length === 0) return;
+
+    const visible = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            visible.add(entry.target.id);
+          } else {
+            visible.delete(entry.target.id);
+          }
+        }
+        if (suppressed) return;
+        for (const id of ids) {
+          if (visible.has(id)) {
+            activeId = id;
+            return;
+          }
+        }
+        // Nothing visible: keep the last active id. Heading-dense pages often
+        // have brief gaps where no heading sits in the rootMargin band; the
+        // scroll-spy should feel sticky, not flicker.
+      },
+      {
+        // Match the legacy TocSidebar band: a heading becomes "active" once
+        // its top enters the 10-20% strip of the viewport.
+        rootMargin: "-10% 0px -80% 0px",
+        threshold: 0,
+      },
+    );
+
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    }
+
+    // Read activeId via untrack so the effect does not depend on its own
+    // writes; otherwise every observer-driven update would re-run the effect,
+    // tearing down and rebuilding the observer.
+    untrack(() => {
+      if (activeId === null || !ids.includes(activeId)) {
+        activeId = ids[0];
+      }
+    });
+
+    return () => observer.disconnect();
+  });
+
+  return {
+    get activeId() {
+      return activeId;
+    },
+    setActiveId(id: string | null) {
+      activeId = id;
+    },
+    suppressUntilScrollEnd,
+  };
+}

--- a/packages/viewer/src/lib/ui/hooks/useActiveHeading.test.svelte.ts
+++ b/packages/viewer/src/lib/ui/hooks/useActiveHeading.test.svelte.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { flushSync } from "svelte";
+import { render } from "@testing-library/svelte";
+import Harness from "./__fixtures__/ActiveHeadingHarness.svelte";
+import type { ActiveHeading } from "./useActiveHeading.svelte";
+
+// jsdom does not implement IntersectionObserver, and even if it did we need
+// programmatic control over the callback to simulate viewport changes.
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  callback: IntersectionObserverCallback;
+  observed: Element[] = [];
+  disconnected = false;
+
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+
+  unobserve() {}
+
+  disconnect() {
+    this.disconnected = true;
+    this.observed = [];
+  }
+
+  trigger(entries: Array<{ id: string; isIntersecting: boolean }>) {
+    const observerEntries = entries.map(({ id, isIntersecting }) => {
+      const target = this.observed.find((el) => el.id === id);
+      if (!target) throw new Error(`No observed element with id "${id}"`);
+      return { target, isIntersecting } as unknown as IntersectionObserverEntry;
+    });
+    this.callback(observerEntries, this as unknown as IntersectionObserver);
+  }
+}
+
+function makeHeading(id: string): HTMLElement {
+  const el = document.createElement("h2");
+  el.id = id;
+  document.body.appendChild(el);
+  return el;
+}
+
+function latestObserver(): MockIntersectionObserver {
+  const observer = MockIntersectionObserver.instances.at(-1);
+  if (!observer) throw new Error("No IntersectionObserver was created");
+  return observer;
+}
+
+describe("useActiveHeading", () => {
+  let captured: ActiveHeading | null = null;
+  const captureInit = (handle: ActiveHeading) => {
+    captured = handle;
+  };
+
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    captured = null;
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("does not create an observer for an empty heading list", () => {
+    const { getByTestId } = render(Harness, { headingIds: [], onInit: captureInit });
+    const out = getByTestId("active-heading");
+
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+    expect(out.dataset.active).toBe("");
+    expect(captured?.activeId).toBeNull();
+  });
+
+  it("seeds activeId with the first heading on mount", () => {
+    makeHeading("intro");
+    makeHeading("usage");
+
+    const { getByTestId } = render(Harness, {
+      headingIds: ["intro", "usage"],
+      onInit: captureInit,
+    });
+
+    expect(getByTestId("active-heading").dataset.active).toBe("intro");
+    expect(captured?.activeId).toBe("intro");
+  });
+
+  it("observes every heading id that is present in the DOM", () => {
+    makeHeading("intro");
+    makeHeading("usage");
+
+    render(Harness, { headingIds: ["intro", "missing", "usage"], onInit: captureInit });
+
+    const observer = latestObserver();
+    const observedIds = observer.observed.map((el) => el.id);
+    expect(observedIds).toEqual(["intro", "usage"]);
+  });
+
+  it("updates activeId when an observed heading becomes intersecting", () => {
+    makeHeading("intro");
+    makeHeading("usage");
+    makeHeading("api");
+
+    const { getByTestId } = render(Harness, {
+      headingIds: ["intro", "usage", "api"],
+      onInit: captureInit,
+    });
+    const out = getByTestId("active-heading");
+    expect(out.dataset.active).toBe("intro");
+
+    latestObserver().trigger([{ id: "usage", isIntersecting: true }]);
+    flushSync();
+
+    expect(out.dataset.active).toBe("usage");
+  });
+
+  it("prefers the topmost heading in list order when several are visible", () => {
+    makeHeading("intro");
+    makeHeading("usage");
+    makeHeading("api");
+
+    const { getByTestId } = render(Harness, {
+      headingIds: ["intro", "usage", "api"],
+      onInit: captureInit,
+    });
+
+    latestObserver().trigger([
+      { id: "api", isIntersecting: true },
+      { id: "usage", isIntersecting: true },
+    ]);
+    flushSync();
+
+    expect(getByTestId("active-heading").dataset.active).toBe("usage");
+  });
+
+  it("keeps the last active heading when no heading is currently visible", () => {
+    makeHeading("intro");
+    makeHeading("usage");
+
+    const { getByTestId } = render(Harness, {
+      headingIds: ["intro", "usage"],
+      onInit: captureInit,
+    });
+
+    const observer = latestObserver();
+    observer.trigger([{ id: "usage", isIntersecting: true }]);
+    flushSync();
+    expect(getByTestId("active-heading").dataset.active).toBe("usage");
+
+    observer.trigger([{ id: "usage", isIntersecting: false }]);
+    flushSync();
+
+    expect(getByTestId("active-heading").dataset.active).toBe("usage");
+  });
+
+  it("ignores observer updates while suppression is active", async () => {
+    makeHeading("intro");
+    makeHeading("usage");
+
+    const { getByTestId } = render(Harness, {
+      headingIds: ["intro", "usage"],
+      onInit: captureInit,
+    });
+    const out = getByTestId("active-heading");
+
+    captured!.setActiveId("usage");
+    captured!.suppressUntilScrollEnd();
+    flushSync();
+    expect(out.dataset.active).toBe("usage");
+
+    // Simulate a scroll so the fallback path kicks in; otherwise the rAF
+    // callback releases suppression synchronously on the next frame.
+    window.scrollY = 42;
+
+    latestObserver().trigger([{ id: "intro", isIntersecting: true }]);
+    flushSync();
+
+    expect(out.dataset.active).toBe("usage");
+  });
+
+  it("releases suppression when scrollend fires so observer updates resume", async () => {
+    makeHeading("intro");
+    makeHeading("usage");
+
+    const { getByTestId } = render(Harness, {
+      headingIds: ["intro", "usage"],
+      onInit: captureInit,
+    });
+    const out = getByTestId("active-heading");
+
+    captured!.setActiveId("usage");
+    captured!.suppressUntilScrollEnd();
+    window.scrollY = 99;
+
+    // Wait for rAF to register the scrollend listener.
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    window.dispatchEvent(new Event("scrollend"));
+
+    latestObserver().trigger([{ id: "intro", isIntersecting: true }]);
+    flushSync();
+
+    expect(out.dataset.active).toBe("intro");
+  });
+
+  it("releases suppression immediately when no scroll actually happened", async () => {
+    makeHeading("intro");
+    makeHeading("usage");
+
+    const { getByTestId } = render(Harness, {
+      headingIds: ["intro", "usage"],
+      onInit: captureInit,
+    });
+    const out = getByTestId("active-heading");
+
+    const scrollBefore = window.scrollY;
+    captured!.setActiveId("usage");
+    captured!.suppressUntilScrollEnd();
+    // scrollY stays equal → rAF path sees no movement, releases on the spot.
+    window.scrollY = scrollBefore;
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    latestObserver().trigger([{ id: "intro", isIntersecting: true }]);
+    flushSync();
+
+    expect(out.dataset.active).toBe("intro");
+  });
+
+  it("lets setActiveId override the current active heading", () => {
+    makeHeading("intro");
+    makeHeading("usage");
+
+    const { getByTestId } = render(Harness, {
+      headingIds: ["intro", "usage"],
+      onInit: captureInit,
+    });
+
+    captured!.setActiveId("usage");
+    flushSync();
+
+    expect(getByTestId("active-heading").dataset.active).toBe("usage");
+  });
+
+  it("keeps activeId when the heading list changes and the id is still present", async () => {
+    makeHeading("intro");
+    makeHeading("usage");
+    makeHeading("api");
+
+    const { getByTestId, rerender } = render(Harness, {
+      headingIds: ["intro", "usage"],
+      onInit: captureInit,
+    });
+
+    captured!.setActiveId("usage");
+    flushSync();
+    expect(getByTestId("active-heading").dataset.active).toBe("usage");
+
+    await rerender({ headingIds: ["usage", "api"], onInit: captureInit });
+
+    expect(getByTestId("active-heading").dataset.active).toBe("usage");
+  });
+
+  it("resets activeId to the first heading when the list no longer contains it", async () => {
+    makeHeading("intro");
+    makeHeading("usage");
+    makeHeading("api");
+
+    const { getByTestId, rerender } = render(Harness, {
+      headingIds: ["intro", "usage"],
+      onInit: captureInit,
+    });
+
+    captured!.setActiveId("usage");
+    flushSync();
+
+    await rerender({ headingIds: ["api"], onInit: captureInit });
+
+    expect(getByTestId("active-heading").dataset.active).toBe("api");
+  });
+
+  it("disconnects the previous observer when the heading list changes", async () => {
+    makeHeading("intro");
+    makeHeading("usage");
+
+    const { rerender } = render(Harness, {
+      headingIds: ["intro"],
+      onInit: captureInit,
+    });
+    const first = latestObserver();
+    expect(first.disconnected).toBe(false);
+
+    await rerender({ headingIds: ["intro", "usage"], onInit: captureInit });
+
+    expect(first.disconnected).toBe(true);
+    expect(MockIntersectionObserver.instances).toHaveLength(2);
+  });
+
+  it("disconnects the observer on unmount", () => {
+    makeHeading("intro");
+
+    const { unmount } = render(Harness, {
+      headingIds: ["intro"],
+      onInit: captureInit,
+    });
+    const observer = latestObserver();
+    expect(observer.disconnected).toBe(false);
+
+    unmount();
+
+    expect(observer.disconnected).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `useActiveHeading` in `lib/ui/hooks/` — scroll-spy hook with IntersectionObserver + scrollend suppression; exposes readonly `activeId`, `setActiveId`, and `suppressUntilScrollEnd`
- Refactors `TocSidebar` into a presentational component that takes pre-filtered `toc`, `activeId`, `onNavigate(id)` props — no more `router.hash` / `router.embedded` reads
- `TocPopover` threads the same props and composes close-on-click into its `onNavigate`
- `Layout` (the composition root) owns the hook, hash effect, and embedded-mode popstate handler
- TOC wrapper visibility now guards on the filtered h2/h3 list, so pages with only an h1 no longer render an empty "On this page" sidebar

Advances the viewer-design-kit spec: ships the hook from §5.8 and completes the TOC portion of §6.2.

## Test plan
- [x] `npm run lint` — no new warnings (pre-existing `Button.svelte` wrapping warning unrelated)
- [x] `npm run test` — 332/332 pass, including 14 new tests for `useActiveHeading`
- [x] `npx playwright test` — 92/92 pass across chromium + chromium-embedded, covering `toc-popover.spec.ts`, `page-content.spec.ts` ToC sticky + scroll-on-click, and embedded hash-fragment/popstate paths
- [x] `grep -rE "router\.hash|router\.embedded" packages/viewer/src/components/Toc*.svelte` → zero hits (§6.2 exit criterion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)