### PR TITLE
refactor(renderer): split state.rs by audience

### DIFF
--- a/crates/rw-renderer/src/html.rs
+++ b/crates/rw-renderer/src/html.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 
 use crate::backend::{AlertKind, RenderBackend};
-use crate::state::escape_html;
+use crate::util::escape_html;
 
 // SVG icons for alerts (GitHub Octicons-style, 16x16)
 const SVG_INFO: &str = r#"<svg class="alert-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>"#;

--- a/crates/rw-renderer/src/lib.rs
+++ b/crates/rw-renderer/src/lib.rs
@@ -125,9 +125,10 @@ mod html;
 mod renderer;
 mod scope;
 mod search_document;
-mod state;
 mod status;
+mod table;
 pub(crate) mod tabs;
+mod toc;
 mod util;
 mod walker;
 
@@ -148,6 +149,7 @@ pub use renderer::{MarkdownRenderer, RenderResult};
 /// configuration.
 pub use rw_sections::Sections;
 pub use search_document::SearchDocumentBackend;
-pub use state::{TocEntry, escape_html};
 pub use status::{StatusColor, StatusDirective};
 pub use tabs::TabsDirective;
+pub use toc::TocEntry;
+pub use util::escape_html;

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -12,7 +12,7 @@ use crate::backend::RenderBackend;
 use crate::code_block::CodeBlockProcessor;
 use crate::config::{RenderConfig, TitleResolver};
 use crate::directive::DirectiveProcessor;
-use crate::state::TocEntry;
+use crate::toc::TocEntry;
 
 /// Output produced by [`MarkdownRenderer::render`] or [`MarkdownRenderer::render_markdown`].
 ///

--- a/crates/rw-renderer/src/scope.rs
+++ b/crates/rw-renderer/src/scope.rs
@@ -8,7 +8,7 @@
 //! where to write.
 //!
 //! Cross-instance accumulators (TOC entries, title, `id_counts`,
-//! `seen_first_h1`) live on [`HeadingAccumulator`](crate::state::HeadingAccumulator),
+//! `seen_first_h1`) live on [`HeadingAccumulator`](crate::toc::HeadingAccumulator),
 //! not here.
 
 use std::collections::HashMap;

--- a/crates/rw-renderer/src/table.rs
+++ b/crates/rw-renderer/src/table.rs
@@ -1,0 +1,78 @@
+//! Walker-private state for tracking table rendering.
+
+use pulldown_cmark::Alignment;
+
+/// State for tracking table rendering.
+#[derive(Default)]
+pub(crate) struct TableState {
+    /// Whether we're inside the table header row.
+    in_head: bool,
+    /// Column alignments for current table.
+    alignments: Vec<Alignment>,
+    /// Current column index in table row.
+    cell_index: usize,
+}
+
+impl TableState {
+    /// Start a new table with column alignments.
+    pub fn start(&mut self, alignments: Vec<Alignment>) {
+        self.alignments = alignments;
+        self.in_head = false;
+        self.cell_index = 0;
+    }
+
+    /// Start the table header row.
+    pub fn start_head(&mut self) {
+        self.in_head = true;
+        self.cell_index = 0;
+    }
+
+    /// End the table header row.
+    pub fn end_head(&mut self) {
+        self.in_head = false;
+    }
+
+    /// Start a new table row.
+    pub fn start_row(&mut self) {
+        self.cell_index = 0;
+    }
+
+    /// Move to the next cell.
+    pub fn next_cell(&mut self) {
+        self.cell_index += 1;
+    }
+
+    /// Check if we're in the table header.
+    pub fn is_in_head(&self) -> bool {
+        self.in_head
+    }
+
+    /// Get the alignment for the current cell.
+    pub fn current_alignment(&self) -> Option<Alignment> {
+        self.alignments.get(self.cell_index).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_table_state() {
+        let mut state = TableState::default();
+        state.start(vec![Alignment::Left, Alignment::Center, Alignment::Right]);
+
+        state.start_head();
+        assert!(state.is_in_head());
+        assert_eq!(state.current_alignment(), Some(Alignment::Left));
+
+        state.next_cell();
+        assert_eq!(state.current_alignment(), Some(Alignment::Center));
+
+        state.next_cell();
+        assert_eq!(state.current_alignment(), Some(Alignment::Right));
+
+        state.end_head();
+        assert!(!state.is_in_head());
+    }
+}

--- a/crates/rw-renderer/src/tabs/directive.rs
+++ b/crates/rw-renderer/src/tabs/directive.rs
@@ -7,7 +7,7 @@ use std::fmt::Write;
 use crate::directive::{
     ContainerDirective, DirectiveArgs, DirectiveContext, DirectiveOutput, Replacements,
 };
-use crate::state::escape_html;
+use crate::util::escape_html;
 
 /// Metadata for a single tab within a tab group.
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/rw-renderer/src/toc.rs
+++ b/crates/rw-renderer/src/toc.rs
@@ -1,62 +1,14 @@
-//! Shared state structs for markdown rendering.
+//! Table of contents output type and heading accumulator.
 //!
-//! These structs track context during event processing and are shared
-//! between HTML and Confluence backends.
+//! [`TocEntry`] is the public output type collected in
+//! [`RenderResult::toc`](crate::RenderResult::toc).
+//! [`HeadingAccumulator`] is walker-private scratch that tracks
+//! cross-heading state (title, TOC entries, id-counts, and the
+//! "have we seen the first H1?" flag) across an entire document render.
 
 use std::collections::HashMap;
 
-use pulldown_cmark::Alignment;
-
-/// State for tracking table rendering.
-#[derive(Default)]
-pub(crate) struct TableState {
-    /// Whether we're inside the table header row.
-    in_head: bool,
-    /// Column alignments for current table.
-    alignments: Vec<Alignment>,
-    /// Current column index in table row.
-    cell_index: usize,
-}
-
-impl TableState {
-    /// Start a new table with column alignments.
-    pub fn start(&mut self, alignments: Vec<Alignment>) {
-        self.alignments = alignments;
-        self.in_head = false;
-        self.cell_index = 0;
-    }
-
-    /// Start the table header row.
-    pub fn start_head(&mut self) {
-        self.in_head = true;
-        self.cell_index = 0;
-    }
-
-    /// End the table header row.
-    pub fn end_head(&mut self) {
-        self.in_head = false;
-    }
-
-    /// Start a new table row.
-    pub fn start_row(&mut self) {
-        self.cell_index = 0;
-    }
-
-    /// Move to the next cell.
-    pub fn next_cell(&mut self) {
-        self.cell_index += 1;
-    }
-
-    /// Check if we're in the table header.
-    pub fn is_in_head(&self) -> bool {
-        self.in_head
-    }
-
-    /// Get the alignment for the current cell.
-    pub fn current_alignment(&self) -> Option<Alignment> {
-        self.alignments.get(self.cell_index).copied()
-    }
-}
+use crate::util::slugify;
 
 /// A single heading in the table of contents.
 ///
@@ -118,7 +70,7 @@ pub(crate) struct CompletedHeading {
 ///
 /// Per-heading state (the heading's level, plain-text shadow, formatted
 /// HTML body, and the `in_first_h1` flag) lives in
-/// [`Scope::Heading`](crate::renderer::Scope) — *not* here. The
+/// [`Scope::Heading`](crate::scope::Scope) — *not* here. The
 /// accumulator is consulted at `Tag::Heading` start (to decide whether
 /// the heading is the skipped Confluence first H1) and at
 /// `TagEnd::Heading` (to capture the title and/or emit the heading).
@@ -235,118 +187,9 @@ impl HeadingAccumulator {
     }
 }
 
-/// Convert text to URL-safe slug.
-///
-/// Converts to lowercase, replaces whitespace/dashes/underscores with single dashes,
-/// and removes other non-alphanumeric characters. Preserves non-Latin Unicode characters
-/// (Cyrillic, CJK, etc.) following GitHub-style heading ID generation.
-#[must_use]
-fn slugify(text: &str) -> String {
-    let mut result = String::new();
-    let mut last_was_dash = true; // Prevents leading dash
-
-    for c in text.trim().chars() {
-        if c.is_alphanumeric() {
-            for lc in c.to_lowercase() {
-                result.push(lc);
-            }
-            last_was_dash = false;
-        } else if !last_was_dash && (c.is_whitespace() || c == '-' || c == '_') {
-            result.push('-');
-            last_was_dash = true;
-        }
-    }
-
-    // Remove trailing dash if present
-    if result.ends_with('-') {
-        result.pop();
-    }
-
-    result
-}
-
-/// Escapes the five HTML special characters (`&`, `<`, `>`, `"`, `'`).
-///
-/// # Examples
-///
-/// ```
-/// use rw_renderer::escape_html;
-///
-/// assert_eq!(escape_html("<script>"), "&lt;script&gt;");
-/// assert_eq!(escape_html(r#"a "b" & 'c'"#), "a &quot;b&quot; &amp; &#x27;c&#x27;");
-/// ```
-#[must_use]
-pub fn escape_html(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '&' => result.push_str("&amp;"),
-            '<' => result.push_str("&lt;"),
-            '>' => result.push_str("&gt;"),
-            '"' => result.push_str("&quot;"),
-            '\'' => result.push_str("&#x27;"),
-            _ => result.push(c),
-        }
-    }
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_slugify() {
-        assert_eq!(slugify("Hello World"), "hello-world");
-        assert_eq!(slugify("What's New?"), "whats-new");
-        assert_eq!(slugify("  Spaces  "), "spaces");
-        assert_eq!(slugify("Multiple   Spaces"), "multiple-spaces");
-        assert_eq!(slugify("kebab-case"), "kebab-case");
-        assert_eq!(slugify("snake_case"), "snake-case");
-    }
-
-    #[test]
-    fn test_slugify_non_latin() {
-        // Cyrillic
-        assert_eq!(slugify("Привет мир"), "привет-мир");
-        // Chinese
-        assert_eq!(slugify("你好世界"), "你好世界");
-        // Japanese
-        assert_eq!(slugify("こんにちは世界"), "こんにちは世界");
-        // Mixed Latin and non-Latin
-        assert_eq!(slugify("Hello Привет"), "hello-привет");
-        // Non-Latin with punctuation
-        assert_eq!(slugify("Привет, мир!"), "привет-мир");
-        // Fully non-Latin should NOT produce empty string
-        assert!(!slugify("Заголовок").is_empty());
-    }
-
-    #[test]
-    fn test_escape_html() {
-        assert_eq!(escape_html("<script>"), "&lt;script&gt;");
-        assert_eq!(escape_html("a & b"), "a &amp; b");
-        assert_eq!(escape_html(r#""quoted""#), "&quot;quoted&quot;");
-        assert_eq!(escape_html("it's"), "it&#x27;s");
-    }
-
-    #[test]
-    fn test_table_state() {
-        let mut state = TableState::default();
-        state.start(vec![Alignment::Left, Alignment::Center, Alignment::Right]);
-
-        state.start_head();
-        assert!(state.is_in_head());
-        assert_eq!(state.current_alignment(), Some(Alignment::Left));
-
-        state.next_cell();
-        assert_eq!(state.current_alignment(), Some(Alignment::Center));
-
-        state.next_cell();
-        assert_eq!(state.current_alignment(), Some(Alignment::Right));
-
-        state.end_head();
-        assert!(!state.is_in_head());
-    }
 
     #[test]
     fn test_heading_accumulator_html_mode() {

--- a/crates/rw-renderer/src/util.rs
+++ b/crates/rw-renderer/src/util.rs
@@ -14,3 +14,98 @@ pub(crate) fn heading_level_to_num(level: HeadingLevel) -> u8 {
         HeadingLevel::H6 => 6,
     }
 }
+
+/// Convert text to URL-safe slug.
+///
+/// Converts to lowercase, replaces whitespace/dashes/underscores with single dashes,
+/// and removes other non-alphanumeric characters. Preserves non-Latin Unicode characters
+/// (Cyrillic, CJK, etc.) following GitHub-style heading ID generation.
+#[must_use]
+pub(crate) fn slugify(text: &str) -> String {
+    let mut result = String::new();
+    let mut last_was_dash = true; // Prevents leading dash
+
+    for c in text.trim().chars() {
+        if c.is_alphanumeric() {
+            for lc in c.to_lowercase() {
+                result.push(lc);
+            }
+            last_was_dash = false;
+        } else if !last_was_dash && (c.is_whitespace() || c == '-' || c == '_') {
+            result.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    // Remove trailing dash if present
+    if result.ends_with('-') {
+        result.pop();
+    }
+
+    result
+}
+
+/// Escapes the five HTML special characters (`&`, `<`, `>`, `"`, `'`).
+///
+/// # Examples
+///
+/// ```
+/// use rw_renderer::escape_html;
+///
+/// assert_eq!(escape_html("<script>"), "&lt;script&gt;");
+/// assert_eq!(escape_html(r#"a "b" & 'c'"#), "a &quot;b&quot; &amp; &#x27;c&#x27;");
+/// ```
+#[must_use]
+pub fn escape_html(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => result.push_str("&amp;"),
+            '<' => result.push_str("&lt;"),
+            '>' => result.push_str("&gt;"),
+            '"' => result.push_str("&quot;"),
+            '\'' => result.push_str("&#x27;"),
+            _ => result.push(c),
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slugify() {
+        assert_eq!(slugify("Hello World"), "hello-world");
+        assert_eq!(slugify("What's New?"), "whats-new");
+        assert_eq!(slugify("  Spaces  "), "spaces");
+        assert_eq!(slugify("Multiple   Spaces"), "multiple-spaces");
+        assert_eq!(slugify("kebab-case"), "kebab-case");
+        assert_eq!(slugify("snake_case"), "snake-case");
+    }
+
+    #[test]
+    fn test_slugify_non_latin() {
+        // Cyrillic
+        assert_eq!(slugify("Привет мир"), "привет-мир");
+        // Chinese
+        assert_eq!(slugify("你好世界"), "你好世界");
+        // Japanese
+        assert_eq!(slugify("こんにちは世界"), "こんにちは世界");
+        // Mixed Latin and non-Latin
+        assert_eq!(slugify("Hello Привет"), "hello-привет");
+        // Non-Latin with punctuation
+        assert_eq!(slugify("Привет, мир!"), "привет-мир");
+        // Fully non-Latin should NOT produce empty string
+        assert!(!slugify("Заголовок").is_empty());
+    }
+
+    #[test]
+    fn test_escape_html() {
+        assert_eq!(escape_html("<script>"), "&lt;script&gt;");
+        assert_eq!(escape_html("a & b"), "a &amp; b");
+        assert_eq!(escape_html(r#""quoted""#), "&quot;quoted&quot;");
+        assert_eq!(escape_html("it's"), "it&#x27;s");
+    }
+}

--- a/crates/rw-renderer/src/walker.rs
+++ b/crates/rw-renderer/src/walker.rs
@@ -33,7 +33,8 @@ use crate::directive::DirectiveProcessor;
 use crate::directive::parser::{ParsedDirective, parse_line};
 use crate::renderer::RenderResult;
 use crate::scope::Scope;
-use crate::state::{HeadingAccumulator, TableState};
+use crate::table::TableState;
+use crate::toc::HeadingAccumulator;
 use crate::util::heading_level_to_num;
 
 pub(crate) struct Walker<'r, B: RenderBackend> {


### PR DESCRIPTION
## Summary

- Untangles `crates/rw-renderer/src/state.rs` (which mixed a public output type, walker-private scratch, and pure utilities) into three focused modules: `util.rs` (gains `escape_html` + `slugify`), `toc.rs` (`TocEntry` + `CompletedHeading` + `HeadingAccumulator`), and `table.rs` (`TableState`). `state.rs` is deleted.
- No public API change. `rw_renderer::TocEntry` and `rw_renderer::escape_html` keep their crate-root paths, so `rw-kroki` (the only external consumer of `escape_html`) compiles untouched. Tests move with the items they cover.
- Drive-by fix: stale intra-doc link `[`Scope::Heading`](crate::renderer::Scope)` → `crate::scope::Scope` (Scope moved to its own module in an earlier refactor; this was a hard error under `-D rustdoc::broken_intra_doc_links`).

## Test plan

- [x] `cargo test -p rw-renderer` — 327 unit + 29 doctests pass
- [x] `cargo test -p rw-kroki -p rw-confluence -p rw-server` — downstream consumers green
- [x] `cargo build --workspace`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p rw-renderer --no-deps --document-private-items` — only the pre-existing `InlineDirectiveStream` link remains (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)