### PR TITLE
refactor(viewer): extract formatRelativeTime into design-kit hook

### DIFF
--- a/packages/viewer/src/components/comments/CommentThread.svelte
+++ b/packages/viewer/src/components/comments/CommentThread.svelte
@@ -3,6 +3,7 @@
   import Avatar from "../../lib/ui/primitives/Avatar.svelte";
   import Badge from "../../lib/ui/primitives/Badge.svelte";
   import Button from "../../lib/ui/primitives/Button.svelte";
+  import { formatRelativeTime } from "../../lib/ui/hooks/formatRelativeTime";
   import CommentForm from "./CommentForm.svelte";
 
   function avatarVariant(author: Author): "person" | "ai" | "initials" {
@@ -44,22 +45,6 @@
 
   let outerRef: HTMLDivElement | undefined = $state();
   let avatarRowRef: HTMLDivElement | undefined = $state();
-
-  function formatRelativeTime(dateStr: string): string {
-    const date = new Date(dateStr);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffSec = Math.floor(diffMs / 1000);
-    const diffMin = Math.floor(diffSec / 60);
-    const diffHr = Math.floor(diffMin / 60);
-    const diffDay = Math.floor(diffHr / 24);
-
-    if (diffSec < 60) return "just now";
-    if (diffMin < 60) return `${diffMin}m ago`;
-    if (diffHr < 24) return `${diffHr}h ago`;
-    if (diffDay < 30) return `${diffDay}d ago`;
-    return date.toLocaleDateString();
-  }
 
   async function handleReply(body: string) {
     await onReply(comment.id, body);
@@ -202,7 +187,7 @@
         </Badge>
       {/if}
       <span class="ml-auto text-xs text-gray-400 dark:text-neutral-500">
-        {formatRelativeTime(comment.createdAt)}
+        {formatRelativeTime(new Date(comment.createdAt))}
       </span>
     </div>
     <p
@@ -266,7 +251,7 @@
               {reply.author.name}
             </span>
             <span class="ml-auto text-xs text-gray-400 dark:text-neutral-500">
-              {formatRelativeTime(reply.createdAt)}
+              {formatRelativeTime(new Date(reply.createdAt))}
             </span>
           </div>
           <p class="text-sm text-gray-900 dark:text-neutral-100">

--- a/packages/viewer/src/lib/ui/hooks/formatRelativeTime.test.ts
+++ b/packages/viewer/src/lib/ui/hooks/formatRelativeTime.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { formatRelativeTime } from "./formatRelativeTime";
+
+describe("formatRelativeTime", () => {
+  const now = new Date("2026-04-24T12:00:00Z");
+
+  it("returns 'just now' for the same instant", () => {
+    expect(formatRelativeTime(now, now)).toBe("just now");
+  });
+
+  it("returns 'just now' under 60 seconds", () => {
+    const date = new Date(now.getTime() - 59 * 1000);
+    expect(formatRelativeTime(date, now)).toBe("just now");
+  });
+
+  it("returns minutes ago between 1 and 59 minutes", () => {
+    expect(formatRelativeTime(new Date(now.getTime() - 60 * 1000), now)).toBe("1m ago");
+    expect(formatRelativeTime(new Date(now.getTime() - 59 * 60 * 1000), now)).toBe("59m ago");
+  });
+
+  it("returns hours ago between 1 and 23 hours", () => {
+    expect(formatRelativeTime(new Date(now.getTime() - 60 * 60 * 1000), now)).toBe("1h ago");
+    expect(formatRelativeTime(new Date(now.getTime() - 23 * 60 * 60 * 1000), now)).toBe("23h ago");
+  });
+
+  it("returns days ago between 1 and 29 days", () => {
+    expect(formatRelativeTime(new Date(now.getTime() - 24 * 60 * 60 * 1000), now)).toBe("1d ago");
+    expect(formatRelativeTime(new Date(now.getTime() - 29 * 24 * 60 * 60 * 1000), now)).toBe(
+      "29d ago",
+    );
+  });
+
+  it("falls back to localized date for 30+ days", () => {
+    const date = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(date, now)).toBe(date.toLocaleDateString());
+  });
+
+  it("uses real-time `now` when omitted", () => {
+    const result = formatRelativeTime(new Date());
+    expect(result).toBe("just now");
+  });
+});

--- a/packages/viewer/src/lib/ui/hooks/formatRelativeTime.ts
+++ b/packages/viewer/src/lib/ui/hooks/formatRelativeTime.ts
@@ -1,0 +1,13 @@
+export function formatRelativeTime(date: Date, now: Date = new Date()): string {
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffSec < 60) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay < 30) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}


### PR DESCRIPTION
## Summary
- Lift the relative-time formatter out of `CommentThread.svelte` into `lib/ui/hooks/formatRelativeTime.ts`, matching the signature in the viewer design-kit spec (`Date`, optional `now`).
- Add unit tests covering all intervals plus the default-`now` path.
- Advances Phase 2 of `docs/superpowers/specs/2026-04-22-viewer-design-kit-design.md`.

## Test plan
- [x] `npm -w @rwdocs/viewer test -- --run formatRelativeTime` — 7 passed
- [x] `npm -w @rwdocs/viewer test -- --run` — 339 passed across 18 files
- [x] `make format` and `make lint` clean (only pre-existing `Button.svelte` line-wrap warning remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)