### PR TITLE
style(viewer): fix Tailwind class line wrapping in Button

### DIFF
--- a/packages/viewer/src/lib/ui/primitives/Button.svelte
+++ b/packages/viewer/src/lib/ui/primitives/Button.svelte
@@ -73,7 +73,8 @@
   class="
     inline-flex cursor-pointer items-center justify-center gap-1.5 font-medium transition-colors
     focus-visible:outline-2 focus-visible:outline-offset-2
-    aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-transparent
+    aria-disabled:cursor-not-allowed aria-disabled:opacity-50
+    aria-disabled:hover:bg-transparent
     {VARIANT_CLASSES[variant]}
     {sizeClass}
     {extraClass}


### PR DESCRIPTION
## Summary

`make lint` reported one eslint warning from `eslint-plugin-better-tailwindcss`: the class list on the `<button>` element in `Button.svelte` exceeded the configured line-wrapping length limit.

This splits the `aria-disabled:*` Tailwind utilities across two lines so the class attribute satisfies `better-tailwindcss/enforce-consistent-line-wrapping`.

## Verification

`make lint` now passes fully — cargo clippy clean, svelte-check 0 errors/0 warnings, eslint clean. No behavior change (whitespace only in a class string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)