### PR TITLE
fix(rw-renderer)!: sandbox DirectiveContext::resolve_path against path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - S3-published documentation bundles now include page modification times in the manifest — previously `lastModified` was always epoch zero for Backstage-served pages
 - `@rwdocs/viewer` now requires Node.js `>=22.12.0` (was `>=20`) — the previous floor was incorrect since Vite 8 needs Node 20.19+/22.12+, and Node 20 reached end-of-life on 2026-04-30; `22.12.0` is the first release where `require(esm)` works without a flag
 - **Breaking:** the HTTP API served by `rw serve` moved from `/api/*` to the reserved `/_api/*` prefix (e.g. `/_api/navigation`, `/_api/pages/...`, `/_api/comments`), freeing the `/api/*` URL space for documentation pages. The bundled viewer moves in lockstep; only external callers hitting `rw serve`'s HTTP endpoints directly need to update.
+- **Breaking (`rw-renderer` Rust API):** `DirectiveContext::resolve_path` now returns `Result<PathBuf, ResolveError>` and rejects inputs that would escape the base directory (absolute paths, Windows-specific prefixes such as `C:\…` / `\\?\…` / UNC, `..` segments that pop above the root, and control bytes). The previous unchecked variant and the canonicalize-based `resolve_path_safe` have both been removed. No directive shipped in `rw` itself used either method, so end-user `rw` binaries are unaffected; only downstream crates that embed `rw-renderer` and implement custom directives (e.g. an `::include` handler) need to migrate.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,7 +4375,7 @@ dependencies = [
  "pulldown-cmark",
  "rw-sections",
  "serde",
- "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/rw-renderer/Cargo.toml
+++ b/crates/rw-renderer/Cargo.toml
@@ -17,7 +17,7 @@ serde = ["dep:serde"]
 pulldown-cmark = { workspace = true }
 rw-sections = { workspace = true }
 serde = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile = { workspace = true }

--- a/crates/rw-renderer/src/directive/context.rs
+++ b/crates/rw-renderer/src/directive/context.rs
@@ -3,7 +3,41 @@
 //! Provides file system access and source location information to directive handlers.
 
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
+
+/// Reason a relative path could not be safely resolved against the base directory.
+///
+/// Returned by [`DirectiveContext::resolve_path`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResolveError {
+    /// The input is an absolute path.
+    ///
+    /// Includes Unix absolute paths (`/etc/passwd`), Windows drive-absolute paths
+    /// (`C:\Windows`), UNC paths (`\\server\share`), and current-drive-rooted
+    /// paths (`\foo`).
+    #[error("path is absolute; only paths relative to the base directory are allowed")]
+    Absolute,
+
+    /// The input uses a Windows-specific prefix that is not a plain relative path.
+    ///
+    /// Covers drive-relative paths (`C:foo`), bare drive letters (`C:`), and the
+    /// verbatim/device namespaces (`\\?\`, `\\.\`). Returned regardless of the host
+    /// OS so directive handlers behave identically on Linux CI and Windows developer
+    /// machines.
+    #[error("path uses a Windows-specific prefix that is not allowed")]
+    WindowsPrefix,
+
+    /// The input would resolve to a location outside the base directory.
+    ///
+    /// Returned when lexical normalization of the path would pop above
+    /// `base_dir` (e.g. `../sibling.md`, `a/../../b`).
+    #[error("path escapes the base directory")]
+    Traversal,
+
+    /// The input contains a NUL or other control byte (< 0x20).
+    #[error("path contains an invalid character")]
+    InvalidChar,
+}
 
 /// Context provided to directive handlers for file system access and source location.
 ///
@@ -19,7 +53,7 @@ use std::path::{Path, PathBuf};
 /// Use the getter methods [`source_path()`](Self::source_path),
 /// [`base_dir()`](Self::base_dir), and [`line()`](Self::line) to access
 /// context information. Use [`read()`](Self::read) to read files and
-/// [`resolve_path()`](Self::resolve_path) to resolve relative paths.
+/// [`resolve_path()`](Self::resolve_path) to safely resolve relative paths.
 pub struct DirectiveContext<'a> {
     /// Path to the source file being rendered (if known).
     pub(crate) source_path: Option<&'a Path>,
@@ -50,39 +84,120 @@ impl DirectiveContext<'_> {
         self.line
     }
 
-    /// Resolve a relative path against the base directory.
+    /// Resolve a path relative to the base directory.
     ///
-    /// Returns the joined path. Use [`resolve_path_safe`](Self::resolve_path_safe)
-    /// to validate that the resolved path stays within the base directory.
-    #[must_use]
-    pub fn resolve_path(&self, relative: &str) -> PathBuf {
-        self.base_dir.join(relative)
-    }
-
-    /// Resolve a relative path with path traversal protection.
+    /// Performs lexical normalization only — the filesystem is not consulted,
+    /// symlinks are not resolved, and the target file does not need to exist.
+    /// Backslashes inside the input are treated as path separators (after the
+    /// Windows-prefix checks below) so the same input behaves identically on
+    /// Linux and Windows.
     ///
-    /// Returns `Some(path)` if the resolved path stays within the base directory,
-    /// or `None` if the path attempts to escape (e.g., `../../etc/passwd`).
+    /// Empty input and `"."` both resolve to `base_dir` itself, which is
+    /// usually a typo on the caller's side — handlers that want to reject
+    /// these should check `args.content().trim().is_empty()` before calling
+    /// `resolve_path`.
     ///
-    /// This method canonicalizes both paths and validates that the resolved path
-    /// starts with the base directory. Returns `None` if the file doesn't exist
-    /// (since canonicalization requires the path to exist).
-    #[must_use]
-    pub fn resolve_path_safe(&self, relative: &str) -> Option<PathBuf> {
-        let resolved = self.base_dir.join(relative);
-
-        // Canonicalize and validate path stays within base_dir
-        let canonical = resolved.canonicalize().ok()?;
-        let canonical_base = self.base_dir.canonicalize().ok()?;
-
-        if canonical.starts_with(&canonical_base) {
-            Some(canonical)
-        } else {
-            None // Path traversal attempt
+    /// # Errors
+    ///
+    /// Returns [`ResolveError`] if the input is absolute, uses a Windows-specific
+    /// prefix, contains an invalid character, or would escape the base directory.
+    ///
+    /// # Security
+    ///
+    /// This is a lexical sandbox, not a filesystem sandbox. In particular:
+    ///
+    /// - **Symlinks are not resolved.** A symlink placed inside `base_dir` that
+    ///   points outside it will be silently followed by [`read`](Self::read).
+    ///   Callers that need symlink containment must add their own check (e.g.
+    ///   `std::fs::canonicalize` + `starts_with`) after resolving.
+    /// - **`base_dir` is trusted as-is.** If the caller constructs the context
+    ///   with a `base_dir` that itself contains `..` segments, is un-normalized,
+    ///   or is relative, the resolved path inherits that shape (a relative
+    ///   `base_dir` produces a relative result, which is then sensitive to the
+    ///   process's working directory at [`read`](Self::read) time). Pass a
+    ///   canonicalized absolute `base_dir` to get the strongest containment.
+    /// - **Inputs are not trimmed.** A leading space or other non-control
+    ///   whitespace becomes a literal segment of the result (e.g.
+    ///   `" /etc/passwd"` resolves to `base_dir/ /etc/passwd`, which is still
+    ///   contained but will fail at read time). Handlers that accept
+    ///   user-pasted paths should `trim()` themselves before calling.
+    pub fn resolve_path(&self, relative: &str) -> Result<PathBuf, ResolveError> {
+        // 1. Reject NUL and other control bytes.
+        if relative.bytes().any(|b| b < 0x20) {
+            return Err(ResolveError::InvalidChar);
         }
+
+        // 2. Reject Windows-specific prefixes regardless of host OS.
+        //    The string-level check runs before Path::components because
+        //    `Path::new("C:\\foo").components()` on Unix yields a single
+        //    Normal component, which would otherwise sneak through.
+        let bytes = relative.as_bytes();
+        // Verbatim / device namespaces: \\?\, \\.\
+        if relative.starts_with(r"\\?\") || relative.starts_with(r"\\.\") {
+            return Err(ResolveError::WindowsPrefix);
+        }
+        // UNC: \\server\share — treat as absolute
+        if relative.starts_with(r"\\") {
+            return Err(ResolveError::Absolute);
+        }
+        // Unix absolute or current-drive-rooted (Windows): leading / or \
+        if matches!(bytes.first(), Some(b'/' | b'\\')) {
+            return Err(ResolveError::Absolute);
+        }
+        // Drive letter: C: ...
+        if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            match bytes.get(2) {
+                Some(b'/' | b'\\') => return Err(ResolveError::Absolute), // C:\foo
+                _ => return Err(ResolveError::WindowsPrefix),             // C: or C:foo
+            }
+        }
+
+        // 3. Normalize backslash separators to forward slashes so the lexical
+        //    walk below treats `dir\file.md` the same on Unix and Windows.
+        //    All known Windows path-prefix attacks were rejected above, so any
+        //    remaining backslash is a separator inside a relative path.
+        let normalized = if relative.contains('\\') {
+            relative.replace('\\', "/")
+        } else {
+            relative.to_owned()
+        };
+
+        // 4. Lexical normalization. Walk components, maintain a stack,
+        //    refuse to pop above the root.
+        let mut stack: Vec<&std::ffi::OsStr> = Vec::new();
+        for component in Path::new(&normalized).components() {
+            match component {
+                Component::Normal(s) => stack.push(s),
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    if stack.pop().is_none() {
+                        return Err(ResolveError::Traversal);
+                    }
+                }
+                Component::RootDir | Component::Prefix(_) => {
+                    return Err(ResolveError::Absolute);
+                }
+            }
+        }
+
+        // 5. Re-join onto base_dir.
+        let mut result = self.base_dir.to_path_buf();
+        for segment in stack {
+            result.push(segment);
+        }
+        Ok(result)
     }
 
     /// Read a file using the context's `read_file` callback.
+    ///
+    /// # Security
+    ///
+    /// This method passes `path` straight to the underlying callback and does
+    /// **not** validate that the path stays within [`base_dir`](Self::base_dir).
+    /// Directive handlers that derive `path` from user-controlled input (e.g.
+    /// the content of an `::include` directive) must first sanitize it via
+    /// [`resolve_path`](Self::resolve_path); otherwise the callback is reachable
+    /// with arbitrary file paths and the sandbox is bypassed.
     ///
     /// # Errors
     ///
@@ -95,37 +210,6 @@ impl DirectiveContext<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_resolve_path() {
-        let ctx = DirectiveContext {
-            source_path: Some(Path::new("docs/guide.md")),
-            base_dir: Path::new("docs"),
-            line: 10,
-            read_file: &|_| Ok(String::new()),
-        };
-
-        assert_eq!(
-            ctx.resolve_path("snippets/code.md"),
-            PathBuf::from("docs/snippets/code.md")
-        );
-    }
-
-    #[test]
-    fn test_resolve_absolute_path() {
-        let ctx = DirectiveContext {
-            source_path: None,
-            base_dir: Path::new("/home/user/docs"),
-            line: 1,
-            read_file: &|_| Ok(String::new()),
-        };
-
-        // Joining absolute path replaces the base
-        assert_eq!(
-            ctx.resolve_path("/etc/config"),
-            PathBuf::from("/etc/config")
-        );
-    }
 
     #[test]
     fn test_read_file() {
@@ -154,58 +238,242 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_path_safe_within_base() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let base_dir = temp_dir.path();
-        std::fs::write(base_dir.join("guide.md"), "# Guide").unwrap();
-
+    fn test_resolve_path_happy_path() {
         let ctx = DirectiveContext {
             source_path: None,
-            base_dir,
+            base_dir: Path::new("/docs"),
             line: 1,
             read_file: &|_| Ok(String::new()),
         };
 
-        let result = ctx.resolve_path_safe("guide.md");
-        assert!(result.is_some());
-        assert!(result.unwrap().ends_with("guide.md"));
+        assert_eq!(
+            ctx.resolve_path("snippets/code.md"),
+            Ok(PathBuf::from("/docs/snippets/code.md"))
+        );
     }
 
     #[test]
-    fn test_resolve_path_safe_blocks_traversal() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let base_dir = temp_dir.path().join("docs");
-        std::fs::create_dir(&base_dir).unwrap();
-
-        // Create a file outside base_dir
-        std::fs::write(temp_dir.path().join("secret.txt"), "secret").unwrap();
-
-        let ctx = DirectiveContext {
-            source_path: None,
-            base_dir: &base_dir,
-            line: 1,
-            read_file: &|_| Ok(String::new()),
-        };
-
-        // Path traversal attempt should return None
-        let result = ctx.resolve_path_safe("../secret.txt");
-        assert!(result.is_none());
+    fn test_resolve_error_display_messages() {
+        assert_eq!(
+            ResolveError::Absolute.to_string(),
+            "path is absolute; only paths relative to the base directory are allowed"
+        );
+        assert_eq!(
+            ResolveError::WindowsPrefix.to_string(),
+            "path uses a Windows-specific prefix that is not allowed"
+        );
+        assert_eq!(
+            ResolveError::Traversal.to_string(),
+            "path escapes the base directory"
+        );
+        assert_eq!(
+            ResolveError::InvalidChar.to_string(),
+            "path contains an invalid character"
+        );
     }
 
     #[test]
-    fn test_resolve_path_safe_nonexistent_returns_none() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let base_dir = temp_dir.path();
-
+    fn test_resolve_path_current_dir_segments() {
         let ctx = DirectiveContext {
             source_path: None,
-            base_dir,
+            base_dir: Path::new("/docs"),
             line: 1,
             read_file: &|_| Ok(String::new()),
         };
+        assert_eq!(
+            ctx.resolve_path("./snippets/code.md"),
+            Ok(PathBuf::from("/docs/snippets/code.md"))
+        );
+        assert_eq!(
+            ctx.resolve_path("a/./b/../c.md"),
+            Ok(PathBuf::from("/docs/a/c.md"))
+        );
+    }
 
-        // Non-existent file cannot be canonicalized
-        let result = ctx.resolve_path_safe("nonexistent.md");
-        assert!(result.is_none());
+    #[test]
+    fn test_resolve_path_internal_parent_dirs_allowed() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        // Steps into subdir then back out, lands in base
+        assert_eq!(
+            ctx.resolve_path("a/b/../../c.md"),
+            Ok(PathBuf::from("/docs/c.md"))
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_traversal_above_root() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(
+            ctx.resolve_path("a/b/../../../c.md"),
+            Err(ResolveError::Traversal)
+        );
+        assert_eq!(
+            ctx.resolve_path("../etc/passwd"),
+            Err(ResolveError::Traversal)
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_unix_absolute() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(ctx.resolve_path("/etc/passwd"), Err(ResolveError::Absolute));
+        // Still Absolute even if it would happen to "stay inside"
+        let ctx_etc = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/etc"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(
+            ctx_etc.resolve_path("/etc/passwd"),
+            Err(ResolveError::Absolute)
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_windows_current_drive_rooted() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(ctx.resolve_path(r"\foo"), Err(ResolveError::Absolute));
+    }
+
+    #[test]
+    fn test_resolve_path_windows_unc() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(
+            ctx.resolve_path(r"\\server\share\file"),
+            Err(ResolveError::Absolute)
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_windows_verbatim_and_device() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(
+            ctx.resolve_path(r"\\?\C:\foo"),
+            Err(ResolveError::WindowsPrefix)
+        );
+        assert_eq!(
+            ctx.resolve_path(r"\\?\UNC\server\share"),
+            Err(ResolveError::WindowsPrefix)
+        );
+        assert_eq!(
+            ctx.resolve_path(r"\\.\PhysicalDrive0"),
+            Err(ResolveError::WindowsPrefix)
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_windows_drive_absolute() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(
+            ctx.resolve_path(r"C:\Windows\System32"),
+            Err(ResolveError::Absolute)
+        );
+        assert_eq!(
+            ctx.resolve_path("c:/Windows/System32"),
+            Err(ResolveError::Absolute)
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_windows_drive_relative() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(ctx.resolve_path("C:foo"), Err(ResolveError::WindowsPrefix));
+        assert_eq!(ctx.resolve_path("c:foo"), Err(ResolveError::WindowsPrefix));
+        // Bare drive letter
+        assert_eq!(ctx.resolve_path("C:"), Err(ResolveError::WindowsPrefix));
+    }
+
+    #[test]
+    fn test_resolve_path_control_chars() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(ctx.resolve_path("a\0b"), Err(ResolveError::InvalidChar));
+        assert_eq!(ctx.resolve_path("a\tb"), Err(ResolveError::InvalidChar));
+        assert_eq!(ctx.resolve_path("a\nb"), Err(ResolveError::InvalidChar));
+    }
+
+    #[test]
+    fn test_resolve_path_normalizes_embedded_backslashes() {
+        // Embedded backslashes in a relative path are treated as separators
+        // so the same markdown source resolves identically on Unix and Windows.
+        // The Windows-prefix attacks (leading \, drive letter, UNC, \\?\, \\.\)
+        // were rejected before reaching this point.
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(
+            ctx.resolve_path(r"subdir\file.md"),
+            Ok(PathBuf::from("/docs/subdir/file.md"))
+        );
+        // Traversal via backslash is also caught.
+        assert_eq!(
+            ctx.resolve_path(r"..\secret.md"),
+            Err(ResolveError::Traversal)
+        );
+        // Mixed separators are normalized.
+        assert_eq!(
+            ctx.resolve_path(r"a/b\c.md"),
+            Ok(PathBuf::from("/docs/a/b/c.md"))
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_empty_and_dot() {
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 1,
+            read_file: &|_| Ok(String::new()),
+        };
+        assert_eq!(ctx.resolve_path(""), Ok(PathBuf::from("/docs")));
+        assert_eq!(ctx.resolve_path("."), Ok(PathBuf::from("/docs")));
     }
 }

--- a/crates/rw-renderer/src/directive/leaf.rs
+++ b/crates/rw-renderer/src/directive/leaf.rs
@@ -113,7 +113,18 @@ mod tests {
         }
 
         fn process(&mut self, args: DirectiveArgs, ctx: &DirectiveContext) -> DirectiveOutput {
-            let path = ctx.resolve_path(args.content());
+            let path = match ctx.resolve_path(args.content()) {
+                Ok(p) => p,
+                Err(e) => {
+                    self.warnings.push(format!(
+                        "line {}: invalid include '{}': {}",
+                        ctx.line(),
+                        args.content(),
+                        e
+                    ));
+                    return DirectiveOutput::Skip;
+                }
+            };
             match ctx.read(&path) {
                 Ok(contents) => DirectiveOutput::markdown(contents),
                 Err(e) => {
@@ -194,6 +205,50 @@ mod tests {
         assert_eq!(include.warnings().len(), 1);
         assert!(include.warnings()[0].contains("line 10"));
         assert!(include.warnings()[0].contains("missing.md"));
+    }
+
+    #[test]
+    fn test_include_rejects_absolute_path_without_reading() {
+        let mut include = TestInclude::new();
+
+        // read_file callback that panics if invoked — proves the file
+        // is never read on resolution failure.
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 7,
+            read_file: &|p| panic!("read_file should not be called; got {p:?}"),
+        };
+
+        let args = DirectiveArgs::parse("/etc/passwd", "");
+        let output = include.process(args, &ctx);
+
+        assert_eq!(output, DirectiveOutput::Skip);
+        assert_eq!(include.warnings().len(), 1);
+        assert!(include.warnings()[0].contains("line 7"));
+        assert!(include.warnings()[0].contains("/etc/passwd"));
+        assert!(include.warnings()[0].contains("invalid include"));
+    }
+
+    #[test]
+    fn test_include_rejects_traversal_without_reading() {
+        let mut include = TestInclude::new();
+
+        let ctx = DirectiveContext {
+            source_path: None,
+            base_dir: Path::new("/docs"),
+            line: 12,
+            read_file: &|p| panic!("read_file should not be called; got {p:?}"),
+        };
+
+        let args = DirectiveArgs::parse("../secret.md", "");
+        let output = include.process(args, &ctx);
+
+        assert_eq!(output, DirectiveOutput::Skip);
+        assert_eq!(include.warnings().len(), 1);
+        assert!(include.warnings()[0].contains("line 12"));
+        assert!(include.warnings()[0].contains("../secret.md"));
+        assert!(include.warnings()[0].contains("invalid include"));
     }
 
     #[test]

--- a/crates/rw-renderer/src/directive/mod.rs
+++ b/crates/rw-renderer/src/directive/mod.rs
@@ -28,6 +28,16 @@
 //!    HTML using the [`Replacements`] collector for efficient single-pass
 //!    string replacement.
 //!
+//! # Path Resolution Sandbox
+//!
+//! Directive handlers that read files (e.g. `::include`) should call
+//! [`DirectiveContext::resolve_path`] to resolve a user-supplied path.
+//! The method rejects absolute paths, Windows-specific prefixes,
+//! `..` segments that would escape the base directory, and control
+//! bytes in the input. See [`ResolveError`] for the full failure
+//! taxonomy. [`DirectiveContext::read`] does **not** sandbox on its own
+//! — handlers must run `resolve_path` first.
+//!
 //! # Example
 //!
 //! ```
@@ -65,7 +75,7 @@ mod replacements;
 
 pub use args::DirectiveArgs;
 pub use container::ContainerDirective;
-pub use context::DirectiveContext;
+pub use context::{DirectiveContext, ResolveError};
 pub use inline::InlineDirective;
 pub use leaf::LeafDirective;
 pub use output::DirectiveOutput;


### PR DESCRIPTION
## Summary

Closes #398.

`DirectiveContext::resolve_path` used to call `self.base_dir.join(relative)`, which silently discards `base_dir` when the input is absolute. A directive of the form `::include[/etc/passwd]` would have read whatever the host process could read. A `resolve_path_safe` variant existed but was opt-in, and the documented `TestInclude` example used the unsafe one — so any downstream crate copying the trait's example pattern would have shipped the same CWE-22.

This PR replaces both methods with a single sandboxed `resolve_path` returning `Result<PathBuf, ResolveError>`. The implementation does **lexical** normalization only — no `canonicalize`, no symlink resolution, target need not exist.

### What's rejected

- **`Absolute`** — Unix absolute paths (`/etc/passwd`), Windows drive-absolute (`C:\foo`), UNC (`\\server\share`), current-drive-rooted (`\foo`)
- **`WindowsPrefix`** — drive-relative (`C:foo`), bare drive letters (`C:`), verbatim / device namespaces (`\\?\`, `\\.\`). Returned regardless of host OS so handlers behave identically on Linux and Windows.
- **`Traversal`** — `..` segments that pop above the base
- **`InvalidChar`** — NUL and other control bytes (< 0x20)

Embedded backslashes (after the prefix checks) are normalized to forward slashes so `subdir\file.md` resolves identically on both platforms.

### Why lexical, not `canonicalize`

The previous `resolve_path_safe` called `canonicalize` and checked `starts_with(base)`. That had three problems: it required the target to exist (conflating "not found" with "traversal attempt"), it failed on legitimate `subdir/../sibling.md` inputs unless every intermediate directory existed, and it followed symlinks — so a legitimate `shared-snippets -> ../shared` symlink in a docs repo would have been rejected. Lexical normalization handles all three cases correctly and is fast.

Symlink containment is now a documented non-goal; if a caller needs it, they can layer their own `canonicalize` + `starts_with` check on top.

### API surface

- `pub enum ResolveError { Absolute, WindowsPrefix, Traversal, InvalidChar }` — `Debug + Display + Error + Clone + Copy + PartialEq + Eq + Hash`, re-exported from `rw_renderer::directive`.
- `DirectiveContext::read` is unchanged in behavior but its rustdoc now states explicitly that it does not sandbox on its own — handlers must call `resolve_path` first.

### Breaking change scope

The old `resolve_path` (`PathBuf` return) and `resolve_path_safe` (`Option<PathBuf>` return) are both removed. Breaking for downstream crates that embed `rw-renderer` and implement custom directives. No in-tree `rw` binary used either method, so end-user `rw` binaries (CLI, Confluence publishing, Backstage publishing, napi bindings) are unaffected.

## Test plan

- [x] `cargo test -p rw-renderer` — 277 lib tests + 28 doc tests pass, including 17 new tests covering the resolution matrix (happy path, traversal, all Windows variants, control chars, backslash normalization, empty/dot)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] `make format` — clean
- [x] `TestInclude` example handler updated to use the new `Result`-returning API; new tests assert `read_file` is never invoked when resolution fails
- [x] CHANGELOG entry under `### Changed` flags the breaking-API impact and migration path

🤖 Generated with [Claude Code](https://claude.com/claude-code)