### PR TITLE
fix(renderer): advance by char when skipping unrecognized directive attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documentation pages whose URL begins with `/api/` (e.g. `docs/api/usage.md`) no longer return 404 when opened directly or refreshed in the browser.
 - Long URLs and other unbreakable tokens (UUIDs, hash digests, file paths) in tables, paragraphs, and list items now wrap instead of forcing horizontal scrolling on narrow viewports — table cells break anywhere, body text only breaks tokens that would otherwise overflow.
+- Directives with non-ASCII characters in their attribute braces (e.g. `:foo[bar]{цвет}`, `{🎉}`, `{اختبار}`) no longer panic the renderer — `rw serve` previously returned 500 and `rw confluence update` / `rw backstage publish` aborted mid-run on these inputs. Valid uses such as `{.заголовок}`, `{#заголовок}`, and `{цвет=зелёный}` were already safe and remain unchanged.
 
 ## [0.1.24] - 2026-04-10
 

--- a/crates/rw-renderer/src/directive/args.rs
+++ b/crates/rw-renderer/src/directive/args.rs
@@ -75,8 +75,11 @@ impl DirectiveArgs {
                 args.attrs.insert(key.to_owned(), value.to_owned());
                 remaining = rest;
             } else {
-                // Skip unrecognized character
-                remaining = &remaining[1..];
+                // Advance one codepoint — byte indexing would split a
+                // multi-byte UTF-8 char (e.g. `ц`, `🎉`) and panic.
+                let mut chars = remaining.chars();
+                chars.next();
+                remaining = chars.as_str();
             }
         }
 
@@ -347,5 +350,25 @@ mod tests {
     fn test_to_syntax_attrs_only() {
         let args = DirectiveArgs::parse("", "#my-id");
         assert_eq!(args.to_syntax(), "{#my-id}");
+    }
+
+    #[test]
+    fn test_non_ascii_bareword_does_not_panic() {
+        // Each input covers a different UTF-8 codepoint width (2, 4, 2 bytes)
+        // through the unrecognized-character fallback.
+        for input in ["цвет", "🎉", "اختبار"] {
+            let args = DirectiveArgs::parse("", input);
+            assert_eq!(args.id, None);
+            assert!(args.classes.is_empty());
+            assert!(args.attrs.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_non_ascii_bareword_then_valid_token() {
+        // The fallback must hand control back to the loop so a recognized
+        // token after the bareword still parses.
+        let args = DirectiveArgs::parse("", "цвет #id");
+        assert_eq!(args.id, Some("id".to_owned()));
     }
 }


### PR DESCRIPTION
## Summary

`DirectiveArgs::parse` walked the attributes string with `remaining = &remaining[1..]` as the fallback for unrecognized input. On a multi-byte UTF-8 codepoint (Cyrillic, emoji, Arabic, ...) that slice lands inside the codepoint and panics with `byte index 1 is not a char boundary`, taking down the request in `rw serve` and aborting `rw confluence update` / `rw backstage publish`.

Switch to `chars.next()` + `chars.as_str()` so the fallback advances by one full codepoint regardless of width — no allocation, no panic.

Fixes #400.

## Test plan

- [x] `cargo test -p rw-renderer` — 24 passing args tests including the new UTF-8 coverage
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rw-renderer --all-targets -- -D warnings`
- [ ] Manual: render a doc page with `:foo{цвет}` under `rw serve` and confirm no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)