### PR TITLE
fix(server): serve documentation pages under /api/ (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Inline comments — select text in the browser and add comments anchored to specific passages; comments persist in `.rw/comments/sqlite.db` and survive content re-renders via multi-selector anchoring (TextQuoteSelector + TextPositionSelector). When the original passage no longer appears verbatim — e.g. after a typo fix or a paragraph split that drops a space — the viewer falls back to fuzzy re-anchoring (diff-match-patch) and marks the comment as **re-anchored** with a softer dashed-underline highlight and an italic label in the thread header, so reviewers can tell when a comment may have moved.
 - Page comments — leave comments on a page without selecting text; page comments appear below the article content with the same threading and resolve/reopen workflow as inline comments
-- Comment REST API (`/api/comments`) for creating, listing, and updating inline annotations
+- Comment REST API (`/_api/comments`) for creating, listing, and updating inline annotations
 - Comment authorship — every comment carries an author (`{ id, name, avatarUrl? }`); `rw serve` stamps browser-created comments with "You". Authors with id `local:human` render a person avatar; authors with id `local:ai` render a sparkles avatar (recommended for LLM agents writing via `rw comment`); others fall back to name initials.
 - `rw comment` CLI (list, show, add, reply, resolve) for scripting and LLM agents — reads and writes comments in the project's `.rw/comments/sqlite.db` directly; works whether or not `rw serve` is running. Identity via `RW_COMMENT_AUTHOR_ID` / `RW_COMMENT_AUTHOR_NAME` env vars or `--author-id` / `--author-name` flags; falls back to the default `local:human` / "You" identity when neither is set. Inline anchoring via `--quote "passage text"` — the CLI renders the target page in-process and rejects ambiguous or missing matches.
 
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Page modification times (`lastModified` in API responses) now reflect the git commit time instead of the filesystem modification time — timestamps remain stable across `git checkout`, `git pull`, and branch switching
 - S3-published documentation bundles now include page modification times in the manifest — previously `lastModified` was always epoch zero for Backstage-served pages
 - `@rwdocs/viewer` now requires Node.js `>=22.12.0` (was `>=20`) — the previous floor was incorrect since Vite 8 needs Node 20.19+/22.12+, and Node 20 reached end-of-life on 2026-04-30; `22.12.0` is the first release where `require(esm)` works without a flag
+- **Breaking:** the HTTP API served by `rw serve` moved from `/api/*` to the reserved `/_api/*` prefix (e.g. `/_api/navigation`, `/_api/pages/...`, `/_api/comments`), freeing the `/api/*` URL space for documentation pages. The bundled viewer moves in lockstep; only external callers hitting `rw serve`'s HTTP endpoints directly need to update.
+
+### Fixed
+
+- Documentation pages whose URL begins with `/api/` (e.g. `docs/api/usage.md`) no longer return 404 when opened directly or refreshed in the browser.
 
 ## [0.1.24] - 2026-04-10
 

--- a/crates/rw-embedded-preview/src/preview.js
+++ b/crates/rw-embedded-preview/src/preview.js
@@ -21,7 +21,7 @@ function applyShellTheme() {
 applyShellTheme();
 
 const currentInstance = mountRw(root, {
-  apiBaseUrl: "/api",
+  apiBaseUrl: "/_api",
   embedded: true,
   colorScheme: themes[themeIndex],
   initialPath: window.location.pathname || "/",

--- a/crates/rw-server/src/app.rs
+++ b/crates/rw-server/src/app.rs
@@ -21,16 +21,19 @@ use crate::static_files;
 /// * `state` - Shared application state
 pub(crate) fn create_router(state: Arc<AppState>) -> Router {
     let mut router = Router::new()
-        .route("/api/config", get(handlers::config::get_config))
-        .route("/api/navigation", get(handlers::navigation::get_navigation))
-        .route("/api/pages/", get(handlers::pages::get_root_page))
-        .route("/api/pages/{*path}", get(handlers::pages::get_page))
+        .route("/_api/config", get(handlers::config::get_config))
         .route(
-            "/api/comments",
+            "/_api/navigation",
+            get(handlers::navigation::get_navigation),
+        )
+        .route("/_api/pages/", get(handlers::pages::get_root_page))
+        .route("/_api/pages/{*path}", get(handlers::pages::get_page))
+        .route(
+            "/_api/comments",
             get(handlers::comments::list_comments).post(handlers::comments::create_comment),
         )
         .route(
-            "/api/comments/{id}",
+            "/_api/comments/{id}",
             get(handlers::comments::get_comment).patch(handlers::comments::update_comment),
         );
 

--- a/crates/rw-server/src/handlers/comments.rs
+++ b/crates/rw-server/src/handlers/comments.rs
@@ -55,7 +55,7 @@ impl IntoResponse for CommentApiError {
     }
 }
 
-/// Handle `GET /api/comments?documentId=...&status=...`.
+/// Handle `GET /_api/comments?documentId=...&status=...`.
 pub(crate) async fn list_comments(
     State(state): State<Arc<AppState>>,
     Query(filter): Query<CommentFilter>,
@@ -63,7 +63,7 @@ pub(crate) async fn list_comments(
     Ok(Json(state.comment_store.list(filter).await?))
 }
 
-/// Handle `POST /api/comments`.
+/// Handle `POST /_api/comments`.
 pub(crate) async fn create_comment(
     State(state): State<Arc<AppState>>,
     Json(input): Json<NewComment>,
@@ -72,7 +72,7 @@ pub(crate) async fn create_comment(
     Ok((StatusCode::CREATED, Json(comment)))
 }
 
-/// Handle `GET /api/comments/{id}`.
+/// Handle `GET /_api/comments/{id}`.
 pub(crate) async fn get_comment(
     State(state): State<Arc<AppState>>,
     Path(id): Path<Uuid>,
@@ -80,7 +80,7 @@ pub(crate) async fn get_comment(
     Ok(Json(state.comment_store.get(id).await?))
 }
 
-/// Handle `PATCH /api/comments/{id}`.
+/// Handle `PATCH /_api/comments/{id}`.
 pub(crate) async fn update_comment(
     State(state): State<Arc<AppState>>,
     Path(id): Path<Uuid>,

--- a/crates/rw-server/src/handlers/config.rs
+++ b/crates/rw-server/src/handlers/config.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 
 use crate::state::AppState;
 
-/// Response for GET /api/config.
+/// Response for GET /_api/config.
 ///
 /// Other backends that share this schema (e.g. the Backstage backend plugin)
 /// set `commentsEnabled` to `false` to opt out.
@@ -23,7 +23,7 @@ pub(crate) struct ConfigResponse {
     comments_enabled: bool,
 }
 
-/// Handle GET /api/config.
+/// Handle GET /_api/config.
 pub(crate) async fn get_config(State(state): State<Arc<AppState>>) -> Json<ConfigResponse> {
     Json(ConfigResponse {
         live_reload_enabled: state.live_reload_enabled(),

--- a/crates/rw-server/src/handlers/navigation.rs
+++ b/crates/rw-server/src/handlers/navigation.rs
@@ -13,7 +13,7 @@ use crate::error::HandlerError;
 use crate::handlers::to_url_path;
 use crate::state::AppState;
 
-/// Query parameters for GET /api/navigation.
+/// Query parameters for GET /_api/navigation.
 #[derive(Deserialize)]
 pub(crate) struct NavigationQuery {
     /// Section ref (optional). If provided, returns navigation for that section.
@@ -22,7 +22,7 @@ pub(crate) struct NavigationQuery {
     section_ref: Option<String>,
 }
 
-/// Response for GET /api/navigation.
+/// Response for GET /_api/navigation.
 #[derive(Serialize)]
 pub(crate) struct NavigationResponse {
     /// Navigation tree items.
@@ -86,7 +86,7 @@ impl From<NavItem> for NavItemResponse {
     }
 }
 
-/// Handle GET /api/navigation.
+/// Handle GET /_api/navigation.
 pub(crate) async fn get_navigation(
     Query(query): Query<NavigationQuery>,
     State(state): State<Arc<AppState>>,

--- a/crates/rw-server/src/handlers/pages.rs
+++ b/crates/rw-server/src/handlers/pages.rs
@@ -20,7 +20,7 @@ use crate::error::HandlerError;
 use crate::handlers::to_url_path;
 use crate::state::AppState;
 
-/// Response for GET /api/pages/{path}.
+/// Response for GET /_api/pages/{path}.
 #[derive(Serialize)]
 struct PageResponse {
     /// Page metadata.
@@ -101,7 +101,7 @@ impl From<&TocEntry> for TocResponse {
     }
 }
 
-/// Handle GET /api/pages/ (root page).
+/// Handle GET /_api/pages/ (root page).
 pub(crate) async fn get_root_page(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -109,7 +109,7 @@ pub(crate) async fn get_root_page(
     get_page_impl(String::new(), state, headers)
 }
 
-/// Handle GET /api/pages/{path}.
+/// Handle GET /_api/pages/{path}.
 pub(crate) async fn get_page(
     Path(path): Path<String>,
     State(state): State<Arc<AppState>>,

--- a/crates/rw-server/src/static_files.rs
+++ b/crates/rw-server/src/static_files.rs
@@ -33,8 +33,12 @@ async fn serve_asset(req: Request<Body>) -> Response {
             .unwrap();
     }
 
-    // SPA fallback: serve index.html for client-side routing
-    let is_spa_route = !path.starts_with("api/") && !path.contains('.');
+    // SPA fallback: serve index.html for client-side routing. Unmatched
+    // requests under the reserved `/_api/` prefix are excluded so a bad API
+    // path returns 404 instead of the HTML shell — including the bare
+    // `/_api` segment with no trailing slash.
+    let is_reserved_api = path == "_api" || path.starts_with("_api/");
+    let is_spa_route = !is_reserved_api && !path.contains('.');
     if is_spa_route && let Some(index) = rw_assets::get("index.html") {
         return Response::builder()
             .status(StatusCode::OK)
@@ -49,21 +53,27 @@ async fn serve_asset(req: Request<Body>) -> Response {
 /// Serve a static asset, falling back to the embedded preview page.
 ///
 /// Only serves actual asset files (JS, CSS, images etc). For any path
-/// that doesn't match a real asset, returns the preview shell HTML.
+/// that doesn't match a real asset, returns the preview shell HTML —
+/// except unmatched requests under the reserved `/_api/` prefix, which
+/// 404 (mirroring [`serve_asset`]) so a bad API path never yields HTML.
 #[cfg(feature = "embedded-preview")]
 pub(crate) async fn asset_or_preview_fallback(req: Request<Body>) -> Response {
     let path = req.uri().path().trim_start_matches('/');
 
     // Only serve real asset files — don't map root or SPA routes to index.html.
-    if !path.is_empty() {
-        if let Some(content) = rw_assets::get(path) {
-            let mime = rw_assets::mime_for(path);
-            return Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, mime)
-                .body(Body::from(content.into_owned()))
-                .unwrap();
-        }
+    if !path.is_empty()
+        && let Some(content) = rw_assets::get(path)
+    {
+        let mime = rw_assets::mime_for(path);
+        return Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, mime)
+            .body(Body::from(content.into_owned()))
+            .unwrap();
+    }
+
+    if path == "_api" || path.starts_with("_api/") {
+        return StatusCode::NOT_FOUND.into_response();
     }
 
     rw_embedded_preview::preview_page().await
@@ -109,6 +119,17 @@ mod tests {
                 response.headers().get(header::CONTENT_TYPE).unwrap(),
                 "text/html; charset=utf-8"
             );
+        }
+
+        #[tokio::test]
+        async fn fallback_returns_404_for_unknown_api_path() {
+            // Unmatched paths under the reserved `/_api/` prefix must 404,
+            // not return the preview shell HTML — including the bare
+            // `/_api` form (no trailing slash).
+            for path in ["/_api/does-not-exist", "/_api"] {
+                let response = asset_or_preview_fallback(request_for(path)).await;
+                assert_eq!(response.status(), StatusCode::NOT_FOUND, "for {path}");
+            }
         }
     }
 }

--- a/packages/viewer/e2e/comments.spec.ts
+++ b/packages/viewer/e2e/comments.spec.ts
@@ -114,11 +114,11 @@ async function createCommentViaUI(page: Page, targetText: string, body: string) 
 /** Resolve all comments for a document via the API so they don't interfere with new tests. */
 async function resolveAllComments(page: Page, documentId: string) {
   await page.evaluate(async (docId) => {
-    const res = await fetch(`/api/comments?documentId=${encodeURIComponent(docId)}`);
+    const res = await fetch(`/_api/comments?documentId=${encodeURIComponent(docId)}`);
     const comments = await res.json();
     for (const c of comments) {
       if (c.status === "open") {
-        await fetch(`/api/comments/${c.id}`, {
+        await fetch(`/_api/comments/${c.id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ status: "resolved" }),
@@ -231,7 +231,7 @@ test.describe("Inline comments", () => {
 
     // Comment should be persisted via the API
     const comments = await page.evaluate(async () => {
-      const res = await fetch("/api/comments?documentId=&status=open");
+      const res = await fetch("/_api/comments?documentId=&status=open");
       return res.json();
     });
     const created = comments.find(
@@ -251,10 +251,12 @@ test.describe("Inline comments", () => {
     const sidebar = page.getByRole("complementary", { name: "Comments" });
     await sidebar.getByPlaceholder("Write a comment...").fill("Check highlight");
     await sidebar.getByRole("button", { name: "Comment", exact: true }).click();
+    // Wait for the form to close — confirms the POST completed before we query.
+    await expect(sidebar.getByPlaceholder("Write a comment...")).not.toBeVisible();
 
     // Verify via API that the comment has both selector types
     const comments = await page.evaluate(async () => {
-      const res = await fetch("/api/comments?documentId=&status=open");
+      const res = await fetch("/_api/comments?documentId=&status=open");
       return res.json();
     });
     const created = comments.find((c: { body: string }) => c.body === "Check highlight");
@@ -368,7 +370,7 @@ test.describe("Inline comments", () => {
 
     // Verify via API that the reply has the correct parentId
     const comments = await page.evaluate(async () => {
-      const res = await fetch("/api/comments?documentId=&status=open");
+      const res = await fetch("/_api/comments?documentId=&status=open");
       return res.json();
     });
     const parent = comments.find((c: { body: string }) => c.body === "Parent comment");
@@ -393,7 +395,7 @@ test.describe("Inline comments", () => {
     await page.getByRole("article").waitFor();
 
     const comments = await page.evaluate(async () => {
-      const res = await fetch("/api/comments?documentId=&status=open");
+      const res = await fetch("/_api/comments?documentId=&status=open");
       return res.json();
     });
     const persisted = comments.find((c: { body: string }) => c.body === "Persistent comment");
@@ -433,7 +435,7 @@ test.describe("Page comments", () => {
 
     // Verify via API — should have no selectors
     const comments = await page.evaluate(async () => {
-      const res = await fetch("/api/comments?documentId=&status=open");
+      const res = await fetch("/_api/comments?documentId=&status=open");
       return res.json();
     });
     const created = comments.find((c: { body: string }) => c.body === "A page-level comment");
@@ -462,7 +464,7 @@ test.describe("Page comments", () => {
 
     // Verify via API — find the reply and check its parentId
     const comments = await page.evaluate(async () => {
-      const res = await fetch("/api/comments?documentId=");
+      const res = await fetch("/_api/comments?documentId=");
       return res.json();
     });
     const reply = comments.find(
@@ -504,7 +506,7 @@ test.describe("Page comments", () => {
     await page.getByRole("article").waitFor();
 
     await page.evaluate(async () => {
-      await fetch("/api/comments", {
+      await fetch("/_api/comments", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/packages/viewer/e2e/page-content.spec.ts
+++ b/packages/viewer/e2e/page-content.spec.ts
@@ -198,3 +198,34 @@ test.describe("Page Content", () => {
     await expect(page).toHaveTitle(/Installation - RW/);
   });
 });
+
+test.describe("Pages under /api/", () => {
+  // Wide enough for the ToC sidebar to render (breakpoint: 1304px)
+  test.use({ viewport: { width: 1400, height: 720 } });
+
+  // Regression test for issue #305: a doc page whose URL starts with /api/
+  // must not collide with the server API namespace on a server round-trip.
+  test("loads a page under /api/ on direct navigation and reload", async ({ page }) => {
+    await page.goto("/api/endpoints");
+
+    const article = page.getByRole("article");
+    await expect(article).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("API Endpoints");
+
+    // Reload hits the server fresh (no SPA shortcut) — must still resolve.
+    await page.reload();
+    await expect(article).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("API Endpoints");
+  });
+
+  // Unmatched paths under the reserved /_api/ prefix must 404, not fall through
+  // to the SPA shell — otherwise API clients receive HTML with a 200 status.
+  // Covers both the bare `/_api` segment and a path under the prefix.
+  for (const apiPath of ["/_api", "/_api/does-not-exist"]) {
+    test(`unknown ${apiPath} returns 404 with no HTML body`, async ({ page }) => {
+      const response = await page.request.get(apiPath);
+      expect(response.status()).toBe(404);
+      expect(response.headers()["content-type"] ?? "").not.toContain("html");
+    });
+  }
+});

--- a/packages/viewer/src/App.svelte
+++ b/packages/viewer/src/App.svelte
@@ -16,7 +16,7 @@
   import NotFound from "./pages/NotFound.svelte";
 
   interface Props {
-    /** API base URL. Defaults to "/api". */
+    /** API base URL. Defaults to "/_api". */
     apiBaseUrl?: string;
     /** Run in embedded mode (no pushState). Defaults to false. */
     embedded?: boolean;
@@ -35,7 +35,7 @@
   }
 
   let {
-    apiBaseUrl = "/api",
+    apiBaseUrl = "/_api",
     embedded = false,
     initialPath,
     sectionRef,
@@ -174,8 +174,8 @@
   const getRoute = (currentPath: string) => {
     if (import.meta.env.DEV && currentPath === "/_kit") return "kit";
     if (currentPath === "/") return "home";
-    // Skip API routes and static assets
-    if (currentPath.startsWith("/api/") || currentPath.startsWith("/assets/")) {
+    // Skip static assets and the reserved /_api/ namespace
+    if (currentPath.startsWith("/assets/") || currentPath.startsWith("/_api/")) {
       return "notfound";
     }
     return "page";

--- a/packages/viewer/src/api/client.test.ts
+++ b/packages/viewer/src/api/client.test.ts
@@ -40,7 +40,7 @@ describe("fetchNavigation", () => {
     const client = createApiClient();
     const result = await client.fetchNavigation();
 
-    expect(fetch).toHaveBeenCalledWith("/api/navigation", {});
+    expect(fetch).toHaveBeenCalledWith("/_api/navigation", {});
     expect(result).toEqual(mockNavTree);
   });
 
@@ -48,7 +48,7 @@ describe("fetchNavigation", () => {
     const client = createApiClient();
     await client.fetchNavigation({ bypassCache: true });
 
-    expect(fetch).toHaveBeenCalledWith("/api/navigation", { cache: "no-store" });
+    expect(fetch).toHaveBeenCalledWith("/_api/navigation", { cache: "no-store" });
   });
 
   it("throws error on non-ok response", async () => {
@@ -91,7 +91,7 @@ describe("fetchPage", () => {
     const client = createApiClient();
     const result = await client.fetchPage("test");
 
-    expect(fetch).toHaveBeenCalledWith("/api/pages/test", {});
+    expect(fetch).toHaveBeenCalledWith("/_api/pages/test", {});
     expect(result).toEqual(mockPage);
   });
 
@@ -99,7 +99,7 @@ describe("fetchPage", () => {
     const client = createApiClient();
     await client.fetchPage("test", { bypassCache: true });
 
-    expect(fetch).toHaveBeenCalledWith("/api/pages/test", { cache: "no-store" });
+    expect(fetch).toHaveBeenCalledWith("/_api/pages/test", { cache: "no-store" });
   });
 
   it("passes signal when provided", async () => {
@@ -107,7 +107,7 @@ describe("fetchPage", () => {
     const client = createApiClient();
     await client.fetchPage("test", { signal: controller.signal });
 
-    expect(fetch).toHaveBeenCalledWith("/api/pages/test", { signal: controller.signal });
+    expect(fetch).toHaveBeenCalledWith("/_api/pages/test", { signal: controller.signal });
   });
 
   it("passes both cache and signal when provided", async () => {
@@ -115,7 +115,7 @@ describe("fetchPage", () => {
     const client = createApiClient();
     await client.fetchPage("test", { bypassCache: true, signal: controller.signal });
 
-    expect(fetch).toHaveBeenCalledWith("/api/pages/test", {
+    expect(fetch).toHaveBeenCalledWith("/_api/pages/test", {
       cache: "no-store",
       signal: controller.signal,
     });
@@ -199,7 +199,7 @@ describe("fetchConfig", () => {
     const client = createApiClient();
     const result = await client.fetchConfig();
 
-    expect(fetch).toHaveBeenCalledWith("/api/config");
+    expect(fetch).toHaveBeenCalledWith("/_api/config");
     expect(result).toEqual(mockConfig);
   });
 

--- a/packages/viewer/src/api/client.ts
+++ b/packages/viewer/src/api/client.ts
@@ -39,7 +39,7 @@ export interface ApiClient {
 }
 
 /** Create an API client bound to the given base URL */
-export function createApiClient(apiBase: string = "/api", fetchFn?: typeof fetch): ApiClient {
+export function createApiClient(apiBase: string = "/_api", fetchFn?: typeof fetch): ApiClient {
   const doFetch = fetchFn ?? fetch;
   const base = apiBase.replace(/\/+$/, "");
 

--- a/packages/viewer/src/api/comments.ts
+++ b/packages/viewer/src/api/comments.ts
@@ -7,7 +7,7 @@ export interface CommentApiClient {
 }
 
 export function createCommentApiClient(
-  apiBase: string = "/api",
+  apiBase: string = "/_api",
   fetchFn?: typeof fetch,
 ): CommentApiClient {
   const doFetch = fetchFn ?? fetch;

--- a/packages/viewer/src/embed.ts
+++ b/packages/viewer/src/embed.ts
@@ -3,7 +3,8 @@ import App from "./App.svelte";
 import { mount, unmount } from "svelte";
 
 export interface MountOptions {
-  /** API base URL (e.g. "/api/rw"). */
+  /** API base URL (host-supplied — e.g. `/api/rw` when proxied by a Backstage
+   *  plugin to the rwdocs backend). */
   apiBaseUrl: string;
   /** Run in embedded mode (no pushState). Defaults to true. */
   embedded?: boolean;

--- a/packages/viewer/src/types/index.ts
+++ b/packages/viewer/src/types/index.ts
@@ -6,7 +6,7 @@ export interface SectionInfo {
   name: string;
 }
 
-/** Navigation tree item from GET /api/navigation */
+/** Navigation tree item from GET /_api/navigation */
 export interface NavItem {
   title: string;
   path: string;
@@ -46,7 +46,7 @@ export interface NavigationTree {
   parentScope?: ScopeInfo;
 }
 
-/** Page metadata from GET /api/pages/{path} */
+/** Page metadata from GET /_api/pages/{path} */
 export interface PageMeta {
   title: string;
   path: string;
@@ -76,7 +76,7 @@ export interface TocEntry {
   id: string;
 }
 
-/** Page response from GET /api/pages/{path} */
+/** Page response from GET /_api/pages/{path} */
 export interface PageResponse {
   meta: PageMeta;
   breadcrumbs: Breadcrumb[];
@@ -90,7 +90,7 @@ export interface ApiError {
   path?: string;
 }
 
-/** Server config from GET /api/config */
+/** Server config from GET /_api/config */
 export interface ConfigResponse {
   liveReloadEnabled: boolean;
   commentsEnabled?: boolean;

--- a/packages/viewer/vite.config.ts
+++ b/packages/viewer/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      "/api": "http://localhost:7979",
+      "/_api": "http://localhost:7979",
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Documentation pages whose URL starts with `/api/` (e.g. `docs/api/usage.md` → `/api/usage`) returned **404** on direct browser load or refresh.

Two layers reserved the `/api/*` URL space and collided with doc pages:

- the server's SPA fallback (`static_files.rs`) excluded any `api/` path from `index.html`, and
- the viewer's `getRoute()` classifier treated any `/api/*` path as not-found.

Both guards could only ever hit documentation pages — real API endpoints are registered routes (including wildcards) and never reach either guard.

The fix moves the rw-server HTTP API to a reserved `/_api/*` prefix, freeing `/api/*` entirely for documentation, then replaces the collision guards with narrower `/_api/`-only 404 guards so unknown API paths still get a clean 404 instead of the HTML shell.

## Changes

- **Server** — routes moved `/api/*` → `/_api/*` (`app.rs`); both fallback paths (`serve_asset` and `asset_or_preview_fallback`) 404 unmatched `/_api/*` requests, including the bare `/_api` segment with no trailing slash.
- **Frontend** — `createApiClient` / `createCommentApiClient` / `App.svelte` `apiBaseUrl` defaults moved to `/_api`; `getRoute()` gains a symmetric `/_api/` not-found clause.
- **Embedded preview shell** (`preview.js`) moves in lockstep.
- **Dev tooling** — Vite dev proxy `/api` → `/_api`.
- **Tests** — new e2e regression for direct load of doc pages under `/api/`; new e2e + Rust unit tests for the `/_api/` 404 guards (bare and sub-path forms, content-type assertion); fixed a pre-existing POST-then-read race in `comments.spec.ts`.
- **CHANGELOG** — documents the HTTP API move as an explicit **Breaking** change, separate from the `### Fixed` entry for the doc-page bug.

Backstage embedding is unaffected: the embedded viewer receives an explicit host-supplied `apiBaseUrl` and talks to the Backstage backend (`@rwdocs/core` napi), not rw-server's HTTP API.

## Test Plan

- [x] New e2e regression — `page.goto("/api/endpoints")` + reload renders the page
- [x] New e2e — `GET /_api` and `GET /_api/<unknown>` both return 404 with non-HTML content-type
- [x] `cargo test -p rw-server --features embedded-preview` — 18 unit + 1 doctest
- [x] Frontend unit suite — 363/363
- [x] Playwright e2e — 96/96
- [x] `make format` / `make lint` — clean

Closes #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
