### PR TITLE
fix(viewer): context-confidence floor for inline-comment re-anchoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Inline comments anchored to short or common text (`-`, `,`, `TODO`, single chars) no longer silently migrate to unrelated occurrences when the original passage is edited away — they now appear in the page-comments timeline at the bottom with the original quote block, instead of getting a confident solid-underline highlight on a different character.
 - Inline directive syntax (`:name[…]`) inside an inline code span (e.g., `` `:status[On Track]` ``), indented code block, or raw inline HTML is no longer expanded — documentation can now demonstrate `:status[…]` or other inline directives as code.
 - Inline directives following a non-directive colon on the same line (e.g. `Note: press :kbd[Ctrl+C]`, `Status: see :status[Done]`, `See https://example.com then run :cmd[deploy]`) are no longer silently dropped — the renderer now skips past punctuation colons, URL schemes, and times and continues scanning for the real directive.
 - Documentation pages whose URL begins with `/api/` (e.g. `docs/api/usage.md`) no longer return 404 when opened directly or refreshed in the browser.

--- a/packages/viewer/src/lib/anchoring.test.ts
+++ b/packages/viewer/src/lib/anchoring.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { rangeToSelectors, selectorsToRange } from "./anchoring";
 import type { Selector } from "../types/comments";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
 
 function createContainer(html: string): HTMLElement {
   const el = document.createElement("div");
@@ -320,6 +324,156 @@ describe("fuzzy fallback", () => {
 
     const result = selectorsToRange(selectors, container);
     expect(result).toBeNull();
+  });
+});
+
+describe("low-confidence demotion", () => {
+  it("orphans a short lone quote when no surviving occurrence has strong context", () => {
+    // Original doc: "abc - def - xyz", comment on the first "-".
+    // After edit, doc is "abc def - xyz" (one "-" left, at offset 8).
+    // The lone "-" has weak prefix/suffix match against the stored context
+    // (only the bordering spaces agree). Must NOT anchor inline.
+    const container = createContainer("<p>abc def - xyz</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "-", prefix: "abc ", suffix: " def - xyz" },
+      { type: "TextPositionSelector", start: 4, end: 5 },
+    ];
+
+    expect(selectorsToRange(selectors, container)).toBeNull();
+  });
+
+  it("orphans a short common word with weak context after the original passage is gone", () => {
+    // Common-token quote ("TODO") that survives elsewhere on the page but
+    // with totally unrelated context. Must not anchor inline.
+    const container = createContainer("<p>morning standup TODO xyz</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "TODO", prefix: "finished ", suffix: " item" },
+      { type: "TextPositionSelector", start: 8, end: 12 },
+    ];
+
+    expect(selectorsToRange(selectors, container)).toBeNull();
+  });
+
+  it("keeps a single-char quote anchored when both sides have strong context", () => {
+    // The same short-quote shape, but with surrounding context that DOES agree —
+    // this is a legitimate anchor and must NOT be demoted.
+    const container = createContainer("<p>foo - bar</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "-", prefix: "foo ", suffix: " bar" },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.strategy).toBe("quote");
+    expect(result!.range.toString()).toBe("-");
+  });
+
+  it("keeps a long quote anchored when only one side of context matches", () => {
+    // 30-char quote, prefix matches verbatim, suffix is totally different.
+    // For long quotes, one strong side is enough to stay anchored as quote.
+    const longExact = "this is a thirty char chunk!!!"; // longer than the short-quote threshold
+    const container = createContainer(`<p>aa before bb ${longExact} totally rewritten</p>`);
+    const selectors: Selector[] = [
+      {
+        type: "TextQuoteSelector",
+        exact: longExact,
+        prefix: "aa before bb ",
+        suffix: " original context here that no longer exists",
+      },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.strategy).toBe("quote");
+    expect(result!.range.toString()).toBe(longExact);
+  });
+
+  it("keeps a quote anchored when both stored sides are empty (boundary selection)", () => {
+    // Selection touched the start/end of the article — stored prefix and
+    // suffix are both empty. Confidence can't be assessed from context;
+    // accept the match.
+    const container = createContainer("<p>single match somewhere</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "single match", prefix: "", suffix: "" },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.strategy).toBe("quote");
+    expect(result!.range.toString()).toBe("single match");
+  });
+
+  it("returns null when stored TextQuoteSelector.exact is empty", () => {
+    // A scripted/external caller could persist a selector with an empty
+    // `exact`. Without a guard, quoteBestOccurrence's `text.indexOf("", n)`
+    // loop never terminates because indexOf("") clamps at text.length
+    // instead of returning -1.
+    const container = createContainer("<p>hello world</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "", prefix: "", suffix: "" },
+    ];
+
+    expect(selectorsToRange(selectors, container)).toBeNull();
+  });
+
+  it("orphans a long quote when one stored side is empty and the other side disagrees", () => {
+    // Long quote (>= SHORT_QUOTE_LEN). Empty prefix (boundary selection at
+    // article start), recorded suffix that no longer matches in the live doc.
+    // Empty side must NOT short-circuit the confidence gate to true.
+    const longExact = "this is a long passage"; // 22 chars
+    const container = createContainer(`<p>random preamble ${longExact} totally different tail</p>`);
+    const selectors: Selector[] = [
+      {
+        type: "TextQuoteSelector",
+        exact: longExact,
+        prefix: "",
+        suffix: " original context that no longer exists",
+      },
+    ];
+
+    expect(selectorsToRange(selectors, container)).toBeNull();
+  });
+
+  it("orphans a short quote with empty stored prefix when the only recorded side disagrees", () => {
+    // Short quote, empty prefix (boundary selection), recorded suffix that
+    // matches a wrong occurrence. Without the empty-side fix, suffixOk passes
+    // and the comment anchors to the wrong "ok".
+    const container = createContainer("<p>ok suddenly unrelated</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "ok", prefix: "", suffix: " then proceed" },
+    ];
+
+    expect(selectorsToRange(selectors, container)).toBeNull();
+  });
+
+  it("anchors a verbatim match even when stored context is shorter than the confidence floor", () => {
+    // Stored prefix is only 1 char (boundary or tiny-article selection); a
+    // verbatim re-anchor must succeed because the maximum achievable score
+    // (= recorded length) is what we should expect.
+    const container = createContainer("<p>X-Y</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "-", prefix: "X", suffix: "Y" },
+    ];
+
+    const result = selectorsToRange(selectors, container);
+    expect(result).not.toBeNull();
+    expect(result!.strategy).toBe("quote");
+    expect(result!.range.toString()).toBe("-");
+  });
+
+  it("orphans a short quote when position validates exact but stored context disagrees", () => {
+    // Original doc: "abc - def - xyz", comment on first "-" at offset 4.
+    // User reorders: "abc - xyz - def". First "-" is STILL at offset 4 and
+    // still equals stored exact "-", but the stored context ("abc ", " def - xyz")
+    // doesn't match the new surroundings. Position branch must not short-circuit
+    // the confidence floor — fall through to quote search, which then orphans.
+    const container = createContainer("<p>abc - xyz - def</p>");
+    const selectors: Selector[] = [
+      { type: "TextQuoteSelector", exact: "-", prefix: "abc ", suffix: " def - xyz" },
+      { type: "TextPositionSelector", start: 4, end: 5 },
+    ];
+
+    expect(selectorsToRange(selectors, container)).toBeNull();
   });
 });
 

--- a/packages/viewer/src/lib/anchoring.ts
+++ b/packages/viewer/src/lib/anchoring.ts
@@ -66,16 +66,21 @@ function findTextPosition(
  * Re-anchor stored selectors to a live DOM Range.
  *
  * Resolution order:
- *   1. TextPositionSelector — instant if the offset still points to the
- *      stored quote (validates against TextQuoteSelector.exact when present).
- *   2. TextQuoteSelector — exact substring match. Every occurrence in the
- *      document is scored against the stored prefix/suffix context; the
- *      highest-scoring occurrence wins. The position selector is a tiebreaker
- *      (closest to the original offset), not a search constraint — see N2.
- *   3. Fuzzy match via diff-match-patch — finds an approximate occurrence
- *      near the position hint when the exact substring no longer appears
- *      (typo fix, paragraph split that drops a space, etc.). Marked as
- *      `strategy: 'fuzzy'` so the UI can flag it.
+ *   1. TextPositionSelector — fast path. When a quote selector is also
+ *      present, validates that the resolved text equals the stored `exact`
+ *      AND that the surrounding context clears the confidence floor (see
+ *      isConfidentMatch). Either check failing falls through.
+ *   2. TextQuoteSelector — exact substring search with a context-confidence
+ *      check. Short quotes (`exact.length` < SHORT_QUOTE_LEN) need strong
+ *      agreement on every recorded context side; long quotes need one
+ *      strongly-agreeing recorded side. Without confidence we don't anchor
+ *      inline — `strategy: 'quote'` is reserved for matches we trust.
+ *   3. Fuzzy match via diff-match-patch — runs ONLY when the exact substring
+ *      is absent from the document (e.g. typo fix inside the quote,
+ *      paragraph split that dropped a space). When the exact text IS present
+ *      but failed the confidence gate, fuzzy would just rescue it to the
+ *      same wrong place, so we orphan instead. Successful fuzzy matches get
+ *      `strategy: 'fuzzy'` (dashed underline + "re-anchored" badge).
  */
 export function selectorsToRange(
   selectors: Selector[],
@@ -93,7 +98,28 @@ export function selectorsToRange(
     const range = positionToRange(posSelector, container);
     if (range && quoteSelector) {
       if (range.toString() === quoteSelector.exact) {
-        return { range, strategy: "position" };
+        const text = getTextContent(container);
+        const score = scoreContext(
+          text,
+          posSelector.start,
+          quoteSelector.exact.length,
+          quoteSelector.prefix,
+          quoteSelector.suffix,
+        );
+        const occ = { index: posSelector.start, ...score };
+        if (
+          isConfidentMatch(
+            occ,
+            quoteSelector.exact.length,
+            quoteSelector.prefix,
+            quoteSelector.suffix,
+          )
+        ) {
+          return { range, strategy: "position" };
+        }
+        // Position validated exact but context disagrees — fall through to the
+        // quote-search branch, which will reach the same occurrence via
+        // quoteBestOccurrence and fail the same gate (orphaning the comment).
       }
     } else if (range) {
       return { range, strategy: "position" };
@@ -101,11 +127,31 @@ export function selectorsToRange(
   }
 
   if (quoteSelector) {
-    const range = quoteToRange(quoteSelector, container, posSelector?.start);
-    if (range) return { range, strategy: "quote" };
-
-    const fuzzy = fuzzyToRange(quoteSelector, container, posSelector?.start);
-    if (fuzzy) return { range: fuzzy, strategy: "fuzzy" };
+    const occ = quoteBestOccurrence(quoteSelector, container, posSelector?.start);
+    if (occ) {
+      if (
+        isConfidentMatch(
+          occ,
+          quoteSelector.exact.length,
+          quoteSelector.prefix,
+          quoteSelector.suffix,
+        )
+      ) {
+        const range = rangeAtTextOffset(
+          container,
+          occ.index,
+          occ.index + quoteSelector.exact.length,
+        );
+        if (range) return { range, strategy: "quote" };
+      }
+      // Exact text is present but failed the confidence gate — the passage
+      // exists in a different context. Don't fuzzy-match: a weaker hit would
+      // only anchor to the wrong place.
+    } else {
+      // Exact text is gone — the passage was edited. Try a fuzzy match.
+      const fuzzy = fuzzyToRange(quoteSelector, container, posSelector?.start);
+      if (fuzzy) return { range: fuzzy, strategy: "fuzzy" };
+    }
   }
 
   return null;
@@ -129,47 +175,9 @@ function positionToRange(
   }
 }
 
-function quoteToRange(
-  selector: Extract<Selector, { type: "TextQuoteSelector" }>,
-  container: HTMLElement,
-  positionHint?: number,
-): Range | null {
-  const text = getTextContent(container);
-  const { exact, prefix, suffix } = selector;
-
-  // Collect ALL occurrences and score each by context. The position hint is a
-  // tiebreaker, not a search constraint — otherwise an occurrence earlier than
-  // the hint would be skipped (the bug uncovered by scenario N2).
-  let bestIndex = -1;
-  let bestScore = -1;
-  let bestDistance = Number.POSITIVE_INFINITY;
-
-  let index = text.indexOf(exact);
-  while (index !== -1) {
-    const score = scoreContext(text, index, exact.length, prefix, suffix);
-    const distance = positionHint === undefined ? 0 : Math.abs(index - positionHint);
-    if (score > bestScore || (score === bestScore && distance < bestDistance)) {
-      bestScore = score;
-      bestDistance = distance;
-      bestIndex = index;
-    }
-    index = text.indexOf(exact, index + 1);
-  }
-
-  if (bestIndex === -1) return null;
-
-  const start = findTextPosition(container, bestIndex);
-  const end = findTextPosition(container, bestIndex + exact.length);
-  if (!start || !end) return null;
-
-  try {
-    const range = document.createRange();
-    range.setStart(start.node, start.offset);
-    range.setEnd(end.node, end.offset);
-    return range;
-  } catch {
-    return null;
-  }
+interface ContextScore {
+  prefixScore: number;
+  suffixScore: number;
 }
 
 function scoreContext(
@@ -178,28 +186,135 @@ function scoreContext(
   length: number,
   prefix: string,
   suffix: string,
-): number {
-  let score = 0;
+): ContextScore {
+  let prefixScore = 0;
   const actualPrefix = text.slice(Math.max(0, index - prefix.length), index);
-  const actualSuffix = text.slice(index + length, index + length + suffix.length);
-
   for (let i = 0; i < Math.min(prefix.length, actualPrefix.length); i++) {
     if (prefix[prefix.length - 1 - i] === actualPrefix[actualPrefix.length - 1 - i]) {
-      score++;
+      prefixScore++;
     } else {
       break;
     }
   }
 
+  let suffixScore = 0;
+  const actualSuffix = text.slice(index + length, index + length + suffix.length);
   for (let i = 0; i < Math.min(suffix.length, actualSuffix.length); i++) {
     if (suffix[i] === actualSuffix[i]) {
-      score++;
+      suffixScore++;
     } else {
       break;
     }
   }
 
-  return score;
+  return { prefixScore, suffixScore };
+}
+
+// 4 chars rejects accidental single-space agreement (the lone-`-` case
+// scores 1 on each side because the bordering spaces happen to match)
+// while accepting a clear word boundary like "foo " (score 4).
+const MIN_CONTEXT_PER_SIDE = 4;
+
+// At ~8 chars an exact text carries enough identifying signal on its own
+// that one strong context side is sufficient; below that, the exact is
+// too common to trust without agreement on BOTH sides (`-`, `,`, `TODO`).
+const SHORT_QUOTE_LEN = 8;
+
+interface QuoteOccurrence {
+  index: number;
+  prefixScore: number;
+  suffixScore: number;
+}
+
+/**
+ * Search the live text for the best occurrence of `exact`. Returns the
+ * occurrence with the highest sum of per-side context scores (with
+ * position-hint distance as a tiebreaker) along with its per-side context
+ * scores, or null if `exact` is not present.
+ */
+function quoteBestOccurrence(
+  selector: Extract<Selector, { type: "TextQuoteSelector" }>,
+  container: HTMLElement,
+  positionHint?: number,
+): QuoteOccurrence | null {
+  const text = getTextContent(container);
+  const { exact, prefix, suffix } = selector;
+  // Empty exact would spin the loop below forever — indexOf("", n) returns n, never -1.
+  if (!exact) return null;
+
+  let best: QuoteOccurrence | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  let index = text.indexOf(exact);
+  while (index !== -1) {
+    const { prefixScore, suffixScore } = scoreContext(text, index, exact.length, prefix, suffix);
+    const distance = positionHint === undefined ? 0 : Math.abs(index - positionHint);
+    const currentSum = prefixScore + suffixScore;
+    const bestSum = best ? best.prefixScore + best.suffixScore : -1;
+    if (currentSum > bestSum || (currentSum === bestSum && distance < bestDistance)) {
+      best = { index, prefixScore, suffixScore };
+      bestDistance = distance;
+    }
+    index = text.indexOf(exact, index + 1);
+  }
+
+  return best;
+}
+
+/**
+ * Decide whether a quote occurrence has enough surrounding-context agreement
+ * to be trusted as the original passage.
+ *
+ *   - Short quotes (`exact.length` < SHORT_QUOTE_LEN): every RECORDED side
+ *     must agree to its achievable threshold. A side we didn't record is
+ *     vacuously ok — but a side we DID record cannot be brushed off.
+ *   - Long quotes (`exact.length` >= SHORT_QUOTE_LEN): at least one RECORDED
+ *     side must strongly agree. An empty side carries no evidence, so it
+ *     cannot be "the strong side."
+ *   - Both sides empty: accept unconditionally (no context to judge against).
+ *
+ * The achievable threshold for each side is
+ * `min(MIN_CONTEXT_PER_SIDE, recordedSide.length)` — a 2-char stored prefix
+ * (boundary selection, tiny article) saturates at 2 and shouldn't be held to
+ * a 4-char floor it can never reach.
+ */
+function isConfidentMatch(
+  occ: QuoteOccurrence,
+  exactLen: number,
+  prefix: string,
+  suffix: string,
+): boolean {
+  const havePrefix = prefix.length > 0;
+  const haveSuffix = suffix.length > 0;
+  if (!havePrefix && !haveSuffix) return true;
+
+  const prefixThreshold = Math.min(MIN_CONTEXT_PER_SIDE, prefix.length);
+  const suffixThreshold = Math.min(MIN_CONTEXT_PER_SIDE, suffix.length);
+
+  const prefixGood = havePrefix && occ.prefixScore >= prefixThreshold;
+  const suffixGood = haveSuffix && occ.suffixScore >= suffixThreshold;
+
+  if (exactLen < SHORT_QUOTE_LEN) {
+    const prefixOk = !havePrefix || prefixGood;
+    const suffixOk = !haveSuffix || suffixGood;
+    return prefixOk && suffixOk;
+  }
+  return prefixGood || suffixGood;
+}
+
+function rangeAtTextOffset(container: HTMLElement, start: number, end: number): Range | null {
+  const startPos = findTextPosition(container, start);
+  const endPos = findTextPosition(container, end);
+  if (!startPos || !endPos) return null;
+
+  try {
+    const range = document.createRange();
+    range.setStart(startPos.node, startPos.offset);
+    range.setEnd(endPos.node, endPos.offset);
+    return range;
+  } catch {
+    return null;
+  }
 }
 
 function fuzzyToRange(


### PR DESCRIPTION
## Summary

- Inline comments anchored to short or common text (`-`, `,`, `TODO`, single chars) used to silently migrate to unrelated occurrences after edits, displaying a confident solid-underline highlight on the wrong character with no UI signal.
- `selectorsToRange` now gates both the position fast-path and the quote-search path on a per-side context-confidence floor (`MIN_CONTEXT_PER_SIDE = 4`, `SHORT_QUOTE_LEN = 8`); non-confident matches skip inline placement and land in the existing orphan timeline at the bottom of the page (which already presents the original quote block with a clear "passage no longer appears" tooltip).
- Fuzzy fallback now fires only when the exact substring is absent from the document (typo fix inside the quote, paragraph split that dropped a space) — it no longer rescues weak-context exact matches to the same wrong place.

## How

- `scoreContext` returns `{prefixScore, suffixScore}` per side.
- `quoteBestOccurrence` ranks by sum-of-sides; `isConfidentMatch` enforces the floor: short quotes need every recorded side to agree, long quotes need at least one recorded side that strongly agrees. Empty stored sides count as "no evidence" rather than free-passes. The threshold clamps to `min(MIN_CONTEXT_PER_SIDE, recordedSide.length)` so boundary-truncated stored context can still saturate.
- Guard against `exact === ""` (`indexOf("", n)` returns `n`, never `-1` — would spin the loop forever).
- All resolution-order JSDoc and constant rationale updated.

## Trade-offs

- A long quote whose surrounding sentences were **both** rewritten in the same edit now shows as `fuzzy` (dashed underline) or orphan instead of confident `quote`. The reader still sees the comment; they get an honest signal instead of a misleading solid underline.
- Hypothesis's reference implementation has the same defect (acknowledged in their fuzzy-anchoring blog post) — this PR goes further than the W3C reference. Documented in the commit message.

## Test plan

- [x] 10 new regression tests in `packages/viewer/src/lib/anchoring.test.ts` under `describe("low-confidence demotion")` covering: lone `-`, lone `TODO`, strong-context short-quote, long quote with one strong side, both-sides-empty boundary selection, empty `exact` (would-have-hung), long quote with empty side + broken other side, short quote with empty prefix + broken suffix, verbatim match below threshold floor, position branch with disagreeing context.
- [x] All 20 pre-existing tests still pass (round-trip, N2 regression, fuzzy fallback, orphan-on-rewrite).
- [x] `make lint test` clean — Rust clippy, svelte-check, ESLint, full Vitest + cargo test suites.
- [ ] Browser smoke-test on a doc with short-quote inline comments before merging.