### PR TITLE
refactor(renderer): separate leaf directive dispatch from inline (#410)

### DIFF
--- a/crates/rw-renderer/src/directive/leaf.rs
+++ b/crates/rw-renderer/src/directive/leaf.rs
@@ -6,7 +6,11 @@ use super::{DirectiveArgs, DirectiveContext, DirectiveOutput, Replacements};
 
 /// Handler for leaf directives: `::name[content]{attrs}`
 ///
-/// Leaf directives are self-contained blocks (like void HTML elements).
+/// Leaf directives are block-level. The handler is invoked only when
+/// `::name[…]{…}` occupies an entire line (leading/trailing whitespace
+/// permitted). A `::name` token inside a paragraph or list item is treated as
+/// literal text and passed through to the markdown parser.
+///
 /// They can return markdown (for `::include`) or HTML (for `::youtube`).
 ///
 /// # Two-Phase Processing

--- a/crates/rw-renderer/src/directive/parser.rs
+++ b/crates/rw-renderer/src/directive/parser.rs
@@ -21,31 +21,29 @@ pub(crate) enum ParsedDirective {
     ContainerEnd { colon_count: usize },
 }
 
-/// Parse a line for directive syntax.
+/// Parse a line for an inline directive (`:name`).
 ///
-/// Returns `None` if the line doesn't contain a directive.
+/// Skips over multi-colon runs (`::`, `:::`, …) so that an inline directive
+/// can still be found after a leaf-like or container-like token on the same
+/// line. Returns `None` only when no single-colon inline directive remains
+/// in the input.
 pub(crate) fn parse_line(line: &str) -> Option<(ParsedDirective, usize, usize)> {
-    // Find first colon that might start a directive
-    let start = line.find(':')?;
-
-    // Count colons
-    let colon_count = line[start..].chars().take_while(|&c| c == ':').count();
-
-    if colon_count < 1 {
-        return None;
-    }
+    // Walk colon runs from left to right, skipping any run of two or more
+    // colons (those are leaf / container tokens, not inline). Stop at the
+    // first single-colon run that starts a valid inline directive.
+    let mut search_from = 0;
+    let (start, colon_count) = loop {
+        let rel = line[search_from..].find(':')?;
+        let abs = search_from + rel;
+        let count = line[abs..].chars().take_while(|&c| c == ':').count();
+        if count == 1 {
+            break (abs, count);
+        }
+        search_from = abs + count;
+    };
 
     let mut pos = start + colon_count;
     let after_colons = &line[pos..];
-
-    // Container end: just colons (with optional whitespace after)
-    if colon_count >= 3 && after_colons.trim().is_empty() {
-        return Some((
-            ParsedDirective::ContainerEnd { colon_count },
-            start,
-            line.len(),
-        ));
-    }
 
     // Parse name - name ends at [, {, or whitespace
     let name_end = after_colons
@@ -69,23 +67,59 @@ pub(crate) fn parse_line(line: &str) -> Option<(ParsedDirective, usize, usize)> 
 
     let args = DirectiveArgs::parse(&content, &attrs_str);
 
-    let directive = match colon_count {
-        1 => ParsedDirective::Inline {
+    Some((
+        ParsedDirective::Inline {
             name: name.to_owned(),
             args,
         },
-        2 => ParsedDirective::Leaf {
-            name: name.to_owned(),
-            args,
-        },
-        _ => ParsedDirective::ContainerStart {
-            name: name.to_owned(),
-            args,
-            colon_count,
-        },
-    };
+        start,
+        pos,
+    ))
+}
 
-    Some((directive, start, pos))
+/// Parse a whole line for a leaf directive.
+///
+/// Used for leaf-style directives that take the entire line.
+/// Returns `None` if the line is not a leaf directive (e.g., `:::name` is a container).
+pub(crate) fn parse_leaf_line(line: &str) -> Option<ParsedDirective> {
+    let trimmed = line.trim();
+
+    // Must start with exactly two colons; three or more is a container
+    if !trimmed.starts_with("::") || trimmed.starts_with(":::") {
+        return None;
+    }
+
+    let after_colons = &trimmed[2..];
+
+    // Parse name
+    let name_end = after_colons
+        .find(|c: char| c == '[' || c == '{' || c.is_whitespace())
+        .unwrap_or(after_colons.len());
+
+    let name = &after_colons[..name_end];
+    if name.is_empty() || !is_valid_directive_name(name) {
+        return None;
+    }
+
+    let after_name = &after_colons[name_end..];
+
+    // Parse content and attributes
+    let (content, content_consumed) = parse_brackets(after_name);
+    let after_content = &after_name[content_consumed..];
+    let (attrs_str, attrs_consumed) = parse_braces(after_content);
+    let after_attrs = &after_content[attrs_consumed..];
+
+    // The rest of the (trimmed) line must be empty — leaf consumes the whole line
+    if !after_attrs.trim().is_empty() {
+        return None;
+    }
+
+    let args = DirectiveArgs::parse(&content, &attrs_str);
+
+    Some(ParsedDirective::Leaf {
+        name: name.to_owned(),
+        args,
+    })
 }
 
 /// Check if a name is a valid directive name.
@@ -249,33 +283,38 @@ mod tests {
     }
 
     #[test]
-    fn test_leaf_directive() {
-        let result = parse_line("::youtube[dQw4w9WgXcQ]");
-        let (directive, _, _) = result.unwrap();
-
-        match directive {
-            ParsedDirective::Leaf { name, args } => {
-                assert_eq!(name, "youtube");
-                assert_eq!(args.content, "dQw4w9WgXcQ");
-            }
-            _ => panic!("expected leaf directive"),
-        }
+    fn test_leaf_directive_no_longer_inline() {
+        // parse_line now returns None for :: (leaf) sequences
+        assert!(parse_line("::youtube[dQw4w9WgXcQ]").is_none());
     }
 
     #[test]
-    fn test_leaf_with_attrs() {
-        let result = parse_line("::include[snippet.md]{#code .highlight}");
-        let (directive, _, _) = result.unwrap();
+    fn test_leaf_with_attrs_no_longer_inline() {
+        // parse_line now returns None for :: (leaf) sequences
+        assert!(parse_line("::include[snippet.md]{#code .highlight}").is_none());
+    }
 
+    #[test]
+    fn test_double_colon_mid_line_no_longer_inline() {
+        // parse_line must return None when the only colon run is >=2
+        assert!(parse_line("text ::foo[x] more").is_none());
+    }
+
+    #[test]
+    fn test_inline_directive_after_double_colon_run() {
+        // A `::leaf` token at the start of the line must not blind the scanner
+        // to a single-colon inline directive that follows on the same line.
+        let result = parse_line("::foo[x] :kbd[Y]");
+        let (directive, start, end) = result.expect("should find :kbd after the :: run");
         match directive {
-            ParsedDirective::Leaf { name, args } => {
-                assert_eq!(name, "include");
-                assert_eq!(args.content, "snippet.md");
-                assert_eq!(args.id, Some("code".to_owned()));
-                assert_eq!(args.classes, vec!["highlight"]);
+            ParsedDirective::Inline { name, args } => {
+                assert_eq!(name, "kbd");
+                assert_eq!(args.content, "Y");
             }
-            _ => panic!("expected leaf directive"),
+            _ => panic!("expected inline directive"),
         }
+        assert_eq!(start, 9);
+        assert_eq!(end, 16);
     }
 
     #[test]
@@ -395,6 +434,76 @@ mod tests {
         assert!(!is_valid_directive_name(""));
         assert!(!is_valid_directive_name("foo@bar"));
         assert!(!is_valid_directive_name("foo bar"));
+    }
+
+    mod parse_leaf_line_tests {
+        use super::*;
+
+        #[test]
+        fn bare_leaf() {
+            let result = parse_leaf_line("::youtube[dQw4w9WgXcQ]");
+            match result.unwrap() {
+                ParsedDirective::Leaf { name, args } => {
+                    assert_eq!(name, "youtube");
+                    assert_eq!(args.content, "dQw4w9WgXcQ");
+                }
+                _ => panic!("expected leaf directive"),
+            }
+        }
+
+        #[test]
+        fn leaf_with_attrs() {
+            let result = parse_leaf_line("::include[snippet.md]{#code .highlight}");
+            match result.unwrap() {
+                ParsedDirective::Leaf { name, args } => {
+                    assert_eq!(name, "include");
+                    assert_eq!(args.content, "snippet.md");
+                    assert_eq!(args.id, Some("code".to_owned()));
+                    assert_eq!(args.classes, vec!["highlight"]);
+                }
+                _ => panic!("expected leaf directive"),
+            }
+        }
+
+        #[test]
+        fn leading_whitespace_tolerated() {
+            let result = parse_leaf_line("  ::youtube[x]");
+            assert!(result.is_some(), "leading whitespace should be accepted");
+            match result.unwrap() {
+                ParsedDirective::Leaf { name, .. } => assert_eq!(name, "youtube"),
+                _ => panic!("expected leaf directive"),
+            }
+        }
+
+        #[test]
+        fn trailing_whitespace_tolerated() {
+            let result = parse_leaf_line("::youtube[x]   ");
+            assert!(result.is_some(), "trailing whitespace should be accepted");
+        }
+
+        #[test]
+        fn trailing_non_whitespace_rejected() {
+            // "::foo[x] bar" — extra text after the directive → None
+            assert!(parse_leaf_line("::foo[x] bar").is_none());
+        }
+
+        #[test]
+        fn three_colons_rejected() {
+            // ":::note" is a container, not a leaf
+            assert!(parse_leaf_line(":::note").is_none());
+        }
+
+        #[test]
+        fn one_colon_rejected() {
+            // ":kbd[X]" is inline, not a leaf
+            assert!(parse_leaf_line(":kbd[X]").is_none());
+        }
+
+        #[test]
+        fn not_at_start_rejected() {
+            // "text ::foo[x]" — leaf must occupy the whole line
+            assert!(parse_leaf_line("text ::foo[x]").is_none());
+        }
     }
 
     #[test]

--- a/crates/rw-renderer/src/directive/processor.rs
+++ b/crates/rw-renderer/src/directive/processor.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use crate::tabs::FenceTracker;
 
-use super::parser::{ParsedDirective, parse_container_line, parse_line};
+use super::parser::{ParsedDirective, parse_container_line, parse_leaf_line, parse_line};
 use super::{
     ContainerDirective, DirectiveContext, DirectiveOutput, InlineDirective, LeafDirective,
     Replacements,
@@ -235,12 +235,17 @@ impl DirectiveProcessor {
             return line.to_owned();
         }
 
-        // Try container directive first (takes whole line)
+        // 1. Container directive — takes the whole line (:::name)
         if let Some(directive) = parse_container_line(line) {
             return self.dispatch_container(directive, line_num, depth);
         }
 
-        // Try inline/leaf directives (can be within a line)
+        // 2. Leaf directive — takes the whole line (::name)
+        if let Some(directive) = parse_leaf_line(line) {
+            return self.dispatch_leaf(directive, line_num, depth);
+        }
+
+        // 3. Inline directives — can appear anywhere in the line (:name)
         self.process_inline_directives(line, line_num, depth)
     }
 
@@ -254,7 +259,7 @@ impl DirectiveProcessor {
                 result.push_str(&remaining[..start]);
 
                 // Process the directive
-                let output = self.dispatch_inline_or_leaf(directive, line_num);
+                let output = self.dispatch_inline(directive, line_num);
 
                 match output {
                     DirectiveOutput::Html(html) => result.push_str(&html),
@@ -344,11 +349,35 @@ impl DirectiveProcessor {
         }
     }
 
-    fn dispatch_inline_or_leaf(
+    fn dispatch_leaf(
         &mut self,
         directive: ParsedDirective,
         line_num: usize,
-    ) -> DirectiveOutput {
+        depth: usize,
+    ) -> String {
+        match directive {
+            ParsedDirective::Leaf { name, args } => {
+                let handler_idx = self.leaf_handlers.iter().position(|h| h.name() == name);
+
+                if let Some(idx) = handler_idx {
+                    let syntax = args.to_syntax();
+                    let ctx = self.config.create_context(line_num);
+                    let output = self.leaf_handlers[idx].process(args, &ctx);
+                    match output {
+                        DirectiveOutput::Html(html) => html,
+                        DirectiveOutput::Markdown(md) => self.process_with_depth(&md, depth + 1),
+                        DirectiveOutput::Skip => format!("::{name}{syntax}"),
+                    }
+                } else {
+                    // No handler — pass through verbatim
+                    format!("::{name}{}", args.to_syntax())
+                }
+            }
+            _ => unreachable!("dispatch_leaf only handles leaf directives"),
+        }
+    }
+
+    fn dispatch_inline(&mut self, directive: ParsedDirective, line_num: usize) -> DirectiveOutput {
         match directive {
             ParsedDirective::Inline { name, args } => {
                 let handler_idx = self.inline_handlers.iter().position(|h| h.name() == name);
@@ -356,16 +385,6 @@ impl DirectiveProcessor {
                 if let Some(idx) = handler_idx {
                     let ctx = self.config.create_context(line_num);
                     self.inline_handlers[idx].process(args, &ctx)
-                } else {
-                    DirectiveOutput::Skip
-                }
-            }
-            ParsedDirective::Leaf { name, args } => {
-                let handler_idx = self.leaf_handlers.iter().position(|h| h.name() == name);
-
-                if let Some(idx) = handler_idx {
-                    let ctx = self.config.create_context(line_num);
-                    self.leaf_handlers[idx].process(args, &ctx)
                 } else {
                     DirectiveOutput::Skip
                 }
@@ -681,5 +700,74 @@ mod tests {
         let warnings = processor.warnings();
 
         assert!(warnings.iter().any(|w| w.contains("Maximum include depth")));
+    }
+
+    #[test]
+    fn leaf_in_paragraph_is_not_expanded() {
+        // A leaf directive token inside a paragraph must NOT be expanded
+        let mut processor = DirectiveProcessor::new().with_leaf(TestYoutube);
+
+        let input = "Press ::youtube[x] now.";
+        let output = processor.process(input);
+
+        // The line is not a standalone leaf directive, so it passes through verbatim
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn leaf_with_leading_whitespace_is_expanded() {
+        // A leaf directive with leading whitespace on an otherwise-empty line IS expanded
+        let mut processor = DirectiveProcessor::new().with_leaf(TestYoutube);
+
+        let output = processor.process("  ::youtube[dQw4w9WgXcQ]");
+        assert!(
+            output.contains("dQw4w9WgXcQ"),
+            "leaf directive with leading whitespace should be expanded"
+        );
+        assert!(
+            output.contains("<iframe"),
+            "leaf directive output should contain iframe"
+        );
+    }
+
+    #[test]
+    fn container_takes_precedence_over_leaf() {
+        // A :::note line routes to the container handler, not the leaf path
+        let mut processor = DirectiveProcessor::new().with_container(TestNote);
+
+        let output = processor.process(":::note[Important]\nContent here\n:::");
+        assert!(
+            output.contains(r#"<div class="note""#),
+            "container handler must fire, not leaf"
+        );
+        assert!(output.contains("Content here"));
+        assert!(output.contains("</div>"));
+    }
+
+    #[test]
+    fn unknown_leaf_passes_through_verbatim() {
+        // An unregistered leaf on a full line is passed through with attrs preserved
+        let mut processor = DirectiveProcessor::new();
+
+        let output = processor.process("::unknown[content]{#id .cls}");
+        assert!(output.contains("::unknown"), "name must be preserved");
+        assert!(output.contains("[content]"), "content must be preserved");
+        assert!(output.contains("#id"), "id attr must be preserved");
+        assert!(output.contains(".cls"), "class attr must be preserved");
+    }
+
+    #[test]
+    fn inline_directive_after_leaf_token_in_paragraph_still_expands() {
+        // Regression guard: a `::leaf` token mid-line must not stop the scanner
+        // from finding a later `:inline` directive on the same line.
+        let mut processor = DirectiveProcessor::new().with_inline(TestKbd);
+
+        let output = processor.process("Press ::foo[x] then :kbd[Ctrl+C].");
+        assert!(
+            output.contains("<kbd>Ctrl+C</kbd>"),
+            "inline directive after a `::` token should still expand. got: {output}"
+        );
+        // The mid-line `::foo[x]` is literal text — no leaf expansion mid-paragraph
+        assert!(output.contains("::foo[x]"));
     }
 }


### PR DESCRIPTION
## Summary

- Leaf directives (`::name[…]`) are now block-level — a handler only fires when the directive occupies an entire line (whitespace permitted on either side). A `::name` token mid-paragraph is treated as literal text instead of silently expanding.
- Splits the dispatch paths for inline (`:name`) and leaf (`::name`) directives, which previously shared `parse_line` and `dispatch_inline_or_leaf`. The shared path made it impossible to reason about inline vs. leaf rules independently and blocked the planned fix for #396.
- Pure internal refactor — no production code registers a \`LeafDirective\` handler today, so no migration is needed.

Closes #410.

## What changed

- **parser.rs**: adds `parse_leaf_line()` modeled on `parse_container_line`; restricts `parse_line` to single-colon inline directives. `parse_line` walks colon runs left-to-right and skips any multi-colon run, so a `::` token mid-line does not mask a later `:inline` on the same line.
- **processor.rs**: `process_line` is now a three-way ladder (container → leaf → inline). `dispatch_inline_or_leaf` is split into `dispatch_leaf` (block-level, returns `String`, verbatim passthrough via `args.to_syntax()` for unknown or `Skip`) and `dispatch_inline` (returns `DirectiveOutput`, falls back to `Skip` on any unexpected variant so parser drift produces literal text instead of a panic).
- **leaf.rs**: tightens the `LeafDirective` trait doc with the block-level constraint and the literal-text fallback for mid-paragraph occurrences.

## Test plan

- [x] `cargo test -p rw-renderer` — 264 unit + 28 doc tests pass
- [x] `cargo clippy -p rw-renderer --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Try a markdown page with `Press ::foo[x] then :kbd[Ctrl+C].` and confirm the inline `:kbd` still expands (regression guard for the colon-run scanner)
- [ ] Try `  ::youtube[id]` (indented full-line leaf) and confirm it expands
- [ ] Try `::unknown[content]{#id .cls}` with no handler and confirm passthrough preserves attrs

🤖 Generated with [Claude Code](https://claude.com/claude-code)