### PR TITLE
chore(renovate): group napi-rs crates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,12 @@
   "minimumReleaseAge": "14 days",
   "postUpdateOptions": [
     "npmDedupe"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["napi", "napi-build", "napi-derive"],
+      "groupName": "napi-rs crates"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Group `napi`, `napi-build`, and `napi-derive` Cargo updates into a single Renovate PR

## Why
Independent updates to `napi` vs `napi-derive` keep failing CI because the proc-macro and runtime share an ABI:

- #328 (`napi` 3.8.4 → 3.8.5 alone) fails with `E0061: this function takes 5 arguments but 4 arguments were supplied` — `register_class` gained a 5th arg, but the old `napi-derive` macro emits 4-arg call sites.
- #329 (`napi-derive` 3.5.3 → 3.5.4 alone) fails with `expected '(', found ']'` — new `napi-derive` pulls `ctor 0.10.1` while old `napi` still pins `ctor 0.8.0`, so `#[napi]` expansion routes through the wrong `unify_features` macro.

Grouping them ensures the two crates advance in lockstep.

## Test plan
- [ ] Close #328 and #329; let Renovate re-run and produce a single combined PR
- [ ] Verify the new combined PR's "Native bindings / Build native" jobs pass on all three targets (linux-gnu, linux-musl, aarch64-darwin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)