### PR TITLE
chore(viewer): require Node >=22.12.0 in engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Page outline (TOC) sidebar widened from 240px to 320px so that opening a comment no longer narrows the article or shifts text sideways; the sidebar now appears at viewport widths ≥ 1304px instead of ≥ 1224px (narrower viewports get the floating "On this page" popover as before)
 - Page modification times (`lastModified` in API responses) now reflect the git commit time instead of the filesystem modification time — timestamps remain stable across `git checkout`, `git pull`, and branch switching
 - S3-published documentation bundles now include page modification times in the manifest — previously `lastModified` was always epoch zero for Backstage-served pages
+- `@rwdocs/viewer` now requires Node.js `>=22.12.0` (was `>=20`) — the previous floor was incorrect since Vite 8 needs Node 20.19+/22.12+, and Node 20 reached end-of-life on 2026-04-30; `22.12.0` is the first release where `require(esm)` works without a flag
 
 ## [0.1.24] - 2026-04-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7126,7 +7126,7 @@
         "vitest": "^4.1.7"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "packages/viewer/node_modules/@sveltejs/vite-plugin-svelte": {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -62,7 +62,7 @@
     "LICENSE-APACHE"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "dependencies": {
     "@fontsource/jetbrains-mono": "^5.2.8",


### PR DESCRIPTION
## Summary

Raises `engines.node` for the published `@rwdocs/viewer` package from `">=20"` to `">=22.12.0"`.

## Why

- **`">=20"` was incorrect.** Vite 8 — a devDependency of the viewer — requires
  Node `^20.19.0 || >=22.12.0`, so `>=20` falsely advertised that Node 20.0–20.18
  work when they don't.
- **`>=22.12.0`, not `^20.19.0 || >=22.12.0`.** Node 20 reached end-of-life on
  2026-04-30, so this PR deliberately drops the Node 20.19 tail that Vite still
  permits, rather than mirroring Vite's full range.
- **`22.12.0`, not `22`.** `22.12.0` is the first 22.x release where `require(esm)`
  works without the `--experimental-require-module` flag — `>=22` would falsely
  claim 22.0–22.11 work for ESM-only packages.

## Side benefit: viewer stays safely ESM-only

`@rwdocs/viewer` is published ESM-only (its `exports` map has only an `import`
condition). This floor guarantees every consumer runs a Node where `require(esm)`
is flag-free, so CommonJS host apps can `require('@rwdocs/viewer')` directly —
no CJS build needed.

## Relationship to #365

Renovate's #365 bumped this to `>=20.20.2`, tracking a Node *security* release.
`engines.node` is an API-compatibility floor, not a security tracker — a security
patch version maps to no capability the code needs, and tracking it spawns a fresh
PR on every Node release. This PR sets a deliberate, correct floor instead.

**Supersedes #365** — that PR can be closed.

## Changes

- `packages/viewer/package.json` — `engines.node`
- `package-lock.json` — mirrored viewer workspace entry
- `CHANGELOG.md` — note under Unreleased › Changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)