### PR TITLE
feat(devcontainer): reproducible dev env with optional Claude Code sandbox

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+ARG VARIANT=ubuntu-24.04
+FROM mcr.microsoft.com/devcontainers/base:${VARIANT}
+
+# System deps: napi-rs build, firewall tooling, devex.
+# Playwright system deps are NOT installed here — `npx playwright install --with-deps`
+# in post-create.sh installs the canonical set per Playwright version.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config libssl-dev \
+    iptables ipset aggregate dnsutils jq \
+    git curl ca-certificates zsh fzf less \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install helper scripts and grant passwordless sudo for them.
+# This is additive on top of the base image's general sudo for `vscode`.
+COPY init-firewall.sh /usr/local/bin/init-firewall.sh
+COPY devcontainer-prepare.sh /usr/local/bin/devcontainer-prepare.sh
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/devcontainer-prepare.sh \
+    && echo "vscode ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh, /usr/local/bin/devcontainer-prepare.sh" \
+       > /etc/sudoers.d/devcontainer-helpers \
+    && chmod 0440 /etc/sudoers.d/devcontainer-helpers
+
+USER vscode
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:$PATH

--- a/.devcontainer/devcontainer-prepare.sh
+++ b/.devcontainer/devcontainer-prepare.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Fix ownership of named-volume mount points. Volumes mount root-owned
+# and empty by default; this lets the vscode user write to them.
+set -euo pipefail
+chown vscode:vscode /workspace/target /workspace/node_modules /usr/local/cargo
+chmod 755 /workspace/target /workspace/node_modules /usr/local/cargo

--- a/.devcontainer/devcontainer-prepare.sh
+++ b/.devcontainer/devcontainer-prepare.sh
@@ -2,5 +2,5 @@
 # Fix ownership of named-volume mount points. Volumes mount root-owned
 # and empty by default; this lets the vscode user write to them.
 set -euo pipefail
-chown vscode:vscode /workspace/target /workspace/node_modules /usr/local/cargo
-chmod 755 /workspace/target /workspace/node_modules /usr/local/cargo
+chown vscode:vscode /workspace/target /workspace/node_modules /usr/local/cargo /home/vscode/.claude
+chmod 755 /workspace/target /workspace/node_modules /usr/local/cargo /home/vscode/.claude

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
   "name": "rw",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "build": { "dockerfile": "Dockerfile" },
   "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "rw",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,47 @@
 {
   "name": "rw",
   "build": { "dockerfile": "Dockerfile" },
-  "remoteUser": "vscode"
+
+  "features": {
+    "ghcr.io/devcontainers/features/node:1":        { "version": "20" },
+    "ghcr.io/devcontainers/features/rust:1":        { "profile": "minimal" },
+    "ghcr.io/devcontainers/features/github-cli:1":  {},
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+  },
+
+  "remoteUser": "vscode",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
+  "workspaceFolder": "/workspace",
+
+  "mounts": [
+    "source=rw-cargo-cache,target=/usr/local/cargo,type=volume",
+    "source=rw-target,target=/workspace/target,type=volume",
+    "source=rw-node-modules,target=/workspace/node_modules,type=volume",
+    "source=rw-claude-config-${devcontainerId},target=/home/vscode/.claude,type=volume",
+    "source=rw-bashhistory-${devcontainerId},target=/commandhistory,type=volume"
+  ],
+
+  "containerEnv": {
+    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude",
+    "RW_DEVCONTAINER_FIREWALL": "${localEnv:RW_DEVCONTAINER_FIREWALL:0}"
+  },
+
+  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
+
+  "forwardPorts": [7979, 8081, 8082],
+
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "postStartCommand":  ".devcontainer/post-start.sh",
+  "waitFor": "postStartCommand",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "svelte.svelte-vscode",
+        "anthropic.claude-code"
+      ]
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1":        { "version": "20" },
     "ghcr.io/devcontainers/features/rust:1":        { "profile": "minimal" },
-    "ghcr.io/devcontainers/features/github-cli:1":  {},
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+    "ghcr.io/devcontainers/features/github-cli:1":  {}
   },
 
   "remoteUser": "vscode",
@@ -23,6 +22,7 @@
 
   "containerEnv": {
     "CLAUDE_CONFIG_DIR": "/home/vscode/.claude",
+    "PATH": "/home/vscode/.local/bin:/usr/local/cargo/bin:/usr/local/share/nvm/current/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     "RW_DEVCONTAINER_FIREWALL": "${localEnv:RW_DEVCONTAINER_FIREWALL:0}"
   },
 

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,5 +1,162 @@
 #!/usr/bin/env bash
-# Egress firewall — populated in chunk 4
+# Egress firewall — adapted from anthropics/claude-code/.devcontainer/init-firewall.sh
+# Allows: GitHub (CIDR ranges), npm registry, crates.io, Anthropic API, kroki.io,
+# Playwright downloads, GitHub release artifacts, VS Code marketplace, telemetry
+# (statsig/sentry — set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 to skip those).
+#
+# Bootstrap dependency: api.github.com must be reachable while this script runs
+# (we fetch meta-IP CIDRs before locking down the policy).
+
 set -euo pipefail
-echo "init-firewall.sh: not implemented yet"
-exit 0
+IFS=$'\n\t'
+
+# 1. Save Docker DNS NAT rules before flushing
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
+# 2. Reset default policies to ACCEPT before flushing.
+# `iptables -F` only flushes rules, not default policies. If a previous run set
+# policies to DROP, the rest of this script (which needs to reach api.github.com
+# to fetch CIDRs) would fail. Resetting first lets the script be re-run safely.
+iptables -P INPUT ACCEPT
+iptables -P FORWARD ACCEPT
+iptables -P OUTPUT ACCEPT
+
+# 3. Flush
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# 3. Restore Docker DNS
+if [ -n "$DOCKER_DNS_RULES" ]; then
+    echo "Restoring Docker DNS rules..."
+    iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+    iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+    echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+fi
+
+# 4. Allow DNS, SSH, localhost — needed by the rest of this script
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A INPUT -p udp --sport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# 5. Build allowed-domains ipset
+ipset create allowed-domains hash:net
+
+# 5a. GitHub IP ranges (web, api, git) — fetched from api.github.com/meta
+echo "Fetching GitHub IP ranges..."
+gh_ranges=$(curl -s https://api.github.com/meta)
+if [ -z "$gh_ranges" ]; then
+    echo "ERROR: Failed to fetch GitHub IP ranges"
+    exit 1
+fi
+if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
+    echo "ERROR: GitHub API response missing required fields"
+    exit 1
+fi
+while read -r cidr; do
+    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+        echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
+        exit 1
+    fi
+    ipset add -exist allowed-domains "$cidr"
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+
+# 5b. Hardcoded CDN anycast CIDRs.
+# `dig` only captures the few IPs DNS returns at init time, but CDN-fronted services
+# (crates.io subdomains on Fastly, kroki.io on Cloudflare proxy) anycast across large
+# blocks and rotate which IPs DNS returns per request. Allowlist the published CDN
+# ranges so requests to those services succeed regardless of which IP DNS hands out.
+#
+# Tradeoff: this also implicitly allowlists every other site on the same CDN. Users
+# who need stricter isolation should switch to a hostname-aware proxy approach.
+#
+# Note on bare `crates.io`: it has migrated to AWS CloudFront and rotates across many
+# CIDR ranges. We don't allowlist all of CloudFront. The actual cargo workflow uses
+# `index.crates.io` (sparse index) and `static.crates.io` (crate downloads), both on
+# Fastly's 151.101.0.0/16 and reachable. `cargo search` (which hits the website) does
+# not work under firewall — disable firewall for that one command if needed.
+echo "Adding CDN anycast ranges..."
+for cidr in \
+    "151.101.0.0/16" \
+    "104.16.0.0/13" \
+    "104.24.0.0/14" \
+    "172.64.0.0/13"; do
+    echo "  $cidr"
+    ipset add -exist allowed-domains "$cidr"
+done
+
+# 5c. Resolve and add named domains (rw allowlist + Claude Code base).
+# Kept for non-CDN services (api.anthropic.com, sentry.io, etc.) and as a safety
+# net for CDN domains in case their published ranges expand.
+for domain in \
+    "registry.npmjs.org" \
+    "crates.io" \
+    "static.crates.io" \
+    "index.crates.io" \
+    "api.anthropic.com" \
+    "statsig.anthropic.com" \
+    "statsig.com" \
+    "sentry.io" \
+    "kroki.io" \
+    "playwright.azureedge.net" \
+    "cdn.playwright.dev" \
+    "playwright.download.prss.microsoft.com" \
+    "objects.githubusercontent.com" \
+    "marketplace.visualstudio.com" \
+    "vscode.blob.core.windows.net" \
+    "update.code.visualstudio.com"; do
+    echo "Resolving $domain..."
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
+    if [ -z "$ips" ]; then
+        echo "ERROR: Failed to resolve $domain"
+        exit 1
+    fi
+    while read -r ip; do
+        if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            echo "ERROR: Invalid IP from DNS for $domain: $ip"
+            exit 1
+        fi
+        ipset add -exist allowed-domains "$ip"
+    done < <(echo "$ips")
+done
+
+# 6. Allow host's /24 network (so VS Code Server port forwarding works)
+HOST_IP=$(ip route | grep default | cut -d" " -f3)
+if [ -z "$HOST_IP" ]; then
+    echo "ERROR: Failed to detect host IP"
+    exit 1
+fi
+HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+echo "Host network detected as: $HOST_NETWORK"
+iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
+iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
+
+# 7. Lock down: default DROP, allow established + allowed-domains, REJECT others
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+# 8. Verify
+echo "Verifying firewall rules..."
+if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+    exit 1
+fi
+echo "Firewall verification passed - example.com correctly blocked"
+if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
+    exit 1
+fi
+echo "Firewall verification passed - api.github.com correctly reachable"
+echo "Firewall configuration complete"

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Egress firewall — populated in chunk 4
+set -euo pipefail
+echo "init-firewall.sh: not implemented yet"
+exit 0

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -101,6 +101,8 @@ for domain in \
     "static.crates.io" \
     "index.crates.io" \
     "api.anthropic.com" \
+    "claude.ai" \
+    "downloads.claude.ai" \
     "statsig.anthropic.com" \
     "statsig.com" \
     "sentry.io" \
@@ -147,13 +149,19 @@ iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
 iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
 
-# 8. Verify
+# 8. Verify.
+# Negative check uses 8.8.8.8 (Google DNS over HTTPS, IP literal in 8.0.0.0/8 —
+# guaranteed not inside any of our allowlist CIDRs). Don't use a domain like
+# example.com here: example.com migrated to Cloudflare and its IPs now fall
+# inside our intentional 104.16.0.0/13 / 172.64.0.0/13 ranges, making the
+# negative test a false positive. -k skips cert verification (the cert won't
+# match an IP literal).
 echo "Verifying firewall rules..."
-if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
-    echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+if curl --connect-timeout 5 -k https://8.8.8.8/ >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - was able to reach https://8.8.8.8/"
     exit 1
 fi
-echo "Firewall verification passed - example.com correctly blocked"
+echo "Firewall verification passed - 8.8.8.8 correctly blocked"
 if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
     echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
     exit 1

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -16,8 +16,18 @@ rustup component add llvm-tools-preview
 # 4. Cargo dev tools (lands in rw-cargo-cache volume, persists across rebuilds)
 cargo install --locked cargo-llvm-cov cargo-edit
 
-# 5. Node deps (lands in rw-node-modules volume)
-npm install
+# 5. Node deps (lands in rw-node-modules volume).
+#    `npm ci` instead of `npm install` because the latter rewrites
+#    package-lock.json based on the workspace directory name (/workspace inside
+#    the container vs the bind-mount source on the host), which would dirty
+#    the working tree.
+npm ci
+
+# 5b. Claude Code CLI via the official installer.
+#     We install directly rather than via the claude-code devcontainer feature
+#     because the latest published OCI artifact still ships an init-firewall.sh
+#     that overwrites our /usr/local/bin/init-firewall.sh.
+curl -fsSL https://claude.ai/install.sh | bash
 
 # 6. Playwright: install chromium plus its OS package deps in one shot.
 #    Covers both `chromium` and `chromium-embedded` projects (same browser binary).

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1. Fix ownership of named-volume mount points (root-owned by default)
+sudo /usr/local/bin/devcontainer-prepare.sh
+
+cd /workspace
+
+# 2. rust-toolchain.toml triggers rustup to install 1.95.0 lazily; make it
+#    explicit so install errors surface here rather than at first cargo build
+rustup show
+
+# 3. cargo-llvm-cov needs the llvm-tools-preview component
+rustup component add llvm-tools-preview
+
+# 4. Cargo dev tools (lands in rw-cargo-cache volume, persists across rebuilds)
+cargo install --locked cargo-llvm-cov cargo-edit
+
+# 5. Node deps (lands in rw-node-modules volume)
+npm install
+
+# 6. Playwright: install chromium plus its OS package deps in one shot.
+#    Covers both `chromium` and `chromium-embedded` projects (same browser binary).
+#    Run as `vscode` (NOT prefixed with sudo) so the browser binary lands in
+#    /home/vscode/.cache/ms-playwright. Playwright self-elevates internally to
+#    sudo for the apt portion; the base image grants `vscode` passwordless sudo,
+#    so this works without any extra sudoers entries.
+npx playwright install --with-deps chromium

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${RW_DEVCONTAINER_FIREWALL:-0}" != "1" ]]; then
+  echo "[rw devcontainer] firewall: OFF (set RW_DEVCONTAINER_FIREWALL=1 on host before opening to enable)"
+  exit 0
+fi
+
+echo "[rw devcontainer] firewall: ENABLING"
+sudo /usr/local/bin/init-firewall.sh

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ RW looks for markdown files in `docs/` by default. If `docs/` has no `index.md`,
 
 Open [http://localhost:7979](http://localhost:7979) to see your site.
 
+## Local development with devcontainers
+
+A `.devcontainer/` is provided for contributors who want a reproducible build
+environment. With Docker Desktop or OrbStack and the VS Code Dev Containers
+extension installed, "Reopen in Container" sets up the full toolchain
+(Rust 1.95, Node 20, napi-rs, Playwright, Claude Code) automatically.
+
+To enable an egress firewall for sandboxed sessions, set
+`RW_DEVCONTAINER_FIREWALL=1` on your host before opening the container.
+See `.devcontainer/init-firewall.sh` for the allowlist.
+
+> **Security note:** the container bind-mounts your repo, including any
+> `private_key.pem` (Confluence OAuth) or `.env` files. Don't run untrusted
+> Claude Code prompts in this container without enabling the firewall, and
+> avoid mounting host credentials (`~/.ssh`, cloud creds) into it.
+
 ## Configuration
 
 RW uses `rw.toml` for configuration, automatically discovered in the current directory or any parent directory.


### PR DESCRIPTION
## Summary

Adds `.devcontainer/` for contributors who want a reproducible Rust + Node + napi-rs + Playwright + Claude Code build environment, with an optional egress firewall for sandboxed Claude Code sessions.

- **Toolchain:** Ubuntu 24.04 base + devcontainer features for Rust (uses `rust-toolchain.toml`), Node 20, GitHub CLI. Claude Code installed via the official `https://claude.ai/install.sh` (the published `claude-code` feature still bundles a firewall script that collides with ours).
- **Performance:** named volumes for `/usr/local/cargo`, `/workspace/target`, `/workspace/node_modules` — rebuilds in seconds after the first cold build.
- **Sandbox:** opt-in egress firewall enabled by setting `RW_DEVCONTAINER_FIREWALL=1` on the host before opening the container. Adapted from anthropics/claude-code's reference, with rw-specific allowlist additions (crates.io subdomains, kroki.io, Playwright domains) and hardcoded CDN CIDRs for Fastly + Cloudflare so cargo build / diagram rendering / npm install all work under the sandbox.
- **README:** new "Local development with devcontainers" section with a security note about the bind-mounted repo (private_key.pem, .env files visible to anything inside the container).

## Test plan

End-to-end verified inside the container with firewall ON:
- [x] `make build` — green
- [x] `make test` — 361 vitest + Rust workspace tests pass
- [x] `make test-e2e` — 92 Playwright tests pass (chromium + chromium-embedded)
- [x] Toolchain pinned: `rustc --version` and `cargo --version` both report 1.95.0
- [x] `cargo llvm-cov` works (llvm-tools-preview component installed)
- [x] `claude --version` works (CLI on PATH at `/home/vscode/.local/bin/claude`)
- [x] `rw serve` reachable from host on `localhost:7979`
- [x] Cargo cache and `~/.claude` auth persist across container removal (named volumes)
- [x] Firewall blocks `8.8.8.8`, allows `api.github.com` / `index.crates.io` / `kroki.io` / `registry.npmjs.org` / `claude.ai`

## Known caveats

Documented in `.devcontainer/init-firewall.sh`:
- Bare `crates.io` (the website / `cargo search`) is on AWS CloudFront and not allowlisted; the cargo build/install workflow uses Fastly subdomains and works fine.
- The CDN CIDR allowlist (Fastly /16 + Cloudflare /13s) implicitly allows any other site behind the same CDNs — tradeoff in favor of letting normal dev workflows function.
- `make test-e2e` requires `cargo build -p rw --features embedded-preview` first because the e2e Playwright config exercises the embedded-preview server. Pre-existing project-side gap, not specific to the devcontainer.