### PR TITLE
Convert imperative bind:this + $effect DOM glue to {@attach} attachments

### DIFF
--- a/packages/viewer/src/components/comments/CommentForm.svelte
+++ b/packages/viewer/src/components/comments/CommentForm.svelte
@@ -42,15 +42,15 @@
 
   let showActions = $derived(pinActions || focused || body.trim().length > 0);
 
-  // Defer to rAF so the parent's visibility-hidden-until-measured wrapper
-  // (CommentSidebar) has flipped to visible before we focus — focus() on a
-  // visibility:hidden element is a spec no-op.
-  $effect(() => {
-    if (!autofocus || !textareaRef) return;
-    const ta = textareaRef;
+  // Auto-focus the textarea on mount. Deferred to rAF so the parent's
+  // visibility-hidden-until-measured wrapper (CommentSidebar) has flipped to
+  // visible before we focus — focus() on a visibility:hidden element is a spec
+  // no-op.
+  function autofocusTextarea(ta: HTMLTextAreaElement) {
+    if (!autofocus) return;
     const id = requestAnimationFrame(() => ta.focus({ preventScroll: true }));
     return () => cancelAnimationFrame(id);
-  });
+  }
 
   let lastReported: number | null = null;
   $effect(() => {
@@ -77,15 +77,15 @@
     }
   }
 
-  // Re-run whenever body changes — including programmatic resets after submit,
-  // which don't fire `oninput` and would otherwise leave the textarea stuck at
-  // its previous grown height.
-  $effect(() => {
-    body;
-    if (!textareaRef) return;
-    textareaRef.style.height = "auto";
-    textareaRef.style.height = `${textareaRef.scrollHeight}px`;
-  });
+  // Grow the textarea to fit its content. Reads `body` so it re-runs on every
+  // change — including programmatic resets after submit, which don't fire
+  // `oninput` and would otherwise leave the textarea stuck at its previous
+  // grown height.
+  function autoGrowTextarea(ta: HTMLTextAreaElement) {
+    void body;
+    ta.style.height = "auto";
+    ta.style.height = `${ta.scrollHeight}px`;
+  }
 
   async function submit() {
     if (!body.trim() || submitting) return;
@@ -125,6 +125,8 @@
     bind:this={textareaRef}
     bind:value={body}
     onkeydown={handleKeydown}
+    {@attach autoGrowTextarea}
+    {@attach autofocusTextarea}
     {placeholder}
     rows={1}
     class="

--- a/packages/viewer/src/lib/ui/primitives/Popover.svelte
+++ b/packages/viewer/src/lib/ui/primitives/Popover.svelte
@@ -75,7 +75,6 @@
   }: Props = $props();
 
   let triggerWrapperEl: HTMLElement | undefined = $state();
-  let panelEl: HTMLElement | undefined = $state();
 
   const panelId = $props.id();
 
@@ -195,16 +194,17 @@
     }
   });
 
-  // Outside-click + Escape. Registers only while open && dismissible so a
-  // closed Popover never holds document-level listeners. Capture-phase click
-  // matches the `lib/ui/hooks/dismissible` helper so behavior stays
-  // consistent across call sites that still use it.
-  $effect(() => {
-    if (!open || !dismissible) return;
+  // Outside-click + Escape dismiss. Attached to the panel, so the
+  // document-level listeners exist only while the panel is mounted (i.e. while
+  // open) — a closed Popover never holds them. Capture-phase click matches the
+  // `lib/ui/hooks/dismissible` helper so behavior stays consistent across call
+  // sites that still use it.
+  function dismissOnInteraction(panel: HTMLElement) {
+    if (!dismissible) return;
 
     function onClick(event: MouseEvent) {
       const target = event.target as Node;
-      if (panelEl?.contains(target)) return;
+      if (panel.contains(target)) return;
       if (triggerWrapperEl?.contains(target)) return;
       if (mode === "external" && anchorEl?.contains(target)) return;
       open = false;
@@ -223,7 +223,7 @@
       document.removeEventListener("click", onClick, true);
       window.removeEventListener("keydown", onKeydown);
     };
-  });
+  }
 </script>
 
 {#if trigger}
@@ -234,7 +234,7 @@
 
 {#if open}
   <div
-    bind:this={panelEl}
+    {@attach dismissOnInteraction}
     id={panelId}
     class="{strategy} z-dropdown {extraClass}"
     style="{positionStyle}{isPositioned ? '' : ' visibility: hidden; pointer-events: none;'}"

--- a/packages/viewer/src/lib/ui/primitives/Popover.test.svelte.ts
+++ b/packages/viewer/src/lib/ui/primitives/Popover.test.svelte.ts
@@ -336,6 +336,37 @@ describe("Popover", () => {
         anchorEl.remove();
       }
     });
+
+    it("removes the outside-click listener when the panel closes", async () => {
+      const addSpy = vi.spyOn(document, "addEventListener");
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+
+      try {
+        const { getByTestId } = render(Harness, {
+          x: 0,
+          y: 0,
+          initialOpen: true,
+          dismissible: true,
+        });
+        flushSync();
+
+        // The dismiss attachment installs a capture-phase click listener
+        // while the panel is open.
+        const clickCall = addSpy.mock.calls.find((call) => call[0] === "click" && call[2] === true);
+        expect(clickCall).toBeTruthy();
+
+        await fireEvent.keyDown(window, { key: "Escape" });
+        flushSync();
+        expect(getByTestId("pp-harness").dataset.open).toBe("false");
+
+        // Closing unmounts the panel, so the attachment teardown ran and
+        // removed the exact listener it installed.
+        expect(removeSpy).toHaveBeenCalledWith("click", clickCall![1], true);
+      } finally {
+        addSpy.mockRestore();
+        removeSpy.mockRestore();
+      }
+    });
   });
 
   describe("aria", () => {


### PR DESCRIPTION
## Summary

Converts imperative `bind:this` + `$effect` DOM glue to Svelte 5.29 `{@attach}` attachments, per #367. Attachments co-locate per-element behavior with the element and tear down automatically — no `bind:this` ref needed.

## Changes

**`CommentForm.svelte`** — both self-contained per-element effects converted:
- Auto-grow textarea `$effect` → `{@attach autoGrowTextarea}`
- Autofocus `$effect` → `{@attach autofocusTextarea}` (retains its `cancelAnimationFrame` cleanup)
- `textareaRef` / `formRef` kept — still used by `useElementSize` and the cross-element `onAnchor` measurement, so not "now-unused"

**`Popover.svelte`** — dismiss effect converted, ref dropped:
- Outside-click + Escape `$effect` → `{@attach dismissOnInteraction}` on the panel
- `panelEl` `bind:this` ref **dropped entirely** (the attachment's element parameter replaces it)

**`Popover.test.svelte.ts`** — added a test verifying the dismiss attachment removes its exact `click` listener when the panel closes (the "attachment teardown verified" criterion).

## Evaluated but kept as-is

Following the issue's "convert self-contained cases first / evaluate case by case" guidance:

- **`Menu/Root.svelte` auto-focus** — attempted, but it broke `Menu.test.svelte.ts:352`. The auto-focus is *not* self-contained: it relies on running after Popover's `restoreFocusEl` capture. As an attachment it runs too early, so Escape stopped restoring focus to the anchor. Reverted.
- **`useActiveHeading`** — observes many heading elements at once; an attachment is per-element. The issue explicitly permits this to stay.
- **`observeElement` / `useElementSize` / `useAnchorOffset`** — the getter-based API is load-bearing (runtime target switching + conditional null subscription that Popover relies on); converting would ripple across ~6 consumers — not incremental.

## Acceptance criteria

- [x] CommentForm auto-grow textarea converted to `{@attach}`
- [x] Converted sites drop now-unused `bind:this` refs (`panelEl` dropped; CommentForm refs remain genuinely used)
- [x] Cleanup verified — new Popover teardown test
- [x] Viewer behavior unchanged

## Test plan

- `npm -w @rwdocs/viewer run test` — 363 pass (+1 new teardown test)
- `npm -w @rwdocs/viewer run check` — 0 errors, 0 warnings
- `npm -w @rwdocs/viewer run lint` — clean

Change is frontend-only (no Rust touched).

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
