### PR TITLE
feat: add status badge directive

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -7,3 +7,4 @@ globs: "**/*.rs"
 
 - Import all types and traits you use via `use` statements at the top of the file.
 - Fully-qualified paths are only for disambiguating name conflicts or one-off references in doc comments.
+- Prefer standard traits over custom methods that mirror them. Use `impl From<&str>` (or `impl FromStr` if it can fail) for string-to-type conversion instead of `fn parse`; use `impl Display` instead of `fn as_str` / `fn to_string`. Custom method names hide intent and don't compose with `format!`, `.parse()`, or `.into()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comment REST API (`/api/comments`) for creating, listing, and updating inline annotations
 - Comment authorship — every comment carries an author (`{ id, name, avatarUrl? }`); `rw serve` stamps browser-created comments with "You". Authors with id `local:human` render a person avatar; authors with id `local:ai` render a sparkles avatar (recommended for LLM agents writing via `rw comment`); others fall back to name initials.
 - `rw comment` CLI (list, show, add, reply, resolve) for scripting and LLM agents — reads and writes comments in the project's `.rw/comments/sqlite.db` directly; works whether or not `rw serve` is running. Identity via `RW_COMMENT_AUTHOR_ID` / `RW_COMMENT_AUTHOR_NAME` env vars or `--author-id` / `--author-name` flags; falls back to the default `local:human` / "You" identity when neither is set. Inline anchoring via `--quote "passage text"` — the CLI renders the target page in-process and rejects ambiguous or missing matches.
+- Status badges — `:status[Label]{color=NAME}` renders an inline colored pill label (`grey`, `red`, `yellow`, `green`, `blue`, `purple`). Publishing to Confluence emits the native `status` macro, so badges stay editable and on-style in Confluence. Color is case-insensitive and optional; unknown or omitted colors fall back to `grey`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Publish the same markdown to Confluence pages or embed in Backstage with native 
 - **Live reload** — edit markdown, see changes instantly in the browser
 - **Diagram rendering** — PlantUML, Mermaid, GraphViz, and 14+ formats via Kroki
 - **Tabbed content** — group related content with `:::tab` syntax
+- **Status badges** — inline colored pill labels with Confluence status-macro parity
 - **GitHub-style alerts** — `[!NOTE]`, `[!TIP]`, `[!WARNING]`, and more
 - **Navigation and TOC** — automatic sidebar, breadcrumbs, and table of contents
 - **Page metadata** — YAML frontmatter or sidecar files for titles, descriptions, and custom variables
@@ -77,6 +78,7 @@ See the [configuration guide](docs/configuration.md) for all options.
 - [Page Metadata](docs/metadata.md)
 - [Confluence Publishing](docs/confluence.md)
 - [Diagram Rendering](docs/diagrams.md)
+- [Status Badges](docs/status-badges.md)
 - [Comment CLI](docs/comment-cli.md)
 
 ## License

--- a/crates/rw-confluence/src/backend.rs
+++ b/crates/rw-confluence/src/backend.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::Write;
 
-use rw_renderer::{AlertKind, RenderBackend, escape_html};
+use rw_renderer::{AlertKind, RenderBackend, StatusColor, escape_html};
 
 /// Confluence render backend.
 ///
@@ -90,6 +90,45 @@ impl RenderBackend for ConfluenceBackend {
 
     fn task_list_marker(checked: bool, out: &mut String) {
         out.push_str(if checked { "[x] " } else { "[ ] " });
+    }
+
+    /// Translates the `<rw-status>` markers emitted by the status directive
+    /// into Confluence `status` structured macros; all other raw HTML passes
+    /// through unchanged.
+    ///
+    /// The open marker becomes the macro prefix plus an open `title`
+    /// parameter, the close marker closes that parameter and the macro — the
+    /// label text in between flows through the normal `text` path.
+    fn raw_html(html: &str, out: &mut String) {
+        if let Some(rest) = html.strip_prefix(r#"<rw-status data-color=""#) {
+            // `rest` is `COLOR">` — the color value up to its closing quote.
+            let color = rest
+                .split_once('"')
+                .map_or_else(StatusColor::default, |(name, _)| StatusColor::from(name));
+            // Confluence's `colour` parameter expects capitalized names.
+            let confluence_color = match color {
+                StatusColor::Grey => "Grey",
+                StatusColor::Red => "Red",
+                StatusColor::Yellow => "Yellow",
+                StatusColor::Green => "Green",
+                StatusColor::Blue => "Blue",
+                StatusColor::Purple => "Purple",
+            };
+            write!(
+                out,
+                concat!(
+                    r#"<ac:structured-macro ac:name="status" ac:schema-version="1">"#,
+                    r#"<ac:parameter ac:name="colour">{}</ac:parameter>"#,
+                    r#"<ac:parameter ac:name="title">"#,
+                ),
+                confluence_color
+            )
+            .unwrap();
+        } else if html == "</rw-status>" {
+            out.push_str("</ac:parameter></ac:structured-macro>");
+        } else {
+            out.push_str(html);
+        }
     }
 }
 
@@ -209,5 +248,44 @@ mod tests {
         ConfluenceBackend::alert_end(AlertKind::Caution, &mut out);
         // Caution also maps to "warning" macro in Confluence
         assert!(out.contains(r#"ac:name="warning""#));
+    }
+
+    #[test]
+    fn test_raw_html_status_open_emits_macro_prefix() {
+        let mut out = String::new();
+        ConfluenceBackend::raw_html(r#"<rw-status data-color="green">"#, &mut out);
+        assert!(out.contains(r#"ac:name="status""#), "got: {out}");
+        assert!(
+            out.contains(r#"<ac:parameter ac:name="colour">Green</ac:parameter>"#),
+            "got: {out}"
+        );
+        assert!(
+            out.ends_with(r#"<ac:parameter ac:name="title">"#),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_raw_html_status_close_emits_macro_suffix() {
+        let mut out = String::new();
+        ConfluenceBackend::raw_html("</rw-status>", &mut out);
+        assert_eq!(out, "</ac:parameter></ac:structured-macro>");
+    }
+
+    #[test]
+    fn test_raw_html_status_unknown_color_is_grey() {
+        let mut out = String::new();
+        ConfluenceBackend::raw_html(r#"<rw-status data-color="mauve">"#, &mut out);
+        assert!(
+            out.contains(r#"<ac:parameter ac:name="colour">Grey</ac:parameter>"#),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_raw_html_passes_through_unrelated_html() {
+        let mut out = String::new();
+        ConfluenceBackend::raw_html("<br />", &mut out);
+        assert_eq!(out, "<br />");
     }
 }

--- a/crates/rw-confluence/src/renderer.rs
+++ b/crates/rw-confluence/src/renderer.rs
@@ -21,7 +21,8 @@
 //! then call `render(markdown, kroki_url, diagram_dir)` to produce Confluence XHTML.
 
 use rw_kroki::{DiagramOutput, DiagramProcessor};
-use rw_renderer::{MarkdownRenderer, RenderResult, TocEntry};
+use rw_renderer::directive::DirectiveProcessor;
+use rw_renderer::{MarkdownRenderer, RenderResult, StatusDirective, TocEntry};
 use std::path::{Path, PathBuf};
 
 use crate::backend::ConfluenceBackend;
@@ -150,10 +151,56 @@ impl PageRenderer {
 
     /// Create a Confluence renderer with common configuration.
     fn create_renderer(&self) -> MarkdownRenderer<ConfluenceBackend> {
-        let mut renderer = MarkdownRenderer::<ConfluenceBackend>::new().with_gfm(self.gfm);
+        let directives = DirectiveProcessor::new().with_inline(StatusDirective::new());
+        let mut renderer = MarkdownRenderer::<ConfluenceBackend>::new()
+            .with_gfm(self.gfm)
+            .with_directives(directives);
         if self.extract_title {
             renderer = renderer.with_title_extraction();
         }
         renderer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_status_directive_renders_confluence_macro() {
+        let renderer = PageRenderer::new();
+        let result = renderer.render(":status[On Track]{color=green}", None, None);
+        assert!(
+            result.html.contains(r#"ac:name="status""#),
+            "got: {}",
+            result.html
+        );
+        assert!(
+            result
+                .html
+                .contains(r#"<ac:parameter ac:name="colour">Green</ac:parameter>"#),
+            "got: {}",
+            result.html
+        );
+        assert!(
+            result
+                .html
+                .contains(r#"<ac:parameter ac:name="title">On Track</ac:parameter>"#),
+            "got: {}",
+            result.html
+        );
+    }
+
+    #[test]
+    fn test_status_directive_unknown_color_is_grey() {
+        let renderer = PageRenderer::new();
+        let result = renderer.render(":status[X]{color=mauve}", None, None);
+        assert!(
+            result
+                .html
+                .contains(r#"<ac:parameter ac:name="colour">Grey</ac:parameter>"#),
+            "got: {}",
+            result.html
+        );
     }
 }

--- a/crates/rw-renderer/src/directive/inline.rs
+++ b/crates/rw-renderer/src/directive/inline.rs
@@ -2,12 +2,18 @@
 //!
 //! Inline directives use single-colon syntax: `:name[content]{attrs}`
 
-use super::{DirectiveArgs, DirectiveContext, DirectiveOutput};
+use super::{DirectiveArgs, DirectiveContext, DirectiveOutput, Replacements};
 
 /// Handler for inline directives: `:name[content]{attrs}`
 ///
 /// Inline directives appear within text flow and produce inline HTML elements.
 /// They are processed during the preprocessing phase before pulldown-cmark parsing.
+///
+/// # Two-Phase Processing
+///
+/// Inline directives support post-processing via [`post_process`](Self::post_process).
+/// During preprocessing, return intermediate HTML that will be transformed
+/// during post-processing.
 ///
 /// # Thread Safety
 ///
@@ -44,6 +50,15 @@ pub trait InlineDirective: Send {
     /// Note: [`DirectiveOutput::Markdown`] is supported but uncommon for inline
     /// directives since they typically produce simple HTML.
     fn process(&mut self, args: DirectiveArgs, ctx: &DirectiveContext) -> DirectiveOutput;
+
+    /// Register post-processing replacements for intermediate marker elements.
+    ///
+    /// Inline directives that emit neutral marker elements during
+    /// [`process`](Self::process) can override this to rewrite those markers
+    /// into final HTML after rendering, using the [`Replacements`] collector.
+    /// The default is a no-op — most inline directives emit final HTML
+    /// directly and need nothing here.
+    fn post_process(&mut self, _replacements: &mut Replacements) {}
 }
 
 #[cfg(test)]
@@ -87,5 +102,13 @@ mod tests {
     fn test_inline_directive_name() {
         let kbd = TestKbd;
         assert_eq!(kbd.name(), "kbd");
+    }
+
+    #[test]
+    fn test_default_post_process() {
+        let mut kbd = TestKbd;
+        let mut replacements = Replacements::new();
+        kbd.post_process(&mut replacements);
+        assert!(replacements.is_empty());
     }
 }

--- a/crates/rw-renderer/src/directive/processor.rs
+++ b/crates/rw-renderer/src/directive/processor.rs
@@ -386,10 +386,14 @@ impl DirectiveProcessor {
     ///
     /// Collects all replacements from handlers and applies them in a single pass.
     pub fn post_process(&mut self, html: &mut String) {
-        let capacity = self.leaf_handlers.len() + self.container_handlers.len();
+        let capacity =
+            self.inline_handlers.len() + self.leaf_handlers.len() + self.container_handlers.len();
         let mut replacements = Replacements::with_capacity(capacity);
 
         // Collect replacements from all handlers
+        for handler in &mut self.inline_handlers {
+            handler.post_process(&mut replacements);
+        }
         for handler in &mut self.leaf_handlers {
             handler.post_process(&mut replacements);
         }
@@ -481,6 +485,35 @@ mod tests {
 
         let output = processor.process("Press :kbd[Ctrl+C] to copy.");
         assert_eq!(output, "Press <kbd>Ctrl+C</kbd> to copy.");
+    }
+
+    #[test]
+    fn test_inline_directive_post_process_runs() {
+        struct MarkerDirective;
+
+        impl InlineDirective for MarkerDirective {
+            fn name(&self) -> &'static str {
+                "marker"
+            }
+
+            fn process(
+                &mut self,
+                _args: DirectiveArgs,
+                _ctx: &DirectiveContext,
+            ) -> DirectiveOutput {
+                DirectiveOutput::html("<rw-marker>")
+            }
+
+            fn post_process(&mut self, replacements: &mut Replacements) {
+                replacements.add("<rw-marker>", r#"<span class="marker">"#);
+            }
+        }
+
+        let mut processor = DirectiveProcessor::new().with_inline(MarkerDirective);
+        let mut html = processor.process(":marker[x]");
+        processor.post_process(&mut html);
+
+        assert_eq!(html, r#"<span class="marker">"#);
     }
 
     #[test]

--- a/crates/rw-renderer/src/lib.rs
+++ b/crates/rw-renderer/src/lib.rs
@@ -124,6 +124,7 @@ mod html;
 mod renderer;
 mod search_document;
 mod state;
+mod status;
 pub(crate) mod tabs;
 mod util;
 
@@ -144,4 +145,5 @@ pub use renderer::{MarkdownRenderer, RenderResult, TitleResolver};
 pub use rw_sections::Sections;
 pub use search_document::SearchDocumentBackend;
 pub use state::{TocEntry, escape_html};
+pub use status::{StatusColor, StatusDirective};
 pub use tabs::TabsDirective;

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -1521,6 +1521,26 @@ Install with apt.
     }
 
     #[test]
+    fn test_with_directives_status() {
+        use crate::StatusDirective;
+        use crate::directive::DirectiveProcessor;
+
+        let processor = DirectiveProcessor::new().with_inline(StatusDirective::new());
+        let mut renderer = MarkdownRenderer::<HtmlBackend>::new().with_directives(processor);
+
+        let result =
+            renderer.render_markdown("Billing is :status[On Track]{color=green} this quarter.");
+
+        assert!(
+            result
+                .html
+                .contains(r#"<span class="status status-green">On Track</span>"#),
+            "got: {}",
+            result.html
+        );
+    }
+
+    #[test]
     fn test_directives_warnings_included() {
         use crate::TabsDirective;
         use crate::directive::DirectiveProcessor;

--- a/crates/rw-renderer/src/status/directive.rs
+++ b/crates/rw-renderer/src/status/directive.rs
@@ -1,0 +1,236 @@
+//! Status badge inline directive.
+//!
+//! Implements the `:status[Label]{color=NAME}` inline directive — colored
+//! pill labels mirroring Confluence's `status` macro.
+
+use std::fmt;
+
+use crate::directive::{
+    DirectiveArgs, DirectiveContext, DirectiveOutput, InlineDirective, Replacements,
+};
+use crate::state::escape_html;
+
+/// One of the six Confluence-native status colors. [`Default`] is Grey;
+/// [`From<&str>`] parses a name case-insensitively and returns the default
+/// for unknown or empty input. [`Display`](fmt::Display) writes the lowercase
+/// name (used for the `data-color` attribute and CSS class suffix).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum StatusColor {
+    #[default]
+    Grey,
+    Red,
+    Yellow,
+    Green,
+    Blue,
+    Purple,
+}
+
+impl StatusColor {
+    /// All six colors, in palette order. Used to register post-processing
+    /// replacements for every possible `<rw-status>` marker.
+    const ALL: [StatusColor; 6] = [
+        StatusColor::Grey,
+        StatusColor::Red,
+        StatusColor::Yellow,
+        StatusColor::Green,
+        StatusColor::Blue,
+        StatusColor::Purple,
+    ];
+}
+
+impl From<&str> for StatusColor {
+    fn from(name: &str) -> Self {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "red" => Self::Red,
+            "yellow" => Self::Yellow,
+            "green" => Self::Green,
+            "blue" => Self::Blue,
+            "purple" => Self::Purple,
+            // "grey", "gray", unknown values, and the empty string -> default (Grey).
+            _ => Self::default(),
+        }
+    }
+}
+
+impl fmt::Display for StatusColor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Grey => "grey",
+            Self::Red => "red",
+            Self::Yellow => "yellow",
+            Self::Green => "green",
+            Self::Blue => "blue",
+            Self::Purple => "purple",
+        })
+    }
+}
+
+/// Inline directive for status badges: `:status[Label]{color=NAME}`.
+///
+/// `process` emits a neutral `<rw-status data-color="X">label</rw-status>`
+/// marker. `post_process` rewrites that marker to
+/// `<span class="status status-X">…</span>` for HTML output; the Confluence
+/// backend translates the same marker into a native `status` macro.
+///
+/// # Example
+///
+/// ```
+/// use rw_renderer::directive::DirectiveProcessor;
+/// use rw_renderer::StatusDirective;
+///
+/// let mut processor = DirectiveProcessor::new()
+///     .with_inline(StatusDirective::new());
+///
+/// let mut html = processor.process(":status[On Track]{color=green}");
+/// processor.post_process(&mut html);
+/// assert_eq!(html, r#"<span class="status status-green">On Track</span>"#);
+/// ```
+#[derive(Debug, Default)]
+pub struct StatusDirective;
+
+impl StatusDirective {
+    /// Create a new status directive handler.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl InlineDirective for StatusDirective {
+    fn name(&self) -> &'static str {
+        "status"
+    }
+
+    fn process(&mut self, args: DirectiveArgs, _ctx: &DirectiveContext) -> DirectiveOutput {
+        let color = StatusColor::from(args.get("color").unwrap_or_default());
+        // The label becomes element content and is re-parsed as markdown by
+        // pulldown-cmark, so escape it to neutralize any HTML metacharacters.
+        let label = escape_html(args.content().trim());
+        DirectiveOutput::html(format!(
+            r#"<rw-status data-color="{color}">{label}</rw-status>"#
+        ))
+    }
+
+    fn post_process(&mut self, replacements: &mut Replacements) {
+        // The open marker maps purely from its color, and the close marker is
+        // constant — register all six unconditionally; Replacements skips any
+        // pattern not present in the output.
+        for color in StatusColor::ALL {
+            replacements.add(
+                format!(r#"<rw-status data-color="{color}">"#),
+                format!(r#"<span class="status status-{color}">"#),
+            );
+        }
+        replacements.add("</rw-status>", "</span>");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::directive::DirectiveProcessor;
+
+    #[test]
+    fn test_from_known_colors() {
+        assert_eq!(StatusColor::from("grey"), StatusColor::Grey);
+        assert_eq!(StatusColor::from("red"), StatusColor::Red);
+        assert_eq!(StatusColor::from("yellow"), StatusColor::Yellow);
+        assert_eq!(StatusColor::from("green"), StatusColor::Green);
+        assert_eq!(StatusColor::from("blue"), StatusColor::Blue);
+        assert_eq!(StatusColor::from("purple"), StatusColor::Purple);
+    }
+
+    #[test]
+    fn test_from_is_case_insensitive_and_trims() {
+        assert_eq!(StatusColor::from("GREEN"), StatusColor::Green);
+        assert_eq!(StatusColor::from("  Green  "), StatusColor::Green);
+    }
+
+    #[test]
+    fn test_from_unknown_falls_back_to_grey() {
+        assert_eq!(StatusColor::from("mauve"), StatusColor::Grey);
+        assert_eq!(StatusColor::from(""), StatusColor::Grey);
+    }
+
+    #[test]
+    fn test_default_is_grey() {
+        assert_eq!(StatusColor::default(), StatusColor::Grey);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(StatusColor::Grey.to_string(), "grey");
+        assert_eq!(StatusColor::Red.to_string(), "red");
+        assert_eq!(StatusColor::Yellow.to_string(), "yellow");
+        assert_eq!(StatusColor::Green.to_string(), "green");
+        assert_eq!(StatusColor::Blue.to_string(), "blue");
+        assert_eq!(StatusColor::Purple.to_string(), "purple");
+    }
+
+    fn render(input: &str) -> String {
+        let mut processor = DirectiveProcessor::new().with_inline(StatusDirective::new());
+        let mut html = processor.process(input);
+        processor.post_process(&mut html);
+        html
+    }
+
+    #[test]
+    fn test_status_renders_span() {
+        assert_eq!(
+            render(":status[On Track]{color=green}"),
+            r#"<span class="status status-green">On Track</span>"#
+        );
+    }
+
+    #[test]
+    fn test_status_color_defaults_to_grey() {
+        assert_eq!(
+            render(":status[Declined]"),
+            r#"<span class="status status-grey">Declined</span>"#
+        );
+    }
+
+    #[test]
+    fn test_status_unknown_color_falls_back_to_grey() {
+        assert_eq!(
+            render(":status[X]{color=mauve}"),
+            r#"<span class="status status-grey">X</span>"#
+        );
+    }
+
+    #[test]
+    fn test_status_escapes_label() {
+        let html = render(":status[<script>]{color=red}");
+        assert!(html.contains("&lt;script&gt;"), "got: {html}");
+        assert!(!html.contains("<script>"), "got: {html}");
+    }
+
+    #[test]
+    fn test_status_trims_label() {
+        assert_eq!(
+            render(":status[  Spaced  ]{color=blue}"),
+            r#"<span class="status status-blue">Spaced</span>"#
+        );
+    }
+
+    #[test]
+    fn test_status_empty_label() {
+        assert_eq!(
+            render(":status[]{color=blue}"),
+            r#"<span class="status status-blue"></span>"#
+        );
+    }
+
+    #[test]
+    fn test_multiple_status_badges_on_one_line() {
+        let html = render(":status[A]{color=red} and :status[B]{color=blue}");
+        assert!(
+            html.contains(r#"<span class="status status-red">A</span>"#),
+            "got: {html}"
+        );
+        assert!(
+            html.contains(r#"<span class="status status-blue">B</span>"#),
+            "got: {html}"
+        );
+    }
+}

--- a/crates/rw-renderer/src/status/mod.rs
+++ b/crates/rw-renderer/src/status/mod.rs
@@ -1,0 +1,8 @@
+//! Status badge inline directive (`:status[Label]{color=NAME}`).
+//!
+//! [`StatusColor`] is the six-value color palette; `StatusDirective` (in the
+//! `directive` submodule) is the directive handler.
+
+mod directive;
+
+pub use directive::{StatusColor, StatusDirective};

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -12,8 +12,8 @@ use rw_cache::{Cache, CacheBucket, CacheBucketExt};
 use rw_kroki::{DiagramProcessor, MetaIncludeSource, SearchDiagramProcessor};
 use rw_renderer::directive::DirectiveProcessor;
 use rw_renderer::{
-    HtmlBackend, MarkdownRenderer, RenderBackend, SearchDocumentBackend, TabsDirective, TocEntry,
-    escape_html,
+    HtmlBackend, MarkdownRenderer, RenderBackend, SearchDocumentBackend, StatusDirective,
+    TabsDirective, TocEntry, escape_html,
 };
 use rw_sections::{Section, Sections};
 
@@ -428,7 +428,9 @@ impl PageRenderer {
         renderer: MarkdownRenderer<B>,
         ctx: &RenderContext,
     ) -> MarkdownRenderer<B> {
-        let directives = DirectiveProcessor::new().with_container(TabsDirective::new());
+        let directives = DirectiveProcessor::new()
+            .with_container(TabsDirective::new())
+            .with_inline(StatusDirective::new());
 
         let mut renderer = renderer
             .with_gfm(true)

--- a/docs/status-badges.md
+++ b/docs/status-badges.md
@@ -1,0 +1,36 @@
+# Status Badges
+
+Status badges are inline colored pill labels — like `On Track` or `Blocked` —
+for summarizing the state of something inline with prose. They mirror
+Confluence's `status` macro, so pages published with `rw confluence update`
+render as native, editable Confluence status badges.
+
+## Syntax
+
+```markdown
+Billing is :status[On Track]{color=green}, search is :status[Behind]{color=yellow},
+and the audit rewrite was :status[Declined]{color=grey}.
+```
+
+- `:status[Label]` — the bracketed text is the badge label.
+- `{color=NAME}` — sets the badge color. Optional; defaults to `grey`.
+
+## Colors
+
+| Name     | Typical use            |
+|----------|------------------------|
+| `grey`   | Neutral, default       |
+| `red`    | Blocked, failing       |
+| `yellow` | At risk, in progress   |
+| `green`  | On track, done         |
+| `blue`   | Informational          |
+| `purple` | Special status         |
+
+Color names are case-insensitive. An unknown or omitted color falls back to
+`grey` — no error.
+
+## Confluence publishing
+
+When published to Confluence, each badge becomes a native `status` structured
+macro, so it stays editable in the Confluence editor and matches the
+surrounding page style.

--- a/packages/viewer/src/styles/content.css
+++ b/packages/viewer/src/styles/content.css
@@ -123,6 +123,39 @@
     @apply text-danger-fg;
   }
 
+  /* Status badges — inline colored pill labels (`:status[Label]{color=NAME}`).
+     Mode-independent: a saturated pill carries its own context and renders
+     identically in light and dark mode, matching Confluence's status badges.
+     Backgrounds are dark enough that the bold white label clears WCAG AA;
+     the yellow variant is a deep amber for that reason. */
+  .prose .status {
+    @apply inline-block whitespace-nowrap rounded px-1.5 py-0.5 align-middle text-xs font-bold text-white;
+  }
+
+  .prose .status-grey {
+    @apply bg-gray-600;
+  }
+
+  .prose .status-red {
+    @apply bg-red-700;
+  }
+
+  .prose .status-yellow {
+    @apply bg-amber-700;
+  }
+
+  .prose .status-green {
+    @apply bg-green-700;
+  }
+
+  .prose .status-blue {
+    @apply bg-blue-700;
+  }
+
+  .prose .status-purple {
+    @apply bg-purple-700;
+  }
+
   /* Tabs styling */
   .prose .tabs {
     @apply my-6;


### PR DESCRIPTION
Add a `:status[Label]{color=NAME}` inline directive that mirrors
Confluence's `status` macro: renders a colored pill in the HTML viewer
and publishes as a native Confluence `status` structured macro via
`rw confluence update`.

- Six colors (grey, red, yellow, green, blue, purple); case-insensitive,
  unknown or omitted falls back to grey.
- `<rw-status data-color="X">label</rw-status>` is the wire format
  between the directive and both backends. A custom tag (not a bare
  `<span>`) lets the stateless ConfluenceBackend unambiguously recognize
  the close marker.
- HTML path: the directive's `post_process` rewrites `<rw-status>` to
  `<span class="status status-X">`.
- Confluence path: `ConfluenceBackend::raw_html` translates the marker
  into the native `status` structured macro.
- `InlineDirective` gains a default-no-op `post_process` method,
  completing the directive-trait family alongside `LeafDirective` and
  `ContainerDirective`.
- `StatusColor` uses standard traits: `From<&str>` (case-insensitive,
  unknown -> Default), `Display` (lowercase name), `Default` (Grey).
  Confluence's capitalized name forms live in `rw-confluence`, not in
  the generic renderer.
- Six pill-color CSS variants in the viewer (Tailwind, WCAG-AA contrast,
  mode-independent — a saturated pill carries its own context).
- Doc page at `docs/status-badges.md`; README feature bullet and link;
  changelog entry under Unreleased.
- Project rule added to `.claude/rules/rust.md`: prefer standard traits
  over custom mirror-named methods (surfaced during PR review).

Closes #288.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
