### PR TITLE
chore: fix package-lock.json drift from Renovate npm updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8206,7 +8206,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
-        "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.18",

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
       "matchManagers": ["cargo"],
       "matchPackageNames": ["napi", "napi-build", "napi-derive"],
       "groupName": "napi-rs crates"
+    },
+    {
+      "description": "Bump so npm updates edit package.json and package-lock.json together — avoids lockfile-mirror drift in npm workspaces (see renovatebot/renovate#28797)",
+      "matchManagers": ["npm"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
## Problem

Running `make` on a clean checkout leaves `package-lock.json` modified.

Renovate's npm dependency updates bump a dependency's version range inside `package-lock.json`'s npm-workspace mirror (the `packages/viewer` block) **without** updating `packages/viewer/package.json` — a known Renovate + npm-workspaces issue (renovatebot/renovate#25847), caused by Renovate's `--package-lock-only` flag. The committed lockfile is left inconsistent with `package.json`, so `npm install` — run by `make` — reverts the mirror on every build.

Commit ca71467 is the current instance: the `packages/viewer` mirror records `@sveltejs/vite-plugin-svelte: ^7.1.2` while `package.json` declares `^7.0.0`.

## Fix

- **Re-sync the lockfile** — revert the mirror entry to `^7.0.0` to match `package.json`. The resolved version stays `7.1.2`.
- **Prevent recurrence** — add an npm-scoped `rangeStrategy: "bump"` rule. With `bump`, Renovate edits `package.json` and the lockfile together so they can't drift apart. This is the maintainer-recommended fix (renovatebot/renovate#28797).

The rule is scoped to `matchManagers: ["npm"]` on purpose: a top-level `rangeStrategy` would also hit the **cargo** manager, flipping Rust updates into editing `Cargo.toml` minimums (cargo Renovate PRs currently touch only `Cargo.lock`). The drift is npm-workspace-specific, so the fix is too.

## Verification

- `package-lock.json`'s `packages/viewer` mirror now matches `packages/viewer/package.json` exactly.
- `make` no longer modifies `package-lock.json` on a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
