### PR TITLE
chore(deps): remove orphaned OAuth dependencies (sha1, rsa, percent-encoding, rand)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,11 +53,6 @@ tempfile = "3"
 tracing = "0.1"
 ureq = { version = "3", features = ["rustls", "json"] }
 
-# OAuth 1.0 RSA-SHA1
-rsa = { version = "0.9", features = ["pem", "sha1"] }
-sha1 = { version = "0.10", features = ["oid"] }
-percent-encoding = "2.3"
-rand = "0.10"
 shellexpand = "3"
 
 # Benchmarking


### PR DESCRIPTION
## What

Removes four orphaned `[workspace.dependencies]` from the root `Cargo.toml`:

- `sha1`
- `rsa`
- `percent-encoding`
- `rand`

## Why

The Confluence render-only refactor (8b9d2db) deleted the `rw-confluence` OAuth module, which was the **sole consumer** of `sha1` and `rsa` (OAuth 1.0 RSA-SHA1 request signing). The neighbouring `percent-encoding` (signature base-string encoding) and `rand` (nonce generation) deps were OAuth-era leftovers too.

I audited every external workspace dep against every `workspace = true` reference across all member crates (and grepped source as a backstop): these four are referenced by **no crate and no source file**. Every other workspace dep is in active use.

## Notes

- These were *unreferenced* `workspace.dependencies`, so they never appeared in `Cargo.lock` — **the lockfile is unchanged**.
- `sha1` remains in the dependency tree transitively via `aws-sdk-s3` / `aws-config` / `axum` / `gix`; that is unaffected.
- This makes the pending Renovate bump #245 (`sha1` 0.10 → 0.11) moot — that PR can be closed rather than merged.

## Verification

- `cargo check --workspace --all-targets` ✅
- `make build` (vite frontend + release Rust CLI) ✅ exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)