### PR TITLE
chore: stop Renovate from bumping the engines.node constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
       "description": "Bump so npm updates edit package.json and package-lock.json together — avoids lockfile-mirror drift in npm workspaces (see renovatebot/renovate#28797)",
       "matchManagers": ["npm"],
       "rangeStrategy": "bump"
+    },
+    {
+      "description": "The engines.node constraint is a deliberate minimum (set to match a tooling requirement), not something to auto-bump to the latest release",
+      "matchDepTypes": ["engines"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,7 @@
     },
     {
       "description": "The engines.node constraint is a deliberate minimum (set to match a tooling requirement), not something to auto-bump to the latest release",
+      "matchManagers": ["npm"],
       "matchDepTypes": ["engines"],
       "enabled": false
     }


### PR DESCRIPTION
The `engines.node` minimum in `packages/viewer/package.json` is a deliberate tooling floor, not a value to chase to the latest Node release. This disables Renovate for the `engines` depType so it stops opening major-bump PRs (e.g. #383, node 22 → 24) against it.

```json
{
  "description": "The engines.node constraint is a deliberate minimum ...",
  "matchDepTypes": ["engines"],
  "enabled": false
}
```

Closes #383 once merged (Renovate auto-closes the disabled dep's PR on its next run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)