### PR TITLE
Sweep remaining palette leaks to semantic tokens

### DIFF
--- a/packages/viewer/src/components/LoadingBar.svelte
+++ b/packages/viewer/src/components/LoadingBar.svelte
@@ -34,14 +34,14 @@
 
 {#if animationState !== "idle"}
   <div
-    class="absolute inset-x-0 top-0 z-50 h-0.5 overflow-hidden"
+    class="absolute inset-x-0 top-0 z-overlay h-0.5 overflow-hidden"
     role="progressbar"
     aria-label="Page loading"
     aria-busy={animationState === "running"}
   >
     <div
       class="
-        h-full origin-left bg-blue-500 will-change-[transform,opacity] dark:bg-blue-400
+        h-full origin-left bg-accent-bg will-change-[transform,opacity]
         {animationState === 'running' ? 'animate-trickle' : 'animate-complete'}"
     ></div>
   </div>

--- a/packages/viewer/src/components/NavigationSidebar.svelte
+++ b/packages/viewer/src/components/NavigationSidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getRwContext } from "../lib/context";
+  import Alert from "../lib/ui/primitives/Alert.svelte";
   import NavTree from "./NavTree.svelte";
 
   const { navigation, router } = getRwContext();
@@ -10,7 +11,7 @@
 {#if navigation.loading}
   <div class="text-sm text-gray-600 dark:text-neutral-400">Loading...</div>
 {:else if navigation.error}
-  <div class="text-sm text-red-600 dark:text-red-400">{navigation.error}</div>
+  <Alert intent="danger">{navigation.error}</Alert>
 {:else if navigation.tree}
   <nav>
     {#if navigation.tree.scope && backLink}

--- a/packages/viewer/src/components/PageContent.svelte
+++ b/packages/viewer/src/components/PageContent.svelte
@@ -5,6 +5,7 @@
   import { rangeToSelectors, selectorsToRange, type AnchorStrategy } from "../lib/anchoring";
   import { LOADING_SHOW_DELAY } from "../lib/constants";
   import LoadingSkeleton from "./LoadingSkeleton.svelte";
+  import Alert from "../lib/ui/primitives/Alert.svelte";
   import Button from "../lib/ui/primitives/Button.svelte";
   import Popover from "../lib/ui/primitives/Popover.svelte";
   import PageComments from "./comments/PageComments.svelte";
@@ -406,7 +407,7 @@
   </div>
 {:else if page.error}
   <div class="flex h-64 items-center justify-center">
-    <p class="text-red-600 dark:text-red-400">Error: {page.error}</p>
+    <Alert intent="danger" title="Error">{page.error}</Alert>
   </div>
 {:else if page.data}
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->

--- a/packages/viewer/src/styles/content.css
+++ b/packages/viewer/src/styles/content.css
@@ -50,7 +50,7 @@
 
   /* Error state for diagrams that failed to render */
   .prose figure.diagram-error {
-    @apply border border-red-200 bg-red-50 rounded p-4 dark:border-red-800 dark:bg-red-950;
+    @apply border border-danger-border bg-danger-bg rounded p-4;
   }
 
   .prose figure.diagram-error pre {
@@ -82,45 +82,45 @@
     @apply mb-0;
   }
 
-  /* Alert type-specific colors */
+  /* Alert type-specific colors — map GitHub alert types to semantic intents. */
   .prose .alert-note {
-    @apply bg-blue-50 border-blue-500 dark:bg-blue-500/10 dark:border-blue-400;
+    @apply bg-info-bg border-info-border;
   }
 
   .prose .alert-note .alert-title {
-    @apply text-blue-600 dark:text-blue-400;
+    @apply text-info-fg;
   }
 
   .prose .alert-tip {
-    @apply bg-green-50 border-green-500 dark:bg-green-500/10 dark:border-green-400;
+    @apply bg-success-bg border-success-border;
   }
 
   .prose .alert-tip .alert-title {
-    @apply text-green-600 dark:text-green-400;
+    @apply text-success-fg;
   }
 
   .prose .alert-important {
-    @apply bg-purple-50 border-purple-500 dark:bg-purple-500/10 dark:border-purple-400;
+    @apply bg-attention-bg border-attention-border;
   }
 
   .prose .alert-important .alert-title {
-    @apply text-purple-600 dark:text-purple-400;
+    @apply text-attention-fg;
   }
 
   .prose .alert-warning {
-    @apply bg-amber-50 border-amber-500 dark:bg-amber-500/10 dark:border-amber-400;
+    @apply bg-warning-bg border-warning-border;
   }
 
   .prose .alert-warning .alert-title {
-    @apply text-amber-600 dark:text-amber-400;
+    @apply text-warning-fg;
   }
 
   .prose .alert-caution {
-    @apply bg-red-50 border-red-500 dark:bg-red-500/10 dark:border-red-400;
+    @apply bg-danger-bg border-danger-border;
   }
 
   .prose .alert-caution .alert-title {
-    @apply text-red-600 dark:text-red-400;
+    @apply text-danger-fg;
   }
 
   /* Tabs styling */


### PR DESCRIPTION
## Summary

- Replaces the last three inline red error sites (`NavigationSidebar`, `PageContent`, the old `LoadingBar` accent) with `<Alert intent="danger">` or semantic tokens — no more raw `bg-red-*` / `text-red-*` / `bg-blue-500` in the viewer components this PR touches.
- Migrates `styles/content.css` `.alert-note/tip/important/warning/caution` and `.diagram-error` from hand-rolled palette pairs to the intent token set (`bg-{intent}-bg`, `border-{intent}-border`, `text-{intent}-fg`). Drops the five dark-mode overrides those blocks used to carry.
- `LoadingBar` progress fill now reads `bg-accent-bg` and `z-overlay` instead of `bg-blue-500 dark:bg-blue-400 z-50`.

## Visual deltas

- `LoadingBar` light mode: blue-500 → accent-600 (one step darker). Subtle.
- `.alert-warning` hue shifts amber (#f59e0b) → yellow (#eab308). Slight.
- `.alert-*` and `.diagram-error` dark-mode backgrounds/borders use the unified intent tokens now; small shifts from the previous bespoke `-400` / `-800` pairs.

## Test plan

- [x] `npm run build` clean; semantic tokens (`bg-info-bg`, `border-danger-border`, `z-overlay`, …) emitted in CSS bundle
- [x] `npm run lint` — zero errors (one pre-existing line-wrapping warning in `Button.svelte:73`)
- [x] `npm run test` — 332 / 332
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] `make format` clean
- [ ] Manual: verify a page with a failed diagram + each GitHub-alert intent still reads legibly in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)