### PR TITLE
chore: name the root npm workspace package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "rw",
       "workspaces": [
         "packages/*"
       ]

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "rw",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
The root `package.json` had no `name` field, so npm derived it from the directory basename and recorded it in `package-lock.json`. When working in a git worktree (a differently-named directory), `npm install` rewrote the lockfile's `name`, producing spurious diffs.

This pins `name` to `"rw"` so the lockfile name stays stable regardless of the checkout directory.

- `package.json` — adds `"name": "rw"`
- `package-lock.json` — adds the matching `packages[""].name` that npm now emits

🤖 Generated with [Claude Code](https://claude.com/claude-code)