### PR TITLE
fix(site): keep fast path after failed background reload (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation pages whose URL begins with `/api/` (e.g. `docs/api/usage.md`) no longer return 404 when opened directly or refreshed in the browser.
 - Long URLs and other unbreakable tokens (UUIDs, hash digests, file paths) in tables, paragraphs, and list items now wrap instead of forcing horizontal scrolling on narrow viewports — table cells break anywhere, body text only breaks tokens that would otherwise overflow.
 - Directives with non-ASCII characters in their attribute braces (e.g. `:foo[bar]{цвет}`, `{🎉}`, `{اختبار}`) no longer panic the renderer — `rw serve` previously returned 500 and `rw confluence update` / `rw backstage publish` aborted mid-run on these inputs. Valid uses such as `{.заголовок}`, `{#заголовок}`, and `{цвет=зелёный}` were already safe and remain unchanged.
+- S3 (and other remote storage) outages no longer turn into "soft outages" where every read serializes on a mutex and re-calls the unreachable backend. When a background reload fails, `rw serve` now keeps serving the stale snapshot via the fast path and only retries on the next explicit signal (file-watcher event, `reload(true)`, or successful `has_changed()` poll).
 
 ## [0.1.24] - 2026-04-10
 

--- a/crates/rw-site/src/site.rs
+++ b/crates/rw-site/src/site.rs
@@ -287,7 +287,12 @@ impl Site {
     ///
     /// On the **initial** load, storage errors propagate to the caller so
     /// that misconfigured storage is surfaced immediately. On subsequent
-    /// reloads, errors are logged and the previous snapshot is kept.
+    /// reloads, errors are logged and the previous snapshot is kept. The
+    /// cache flag is normally restored so later reads serve that snapshot
+    /// via the fast path instead of repeatedly retrying an unreachable
+    /// backend — unless an [`invalidate`](Self::invalidate) raced with
+    /// the failing scan, in which case the next reader retries instead of
+    /// swallowing that signal.
     ///
     /// # Errors
     ///
@@ -311,7 +316,8 @@ impl Site {
         }
 
         let has_loaded = self.has_loaded.load(Ordering::Acquire);
-        let etag = self.generation.load(Ordering::Acquire).to_string();
+        let pre_scan_generation = self.generation.load(Ordering::Acquire);
+        let etag = pre_scan_generation.to_string();
 
         // Load state: skip bucket cache on initial load to verify storage connectivity
         let state = if has_loaded {
@@ -325,6 +331,19 @@ impl Site {
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "Failed to reload site from storage, keeping stale data");
+                        // Restore the fast path so subsequent reads return the
+                        // stale snapshot immediately. Without this, every read
+                        // would re-enter the slow path, serialize on the reload
+                        // mutex, and re-call the unreachable backend.
+                        //
+                        // Only restore it if no `invalidate()` raced with us
+                        // during the (potentially long) failing scan. If the
+                        // generation changed, an invalidate is pending and the
+                        // next reader must retry — otherwise we'd swallow that
+                        // signal and serve stale data even after recovery.
+                        if self.generation.load(Ordering::Acquire) == pre_scan_generation {
+                            self.cache_valid.store(true, Ordering::Release);
+                        }
                         return Ok(self.snapshot());
                     }
                 }
@@ -377,8 +396,14 @@ impl Site {
     /// Readers that already hold a snapshot are unaffected — they continue
     /// using the previous data. This method is lock-free.
     pub fn invalidate(&self) {
-        self.cache_valid.store(false, Ordering::Release);
+        // Bump generation BEFORE clearing the cache flag. The failure branch
+        // of `reload_if_needed` uses the generation as a "was an invalidate
+        // pending?" probe; if we cleared cache_valid first, a concurrent
+        // failing reload could observe the unchanged generation and restore
+        // cache_valid=true before our `fetch_add` lands, swallowing the
+        // invalidate signal.
         self.generation.fetch_add(1, Ordering::Release);
+        self.cache_valid.store(false, Ordering::Release);
     }
 
     /// Renders a page to HTML by its URL path.
@@ -1184,6 +1209,75 @@ mod tests {
         // Reload should succeed with stale data
         let snapshot2 = site.reload_if_needed().unwrap();
         assert!(snapshot2.state.get_page("guide").is_some());
+    }
+
+    #[test]
+    fn test_reload_after_failure_does_not_repeat_storage_scan() {
+        // Regression test for #403: after a failed reload, subsequent reads
+        // must take the fast path and return stale data, NOT re-enter the
+        // slow path and re-call storage. Without the fix, every read during
+        // a backend outage would serialize on the reload mutex and hit the
+        // unreachable backend.
+        let storage = Arc::new(MockStorage::new().with_document("guide", "Guide"));
+        let site = Site::new(
+            Arc::clone(&storage) as Arc<dyn rw_storage::Storage>,
+            Arc::new(rw_cache::NullCache),
+            PageRendererConfig::default(),
+        );
+
+        // Initial load: one scan, succeeds
+        site.reload_if_needed().unwrap();
+        assert_eq!(storage.scan_count(), 1);
+
+        // Backend goes down; explicit invalidate signals "please reload"
+        storage.set_scan_error(Some(StorageErrorKind::Unavailable));
+        site.invalidate();
+
+        // First read after invalidate retries storage and falls back to stale data
+        let snapshot = site.reload_if_needed().unwrap();
+        assert!(snapshot.state.get_page("guide").is_some());
+        assert_eq!(storage.scan_count(), 2);
+
+        // Subsequent reads must NOT re-scan storage — they ride the fast path
+        for _ in 0..5 {
+            let snapshot = site.reload_if_needed().unwrap();
+            assert!(snapshot.state.get_page("guide").is_some());
+        }
+        assert_eq!(storage.scan_count(), 2);
+
+        // After explicit invalidate, the next read retries storage again
+        site.invalidate();
+        site.reload_if_needed().unwrap();
+        assert_eq!(storage.scan_count(), 3);
+    }
+
+    #[test]
+    fn test_reload_recovers_after_storage_comes_back() {
+        let storage = Arc::new(MockStorage::new().with_document("guide", "Guide"));
+        let site = Site::new(
+            Arc::clone(&storage) as Arc<dyn rw_storage::Storage>,
+            Arc::new(rw_cache::NullCache),
+            PageRendererConfig::default(),
+        );
+
+        site.reload_if_needed().unwrap();
+        assert_eq!(storage.scan_count(), 1);
+
+        // Outage
+        storage.set_scan_error(Some(StorageErrorKind::Unavailable));
+        site.invalidate();
+        site.reload_if_needed().unwrap();
+        assert_eq!(storage.scan_count(), 2);
+
+        // Backend comes back; invalidate to signal a retry
+        storage.set_scan_error(None);
+        site.invalidate();
+
+        let snapshot = site.reload_if_needed().unwrap();
+        assert!(snapshot.state.get_page("guide").is_some());
+        // The recovery reload must actually re-call storage, not just serve
+        // the stale snapshot (which would also contain "guide").
+        assert_eq!(storage.scan_count(), 3);
     }
 
     #[test]

--- a/crates/rw-storage/src/mock.rs
+++ b/crates/rw-storage/src/mock.rs
@@ -4,6 +4,7 @@
 //! This implementation returns metadata exactly as set - no inheritance logic.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{RwLock, mpsc};
 
 use crate::event::{StorageEvent, StorageEventKind, StorageEventReceiver, WatchHandle};
@@ -44,6 +45,8 @@ pub struct MockStorage {
     /// If set, overrides the default `has_changed()` return value.
     has_changed: RwLock<Option<Result<bool, StorageErrorKind>>>,
     event_sender: RwLock<Option<mpsc::Sender<StorageEvent>>>,
+    /// Number of times `scan()` has been called (including failed calls).
+    scan_count: AtomicUsize,
 }
 
 impl Default for MockStorage {
@@ -56,6 +59,7 @@ impl Default for MockStorage {
             scan_error: RwLock::new(None),
             has_changed: RwLock::new(None),
             event_sender: RwLock::new(None),
+            scan_count: AtomicUsize::new(0),
         }
     }
 }
@@ -307,6 +311,16 @@ impl MockStorage {
         *self.scan_error.write().unwrap() = kind;
     }
 
+    /// Number of times `scan()` has been called, including failed calls.
+    ///
+    /// Useful for verifying that callers do not re-scan during a backend outage.
+    /// The counter has no associated state to synchronize, so `Relaxed` is
+    /// sufficient — callers reading the counter must already happen-after the
+    /// scans they want to observe through some other synchronization.
+    pub fn scan_count(&self) -> usize {
+        self.scan_count.load(Ordering::Relaxed)
+    }
+
     /// Override `has_changed()` to return a fixed value or error.
     ///
     /// - `Some(Ok(true))` — report changed
@@ -376,6 +390,7 @@ impl MockStorage {
 
 impl Storage for MockStorage {
     fn scan(&self) -> Result<Vec<Document>, StorageError> {
+        self.scan_count.fetch_add(1, Ordering::Relaxed);
         if let Some(kind) = self.scan_error.read().unwrap().as_ref() {
             return Err(StorageError::new(*kind).with_backend("Mock"));
         }


### PR DESCRIPTION
## Summary

Fixes #403 — `Site::reload_if_needed` left `cache_valid=false` after a failed background scan, so every subsequent read re-entered the slow path, serialized on the reload mutex, and re-called the unreachable backend. A transient S3 outage degraded into a "soft outage" where throughput dropped to ~1/timeout requests per second.

- Set `cache_valid=true` in the error branch so later reads serve the stale snapshot via the fast path. The next `invalidate()` (file-watcher event, `reload(true)`, or successful `reload(false)` once `has_changed()` recovers) is the explicit retry signal.
- Guard against a racing `invalidate()` being silently swallowed: the failure branch captures the generation before the scan and only restores the flag if the generation is unchanged. `invalidate()` now bumps the generation **before** clearing the flag so the post-scan load observes the bump before any restore decision is made.
- Adds `MockStorage::scan_count` so the regression test can prove subsequent reads do not re-scan storage during an outage, plus a recovery test that verifies the post-recovery invalidate actually re-runs the scan (not just that the stale snapshot still contains the page).

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] New tests:
  - [x] `test_reload_after_failure_does_not_repeat_storage_scan` — failed reload + 5 reads keeps `scan_count=2`; explicit `invalidate()` bumps to 3.
  - [x] `test_reload_recovers_after_storage_comes_back` — asserts the post-recovery scan actually ran (`scan_count=3`).