### PR TITLE
refactor(viewer): use object/array class syntax for conditional classes

### DIFF
--- a/packages/viewer/src/components/Breadcrumbs.svelte
+++ b/packages/viewer/src/components/Breadcrumbs.svelte
@@ -134,7 +134,7 @@
   });
 </script>
 
-<div class={compact ? "relative min-h-8" : "relative mb-6 min-h-8"}>
+<div class={["relative min-h-8", { "mb-6": !compact }]}>
   <nav aria-label="Breadcrumb" class="min-h-8 overflow-hidden" bind:this={navEl}>
     {#if breadcrumbs.length > 0}
       <ol
@@ -146,9 +146,10 @@
       >
         {#if firstCrumb}
           <li
-            class={breadcrumbs.length > 1
-              ? "after:mx-2 after:text-gray-400 after:content-['/'] dark:after:text-neutral-500"
-              : ""}
+            class={{
+              "after:mx-2 after:text-gray-400 after:content-['/'] dark:after:text-neutral-500":
+                breadcrumbs.length > 1,
+            }}
           >
             <a
               href={resolveHref(firstCrumb)}

--- a/packages/viewer/src/components/NavTree.svelte
+++ b/packages/viewer/src/components/NavTree.svelte
@@ -20,7 +20,7 @@
     <NavGroup {group} />
   {/each}
 {:else}
-  <ul class={depth > 0 ? "ml-3" : ""}>
+  <ul class={{ "ml-3": depth > 0 }}>
     {#each items as item (item.path)}
       <NavItemComponent {item} {depth} />
     {/each}

--- a/packages/viewer/src/components/TocSidebar.svelte
+++ b/packages/viewer/src/components/TocSidebar.svelte
@@ -18,7 +18,7 @@
   </h3>
   <ul class="space-y-1.5">
     {#each toc as entry (entry.id)}
-      <li class={entry.level === 3 ? "ml-3" : ""}>
+      <li class={{ "ml-3": entry.level === 3 }}>
         <a
           href="#{entry.id}"
           onclick={(e) => {

--- a/packages/viewer/src/components/comments/CommentThread.svelte
+++ b/packages/viewer/src/components/comments/CommentThread.svelte
@@ -156,7 +156,7 @@
   {/if}
 
   <!-- Main comment -->
-  <div class={comment.status === "resolved" ? "opacity-60" : ""}>
+  <div class={{ "opacity-60": comment.status === "resolved" }}>
     <div
       bind:this={avatarRowRef}
       data-testid="comment-avatar-row"


### PR DESCRIPTION
## Summary

Svelte 5.16 added clsx-style object/array support on the `class` attribute. This converts the ternary `class` expressions flagged in #368 to that syntax:

- `TocSidebar.svelte` — `class={{ "ml-3": entry.level === 3 }}`
- `NavTree.svelte` — `class={{ "ml-3": depth > 0 }}`
- `Breadcrumbs.svelte` — container ternary → array `["relative min-h-8", { "mb-6": !compact }]`; separator ternary → object form
- `CommentThread.svelte` — `class={{ "opacity-60": comment.status === "resolved" }}`

`Button.svelte` is left as-is — its full-class lookup tables are out of scope per the issue.

## Test plan

- [x] `make lint` passes (exit 0)
- [x] `make test` passes — 362 frontend tests, all Rust suites
- [x] `make format` stable, no reformatting of the edits
- [x] Rendered output unchanged — each conversion is semantically equivalent (clsx produces identical class strings; class-attribute order is irrelevant to CSS)

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)