### PR TITLE
refactor(viewer): move LoadingBar to design-kit primitives

### DIFF
--- a/packages/viewer/src/components/Layout.svelte
+++ b/packages/viewer/src/components/Layout.svelte
@@ -8,7 +8,7 @@
   import Breadcrumbs from "./Breadcrumbs.svelte";
   import MobileDrawer from "./MobileDrawer.svelte";
   import IconButton from "../lib/ui/primitives/IconButton.svelte";
-  import LoadingBar from "./LoadingBar.svelte";
+  import LoadingBar from "../lib/ui/primitives/LoadingBar.svelte";
   import CommentSidebar from "./comments/CommentSidebar.svelte";
   import Alert from "../lib/ui/primitives/Alert.svelte";
   import { useActiveHeading } from "../lib/ui/hooks/useActiveHeading.svelte";

--- a/packages/viewer/src/components/PageContent.svelte
+++ b/packages/viewer/src/components/PageContent.svelte
@@ -3,7 +3,6 @@
   import { initializeTabs } from "../lib/tabs";
   import { rewriteSectionRefLinks } from "../lib/sectionRefs";
   import { rangeToSelectors, selectorsToRange, type AnchorStrategy } from "../lib/anchoring";
-  import { LOADING_SHOW_DELAY } from "../lib/constants";
   import LoadingSkeleton from "../lib/ui/primitives/LoadingSkeleton.svelte";
   import Alert from "../lib/ui/primitives/Alert.svelte";
   import Button from "../lib/ui/primitives/Button.svelte";
@@ -34,12 +33,13 @@
     return () => document.removeEventListener("selectionchange", handler);
   });
 
-  // Show skeleton only if loading takes longer than SHOW_DELAY
+  // Delay skeleton appearance so fast page loads don't flash it.
+  const SKELETON_DELAY_MS = 300;
   $effect(() => {
     if (page.loading) {
       const timeout = setTimeout(() => {
         showSkeleton = true;
-      }, LOADING_SHOW_DELAY);
+      }, SKELETON_DELAY_MS);
       return () => clearTimeout(timeout);
     } else {
       showSkeleton = false;

--- a/packages/viewer/src/lib/constants.ts
+++ b/packages/viewer/src/lib/constants.ts
@@ -1,2 +1,0 @@
-// Delay before showing loading indicators (ms) - prevents "blink" on fast loads
-export const LOADING_SHOW_DELAY = 300;

--- a/packages/viewer/src/lib/ui/primitives/LoadingBar.svelte
+++ b/packages/viewer/src/lib/ui/primitives/LoadingBar.svelte
@@ -1,28 +1,25 @@
 <script lang="ts">
-  import { LOADING_SHOW_DELAY } from "../lib/constants";
-
   const COMPLETION_DURATION = 300;
 
   interface Props {
     loading: boolean;
+    threshold?: number;
   }
 
-  let { loading }: Props = $props();
+  let { loading, threshold = 300 }: Props = $props();
 
   type AnimationState = "idle" | "running" | "completing";
   let animationState = $state<AnimationState>("idle");
 
   $effect(() => {
     if (loading) {
-      // Only show progress bar if loading takes longer than threshold
       const timeout = setTimeout(() => {
         animationState = "running";
-      }, LOADING_SHOW_DELAY);
+      }, threshold);
       return () => clearTimeout(timeout);
     }
 
-    // Not loading - if bar was visible, animate completion then hide
-    if (animationState !== "idle") {
+    if (animationState === "running") {
       animationState = "completing";
       const timeout = setTimeout(() => {
         animationState = "idle";

--- a/packages/viewer/src/lib/ui/primitives/LoadingBar.test.ts
+++ b/packages/viewer/src/lib/ui/primitives/LoadingBar.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import LoadingBar from "./LoadingBar.svelte";
+
+describe("LoadingBar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays idle while loading is false", () => {
+    const { queryByRole } = render(LoadingBar, { loading: false });
+    expect(queryByRole("progressbar")).toBeNull();
+  });
+
+  it("defaults threshold to 300ms and renders a labeled, busy progressbar after it elapses", async () => {
+    const { queryByRole } = render(LoadingBar, { loading: true });
+    await vi.advanceTimersByTimeAsync(299);
+    await tick();
+    expect(queryByRole("progressbar")).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await tick();
+    const bar = queryByRole("progressbar", { name: "Page loading" });
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("honors a custom threshold prop", async () => {
+    const { queryByRole } = render(LoadingBar, { loading: true, threshold: 50 });
+    await vi.advanceTimersByTimeAsync(49);
+    await tick();
+    expect(queryByRole("progressbar")).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await tick();
+    expect(queryByRole("progressbar")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Moves `LoadingBar.svelte` from `components/` into `lib/ui/primitives/` to fit the design-kit and adds a `threshold` prop (default 300ms) so callers no longer import `LOADING_SHOW_DELAY`. `lib/constants.ts` (whose only export was that constant) is deleted; `PageContent.svelte` inlines the same 300ms for its skeleton delay.
- Tightens the completion-branch guard in LoadingBar's `\$effect` from `!== "idle"` to `=== "running"`. The effect both read `animationState` and wrote `"completing"` to it on the next line, so Svelte retriggered the effect, re-entered the branch, and scheduled a fresh `setTimeout` — restarting the exit animation on every self-retrigger.
- Adds `LoadingBar.test.ts` covering idle-when-not-loading, default 300ms threshold (with progressbar role + aria-busy), and a custom threshold.

## Test plan

- [ ] `npm -w @rwdocs/viewer run test -- --run LoadingBar` passes
- [ ] Navigate between pages in `rw serve` — fast loads should not flash the bar; slow loads should show it then animate out cleanly without the exit animation restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)