### PR TITLE
build: declare rw-napi as its own workspace so worktree builds work

### DIFF
--- a/crates/rw-napi/Cargo.toml
+++ b/crates/rw-napi/Cargo.toml
@@ -1,3 +1,13 @@
+# Standalone workspace. The root workspace at ../../Cargo.toml excludes this
+# crate (cdylib can't build for musl via `cargo --workspace`). Declaring an
+# empty [workspace] here stops cargo's upward walk from finding an ancestor
+# workspace — without it, `cargo` and `napi build` get confused when the repo
+# is checked out as a git worktree nested under another copy of the repo: the
+# upward walk finds the outer copy's Cargo.toml, which excludes us by relative
+# path but then treats us as "under its tree but not a member". See
+# rust-lang/cargo#16911 and #6745.
+[workspace]
+
 [package]
 name = "rw-napi"
 description = "NAPI native addon exposing RW core to Node.js"


### PR DESCRIPTION
## Summary

- Add an empty `[workspace]` table to `crates/rw-napi/Cargo.toml` so cargo treats rw-napi as a standalone workspace root.
- Unblocks building rw-napi from a git worktree nested inside another copy of the repo (e.g. `.claude/worktrees/<name>/`) — which currently fails with `current package believes it's in a workspace when it's not`.
- No behavioural change for builds at the canonical repo path or in CI.

## Why

The root workspace excludes `crates/rw-napi` because the cdylib can't be built for musl via `cargo --workspace`. At the canonical repo path, cargo walks up from rw-napi, finds the root `Cargo.toml`, sees the matching exclude, and proceeds as standalone.

In a nested-worktree layout, cargo's upward walk continues past the worktree's own `Cargo.toml` (which excludes rw-napi by relative path) and lands on the outer copy's `Cargo.toml`. That workspace's `exclude = [\"crates/rw-napi\"]` doesn't match the deeply-nested path, so rw-napi ends up "under the workspace but not a member" and the build aborts.

Adding `[workspace]` to rw-napi's manifest stops the upward walk at the crate itself — the workaround the cargo team documents for this exact case: rust-lang/cargo#16911, rust-lang/cargo#6745.

## Test plan

- [x] \`cargo check --manifest-path crates/rw-napi/Cargo.toml\` builds cleanly from a worktree (fails on \`main\`)
- [x] \`cargo metadata --no-deps\` at the root still returns the 18 non-napi crates (rw-napi correctly absent)
- [x] \`cargo metadata --manifest-path crates/rw-napi/Cargo.toml\` returns rw-napi as its own workspace
- [ ] CI workflows pass — \`ci.yml\` (root cargo fmt/clippy/test/build), \`build-npm.yml\` (\`npm -w @rwdocs/core run build\` → \`napi build\`), \`publish-npm.yml\`, \`release.yml\` (cargo-dist at root)