### PR TITLE
chore: enforce consistent Tailwind variant order

### DIFF
--- a/packages/viewer/eslint.config.js
+++ b/packages/viewer/eslint.config.js
@@ -141,6 +141,7 @@ export default defineConfig([
         "warn",
         { printWidth: 100, strictness: "loose", preferSingleLine: true },
       ],
+      "better-tailwindcss/enforce-consistent-variant-order": "warn",
     },
     files: ["**/*.svelte"],
     languageOptions: svelteLanguageOptions,


### PR DESCRIPTION
## What

Enables the `better-tailwindcss/enforce-consistent-variant-order` ESLint rule for `@rwdocs/viewer`, so stacked Tailwind variants (e.g. `aria-disabled:hover:bg-transparent`) keep a consistent, canonical order.

The rule requires `eslint-plugin-better-tailwindcss` >= v4.4.0, which is already on `main` (landed via #370). After rebasing onto `main`, this PR is a single-line ESLint config change.

## Verification

- Added as `warn`, matching the other stylistic better-tailwindcss rules in the config (`enforce-consistent-line-wrapping`).
- `npm -w @rwdocs/viewer run lint` passes with **zero** variant-order violations — the codebase already orders variants canonically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)