### PR TITLE
test(e2e): use aria snapshots for breadcrumb and TOC popover structure

### DIFF
--- a/packages/viewer/e2e/breadcrumb-overflow.spec.ts
+++ b/packages/viewer/e2e/breadcrumb-overflow.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect, type Page, type Locator } from "@playwright/test";
 
 test.describe("Breadcrumb Overflow", () => {
-  // Deep page with 5 breadcrumbs: Home > Advanced Topics > Plugin Development > Custom Extensions Development > Getting Started With Extensions
+  // Deep page: 4 ancestor breadcrumbs (Home > Advanced Topics > Plugin Development >
+  // Custom Extensions Development); the current-page segment renders as the H1, not the nav.
   const deepPage = "/advanced/plugins/custom-extensions/getting-started-guide";
 
   async function openEllipsisDropdown(page: Page): Promise<{
@@ -27,36 +28,57 @@ test.describe("Breadcrumb Overflow", () => {
 
     const breadcrumbs = page.getByRole("navigation", { name: "Breadcrumb" });
     await expect(breadcrumbs).toBeVisible();
-    await expect(breadcrumbs.getByRole("link", { name: "Home" })).toBeVisible();
-    await expect(
-      breadcrumbs.getByRole("link", { name: "Custom Extensions Development" }),
-    ).toBeVisible();
-
-    // Ellipsis should not be present at full width
+    await expect(breadcrumbs).toMatchAriaSnapshot(`
+      - navigation "Breadcrumb":
+        - list:
+          - listitem:
+            - link "Home":
+              - /url: /
+            - text: /
+          - listitem:
+            - link "Advanced Topics":
+              - /url: /advanced
+            - text: /
+          - listitem:
+            - link "Plugin Development":
+              - /url: /advanced/plugins
+            - text: /
+          - listitem:
+            - link "Custom Extensions Development":
+              - /url: /advanced/plugins/custom-extensions
+    `);
+    // Aria snapshots don't assert absence of unlisted nodes; pin it explicitly.
     await expect(breadcrumbs.getByRole("button", { name: "Show hidden breadcrumbs" })).toBeHidden();
 
     // Shrink viewport to trigger overflow
     await page.setViewportSize({ width: 400, height: 800 });
 
-    // Ellipsis button should appear
-    const ellipsisButton = breadcrumbs.getByRole("button", {
-      name: "Show hidden breadcrumbs",
-    });
-    await expect(ellipsisButton).toBeVisible();
-
-    // First and last breadcrumbs should always remain visible
-    await expect(breadcrumbs.getByRole("link", { name: "Home" })).toBeVisible();
-    await expect(
-      breadcrumbs.getByRole("link", { name: "Custom Extensions Development" }),
-    ).toBeVisible();
+    // Ellipsis button + first/last breadcrumbs remain visible; middle items collapse
+    await expect(breadcrumbs).toMatchAriaSnapshot(`
+      - navigation "Breadcrumb":
+        - list:
+          - listitem:
+            - link "Home":
+              - /url: /
+            - text: /
+          - listitem:
+            - button "Show hidden breadcrumbs": …
+            - text: /
+          - listitem:
+            - link "Custom Extensions Development":
+              - /url: /advanced/plugins/custom-extensions
+    `);
   });
 
   test("opens dropdown with hidden breadcrumbs on ellipsis click", async ({ page }) => {
     await openEllipsisDropdown(page);
 
-    // Dropdown should show hidden middle items
     const dropdown = page.getByRole("menu", { name: "Hidden breadcrumbs" });
-    await expect(dropdown.getByRole("menuitem", { name: "Advanced Topics" })).toBeVisible();
+    await expect(dropdown).toMatchAriaSnapshot(`
+      - menu "Hidden breadcrumbs":
+        - menuitem "Advanced Topics"
+        - menuitem "Plugin Development"
+    `);
   });
 
   test("navigates when clicking a hidden breadcrumb in dropdown", async ({ page }) => {
@@ -94,11 +116,21 @@ test.describe("Breadcrumb Overflow", () => {
 
     const breadcrumbs = page.getByRole("navigation", { name: "Breadcrumb" });
     await expect(breadcrumbs).toBeVisible();
-
-    await expect(breadcrumbs.getByRole("link", { name: "Home" })).toBeVisible();
-    await expect(breadcrumbs.getByRole("link", { name: "Advanced Topics" })).toBeVisible();
-    await expect(breadcrumbs.getByRole("link", { name: "Plugin Development" })).toBeVisible();
-
+    await expect(breadcrumbs).toMatchAriaSnapshot(`
+      - navigation "Breadcrumb":
+        - list:
+          - listitem:
+            - link "Home":
+              - /url: /
+            - text: /
+          - listitem:
+            - link "Advanced Topics":
+              - /url: /advanced
+            - text: /
+          - listitem:
+            - link "Plugin Development":
+              - /url: /advanced/plugins
+    `);
     await expect(breadcrumbs.getByRole("button", { name: "Show hidden breadcrumbs" })).toBeHidden();
   });
 });

--- a/packages/viewer/e2e/toc-popover.spec.ts
+++ b/packages/viewer/e2e/toc-popover.spec.ts
@@ -34,13 +34,25 @@ test.describe("TOC Popover", () => {
     const button = page.getByRole("button", { name: "Table of contents" });
     await button.click();
 
-    // Popover nav should appear with TOC links
     const popover = page.getByRole("navigation", { name: "Table of contents" });
     await expect(popover).toBeVisible();
-
-    // Should contain heading links from the page
-    await expect(popover.getByRole("link", { name: "Features" })).toBeVisible();
-    await expect(popover.getByRole("link", { name: "Quick Start" })).toBeVisible();
+    await expect(popover).toMatchAriaSnapshot(`
+      - navigation "Table of contents":
+        - heading "On this page" [level=3]
+        - list:
+          - listitem:
+            - link "Features":
+              - /url: "#features"
+          - listitem:
+            - link "Quick Start":
+              - /url: "#quick-start"
+          - listitem:
+            - link "Code Example":
+              - /url: "#code-example"
+          - listitem:
+            - link "Learn More":
+              - /url: "#learn-more"
+    `);
   });
 
   test("sets aria-expanded on toggle", async ({ page }) => {


### PR DESCRIPTION
## Summary

Refactors four Playwright e2e tests in `packages/viewer/e2e/` to use `toMatchAriaSnapshot()` (Playwright 1.60.0) instead of runs of individual `getByRole().toBeVisible()/toBeHidden()` assertions. The snapshots pin the shape, order, and completeness of the rendered landmark, catching regressions like dropped breadcrumb items or reordered TOC headings that the cherry-picked `toBeVisible()` checks would have missed.

**Refactored:**
- `breadcrumb-overflow.spec.ts` — "collapses middle breadcrumbs when container is narrow", "opens dropdown with hidden breadcrumbs on ellipsis click", "shows all breadcrumbs without ellipsis when they fit"
- `toc-popover.spec.ts` — "opens popover on button click"

**Untouched:**
- Behavior tests in the same files — `aria-expanded` toggles, Escape closes, click-outside closes, `toHaveURL` after navigation.
- All other spec files.

## Gotcha worth noting in review

Playwright's `toMatchAriaSnapshot` is **permissive about extra unmentioned children** — it asserts presence and order, not absence. I verified this empirically (trimmed a snapshot to one listitem against a 3-listitem breadcrumb → still passed). So the two `toBeHidden()` checks for the `"Show hidden breadcrumbs"` button are kept alongside the snapshots — they're the only way to guarantee an unintended overflow at full width can't slip past.

## Test plan

- [x] `npx playwright test e2e/breadcrumb-overflow.spec.ts e2e/toc-popover.spec.ts` — 14/14 pass, twice in a row
- [x] Full suite (`npx playwright test`) — 100/100 pass across `chromium` and `chromium-embedded` projects
- [x] `npm -w @rwdocs/viewer run format` / `run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)