### PR TITLE
build: upgrade to Rust 1.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Minimum supported Rust version raised to 1.96 — downstream crates embedding `rw-renderer` (or any other `rw-*` crate) now need a 1.96+ toolchain to build
 - Page outline (TOC) sidebar widened from 240px to 320px so that opening a comment no longer narrows the article or shifts text sideways; the sidebar now appears at viewport widths ≥ 1304px instead of ≥ 1224px (narrower viewports get the floating "On this page" popover as before)
 - Page modification times (`lastModified` in API responses) now reflect the git commit time instead of the filesystem modification time — timestamps remain stable across `git checkout`, `git pull`, and branch switching
 - S3-published documentation bundles now include page modification times in the manifest — previously `lastModified` was always epoch zero for Backstage-served pages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["crates/rw-napi"]
 [workspace.package]
 version = "0.1.24"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.96"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/crates/rw-comments/src/anchoring.rs
+++ b/crates/rw-comments/src/anchoring.rs
@@ -108,6 +108,7 @@ mod tests {
     use rw_storage::MockStorage;
 
     use super::*;
+    use std::assert_matches;
 
     fn seeded_site(path: &str, markdown: &str) -> Site {
         let storage = Arc::new(
@@ -155,7 +156,7 @@ mod tests {
         let site = seeded_site("guide", "# Guide\n\nSome body text.\n");
 
         let err = resolve_quote(&site, "guide", "missing quote").unwrap_err();
-        assert!(matches!(err, QuoteResolutionError::NotFound { .. }));
+        assert_matches!(err, QuoteResolutionError::NotFound { .. });
     }
 
     #[test]
@@ -174,7 +175,7 @@ mod tests {
         let site = seeded_site("guide", "# Guide\n");
 
         let err = resolve_quote(&site, "nope", "anything").unwrap_err();
-        assert!(matches!(err, QuoteResolutionError::DocumentNotFound { .. }));
+        assert_matches!(err, QuoteResolutionError::DocumentNotFound { .. });
     }
 
     #[test]
@@ -198,7 +199,7 @@ mod tests {
         let site = seeded_site("guide", "This is **bold** text.\n");
 
         let err = resolve_quote(&site, "guide", "**bold**").unwrap_err();
-        assert!(matches!(err, QuoteResolutionError::NotFound { .. }));
+        assert_matches!(err, QuoteResolutionError::NotFound { .. });
     }
 
     #[test]

--- a/crates/rw-comments/src/sqlite.rs
+++ b/crates/rw-comments/src/sqlite.rs
@@ -279,6 +279,7 @@ mod tests {
     use crate::model::{
         Author, CommentFilter, CommentStatus, CreateComment, Selector, UpdateComment,
     };
+    use std::assert_matches;
 
     async fn store() -> SqliteCommentStore {
         SqliteCommentStore::open_memory().await.unwrap()
@@ -408,7 +409,7 @@ mod tests {
         let store = store().await;
         let result = store.get(Uuid::new_v4()).await;
 
-        assert!(matches!(result, Err(StoreError::NotFound(_))));
+        assert_matches!(result, Err(StoreError::NotFound(_)));
     }
 
     #[tokio::test]

--- a/crates/rw-config/src/expand.rs
+++ b/crates/rw-config/src/expand.rs
@@ -43,6 +43,7 @@ struct LookupError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn test_expand_simple_var() {
@@ -89,7 +90,7 @@ mod tests {
         let result = expand_env("${MISSING_VAR_TEST}", "test.field");
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, ConfigError::EnvVar { .. }));
+        assert_matches!(err, ConfigError::EnvVar { .. });
         assert!(err.to_string().contains("MISSING_VAR_TEST"));
         assert!(err.to_string().contains("test.field"));
     }

--- a/crates/rw-config/src/lib.rs
+++ b/crates/rw-config/src/lib.rs
@@ -478,6 +478,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     /// Serializes tests that mutate `RW_DIAGRAMS_KROKI_URL`. The process env is
     /// shared across cargo's parallel tests, so any test that touches this
@@ -846,7 +847,7 @@ kroki_url = "${MISSING_VAR_CONFIG_TEST}"
 
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, ConfigError::EnvVar { .. }));
+        assert_matches!(err, ConfigError::EnvVar { .. });
         assert!(err.to_string().contains("MISSING_VAR_CONFIG_TEST"));
         assert!(err.to_string().contains("diagrams.kroki_url"));
     }
@@ -1040,7 +1041,7 @@ host = "127.0.0.1"
         let (_dir, toml_path) = rw_toml_tempdir("bad-env", "");
         let err = Config::load(Some(&toml_path), None)
             .expect_err("invalid env URL should fail validation");
-        assert!(matches!(err, ConfigError::Validation(_)));
+        assert_matches!(err, ConfigError::Validation(_));
         let msg = err.to_string();
         assert!(msg.contains("kroki_url"), "got error: {msg}");
     }

--- a/crates/rw-kroki/src/output.rs
+++ b/crates/rw-kroki/src/output.rs
@@ -104,6 +104,7 @@ impl std::fmt::Debug for DiagramOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     fn img_tag_generator(prefix: &str) -> TagGenerator {
         let prefix = prefix.to_owned();
@@ -163,7 +164,7 @@ mod tests {
     #[test]
     fn test_diagram_output_default() {
         let output = DiagramOutput::default();
-        assert!(matches!(output, DiagramOutput::Inline));
+        assert_matches!(output, DiagramOutput::Inline);
     }
 
     #[test]

--- a/crates/rw-kroki/src/search.rs
+++ b/crates/rw-kroki/src/search.rs
@@ -125,6 +125,7 @@ mod tests {
     use rw_renderer::ProcessResult;
 
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn strips_plantuml_boilerplate() {
@@ -148,7 +149,7 @@ mod tests {
     fn non_diagram_passes_through() {
         let mut processor = SearchDiagramProcessor::new(vec![]);
         let result = processor.process("python", &HashMap::new(), "def hello(): pass", 0);
-        assert!(matches!(result, ProcessResult::PassThrough));
+        assert_matches!(result, ProcessResult::PassThrough);
     }
 
     #[test]

--- a/crates/rw-napi/Cargo.toml
+++ b/crates/rw-napi/Cargo.toml
@@ -13,7 +13,7 @@ name = "rw-napi"
 description = "NAPI native addon exposing RW core to Node.js"
 version = "0.1.24"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.96"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/crates/rw-renderer/src/directive/container.rs
+++ b/crates/rw-renderer/src/directive/container.rs
@@ -91,6 +91,7 @@ pub trait ContainerDirective: Send {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use std::path::Path;
 
     struct TestNote;
@@ -163,7 +164,7 @@ mod tests {
         let args = DirectiveArgs::parse("Important", "");
         let output = note.start(args, &ctx);
 
-        assert!(matches!(output, DirectiveOutput::Html(s) if s.contains("Important")));
+        assert_matches!(output, DirectiveOutput::Html(s) if s.contains("Important"));
     }
 
     #[test]
@@ -187,7 +188,7 @@ mod tests {
         // Start directive
         let args = DirectiveArgs::parse("Click to expand", "");
         let start_output = details.start(args, &ctx);
-        assert!(matches!(start_output, DirectiveOutput::Html(s) if s.contains("Click to expand")));
+        assert_matches!(start_output, DirectiveOutput::Html(s) if s.contains("Click to expand"));
 
         // End directive
         let end_output = details.end(10);

--- a/crates/rw-renderer/src/directive/leaf.rs
+++ b/crates/rw-renderer/src/directive/leaf.rs
@@ -78,6 +78,7 @@ pub trait LeafDirective: Send {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use std::path::Path;
 
     struct TestYoutube;
@@ -158,7 +159,7 @@ mod tests {
         let args = DirectiveArgs::parse("dQw4w9WgXcQ", "");
         let output = youtube.process(args, &ctx);
 
-        assert!(matches!(output, DirectiveOutput::Html(s) if s.contains("dQw4w9WgXcQ")));
+        assert_matches!(output, DirectiveOutput::Html(s) if s.contains("dQw4w9WgXcQ"));
     }
 
     #[test]

--- a/crates/rw-renderer/src/directive/output.rs
+++ b/crates/rw-renderer/src/directive/output.rs
@@ -123,6 +123,7 @@ impl DirectiveOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn test_html() {
@@ -146,6 +147,6 @@ mod tests {
     fn test_html_from_string() {
         let s = String::from("<div>content</div>");
         let output = DirectiveOutput::html(s);
-        assert!(matches!(output, DirectiveOutput::Html(_)));
+        assert_matches!(output, DirectiveOutput::Html(_));
     }
 }

--- a/crates/rw-renderer/src/link.rs
+++ b/crates/rw-renderer/src/link.rs
@@ -43,6 +43,7 @@ pub(crate) fn section_ref_attrs(cfg: &RenderConfig, href: &str) -> Option<(Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     fn cfg() -> RenderConfig {
         RenderConfig::new()
@@ -53,7 +54,7 @@ mod tests {
         let c = cfg();
         let result = strip_origin(&c, "docs/guide.md");
         assert_eq!(result, "docs/guide.md");
-        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_matches!(result, Cow::Borrowed(_));
     }
 
     #[test]
@@ -62,7 +63,7 @@ mod tests {
         c.origin_prefix = Some("docs/".to_owned());
         let result = strip_origin(&c, "docs/guide.md");
         assert_eq!(result, "guide.md");
-        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_matches!(result, Cow::Borrowed(_));
     }
 
     #[test]
@@ -71,7 +72,7 @@ mod tests {
         c.origin_prefix = Some("docs/".to_owned());
         let result = strip_origin(&c, "other/page.md");
         assert_eq!(result, "other/page.md");
-        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_matches!(result, Cow::Borrowed(_));
     }
 
     #[test]

--- a/crates/rw-renderer/src/pipeline.rs
+++ b/crates/rw-renderer/src/pipeline.rs
@@ -175,7 +175,7 @@ mod tests {
                 _args: DirectiveArgs,
                 _ctx: &DirectiveContext,
             ) -> DirectiveOutput {
-                DirectiveOutput::html("<ALPHA>".to_string())
+                DirectiveOutput::html("<ALPHA>")
             }
         }
         struct BetaTag;
@@ -188,7 +188,7 @@ mod tests {
                 _args: DirectiveArgs,
                 _ctx: &DirectiveContext,
             ) -> DirectiveOutput {
-                DirectiveOutput::html("<BETA>".to_string())
+                DirectiveOutput::html("<BETA>")
             }
         }
 

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -1170,18 +1170,19 @@ Install with apt.
         // I/O). The metadata short-circuit lives in process_event's Event::Text
         // arm; flush_text would otherwise dispatch to handlers regardless of
         // active scope.
-        use std::sync::{Arc, Mutex};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
         use crate::directive::{
             DirectiveArgs, DirectiveContext, DirectiveOutput, DirectiveProcessor, InlineDirective,
         };
 
         struct CountingDirective {
-            calls: Arc<Mutex<usize>>,
+            calls: Arc<AtomicUsize>,
         }
 
         impl InlineDirective for CountingDirective {
-            fn name(&self) -> &str {
+            fn name(&self) -> &'static str {
                 "track"
             }
             fn process(
@@ -1189,12 +1190,12 @@ Install with apt.
                 _args: DirectiveArgs,
                 _ctx: &DirectiveContext,
             ) -> DirectiveOutput {
-                *self.calls.lock().unwrap() += 1;
+                self.calls.fetch_add(1, Ordering::Relaxed);
                 DirectiveOutput::Html(String::new())
             }
         }
 
-        let calls = Arc::new(Mutex::new(0));
+        let calls = Arc::new(AtomicUsize::new(0));
         let processor = DirectiveProcessor::new().with_inline(CountingDirective {
             calls: Arc::clone(&calls),
         });
@@ -1206,7 +1207,7 @@ Install with apt.
 
         // Exactly one invocation expected — from the body heading, not from frontmatter.
         assert_eq!(
-            *calls.lock().unwrap(),
+            calls.load(Ordering::Relaxed),
             1,
             "directive handler should be invoked once (from body), not from frontmatter"
         );
@@ -1684,7 +1685,7 @@ Install with apt.
     }
 
     /// Reused renderer must reset per-render state — `TITLE_AS_METADATA = true`
-    /// backends (Confluence, SearchDocument).
+    /// backends (Confluence, `SearchDocument`).
     ///
     /// Pre-refactor, `HeadingAccumulator::seen_first_h1` stayed true across
     /// renders, so the second render's first H1 was no longer recognized
@@ -1815,7 +1816,7 @@ Install with apt.
                 _source: &str,
                 _index: usize,
             ) -> ProcessResult {
-                assert!(language != "explode", "intentional panic for test",);
+                assert!(language != "explode", "intentional panic for test");
                 ProcessResult::PassThrough
             }
         }

--- a/crates/rw-server/src/live_reload/manager.rs
+++ b/crates/rw-server/src/live_reload/manager.rs
@@ -155,6 +155,7 @@ impl LiveReloadManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     use rw_site::PageRendererConfig;
     use rw_storage::{MockStorage, StorageErrorKind, StorageEvent};
@@ -225,7 +226,7 @@ mod tests {
         let event = rx
             .try_recv()
             .expect("Created should broadcast Structure even when reload would fail");
-        assert!(matches!(event.event_type, ReloadEventType::Structure));
+        assert_matches!(event.event_type, ReloadEventType::Structure);
         assert_eq!(event.path, "/foo");
         assert!(
             rx.try_recv().is_err(),
@@ -262,7 +263,7 @@ mod tests {
         );
 
         let event = rx.try_recv().expect("Created should broadcast Structure");
-        assert!(matches!(event.event_type, ReloadEventType::Structure));
+        assert_matches!(event.event_type, ReloadEventType::Structure);
         assert_eq!(event.path, "/foo");
         assert!(
             rx.try_recv().is_err(),

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -515,6 +515,7 @@ mod tests {
     use rw_storage::MockStorage;
 
     use super::*;
+    use std::assert_matches;
 
     fn create_renderer(storage: MockStorage) -> PageRenderer {
         let config = PageRendererConfig::default();
@@ -578,7 +579,7 @@ mod tests {
         let page = make_page("Missing", "missing", true);
         let result = renderer.render("missing", &page, vec![], &RenderContext::default());
 
-        assert!(matches!(result, Err(RenderError::FileNotFound(_))));
+        assert_matches!(result, Err(RenderError::FileNotFound(_)));
     }
 
     #[test]
@@ -742,7 +743,7 @@ mod tests {
         let page = make_page("Missing", "missing", true);
         let result = renderer.render_search_document("missing", &page, &RenderContext::default());
 
-        assert!(matches!(result, Err(RenderError::FileNotFound(_))));
+        assert_matches!(result, Err(RenderError::FileNotFound(_)));
     }
 
     #[test]

--- a/crates/rw-site/src/site.rs
+++ b/crates/rw-site/src/site.rs
@@ -575,6 +575,7 @@ mod tests {
 
     use super::*;
     use crate::page::RenderError;
+    use std::assert_matches;
 
     fn create_site_with_storage(storage: MockStorage) -> Site {
         let config = PageRendererConfig::default();
@@ -880,7 +881,7 @@ mod tests {
         let site = create_site_with_storage(storage);
 
         let result = site.render("nonexistent");
-        assert!(matches!(result, Err(RenderError::PageNotFound(_))));
+        assert_matches!(result, Err(RenderError::PageNotFound(_)));
     }
 
     #[test]
@@ -1293,7 +1294,7 @@ mod tests {
         let site = create_site_with_storage(storage);
 
         let result = site.render("test");
-        assert!(matches!(result, Err(RenderError::Storage(_))));
+        assert_matches!(result, Err(RenderError::Storage(_)));
     }
 
     #[test]

--- a/crates/rw-storage-fs/src/lib.rs
+++ b/crates/rw-storage-fs/src/lib.rs
@@ -745,6 +745,7 @@ impl Storage for FsStorage {
 mod tests {
     use super::*;
     use rw_storage::StorageErrorKind;
+    use std::assert_matches;
 
     fn assert_send_sync<T: Send + Sync>() {}
 
@@ -1448,7 +1449,7 @@ mod tests {
         assert!(event.is_some(), "Expected to receive event");
         let event = event.unwrap();
         assert_eq!(event.path, "existing");
-        assert!(matches!(event.kind, StorageEventKind::Modified { .. }));
+        assert_matches!(event.kind, StorageEventKind::Modified { .. });
     }
 
     #[test]
@@ -1533,10 +1534,7 @@ mod tests {
         // Should receive only one modified event
         let event = rx.try_recv();
         assert!(event.is_some(), "Expected to receive event");
-        assert!(matches!(
-            event.unwrap().kind,
-            StorageEventKind::Modified { .. }
-        ));
+        assert_matches!(event.unwrap().kind, StorageEventKind::Modified { .. });
 
         // No more events
         let event = rx.try_recv();

--- a/crates/rw-storage/src/mock.rs
+++ b/crates/rw-storage/src/mock.rs
@@ -417,6 +417,7 @@ impl Storage for MockStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     fn assert_send_sync<T: Send + Sync>() {}
 
@@ -633,7 +634,7 @@ mod tests {
         assert!(event.is_some());
         let event = event.unwrap();
         assert_eq!(event.path, "guide");
-        assert!(matches!(event.kind, StorageEventKind::Modified { .. }));
+        assert_matches!(event.kind, StorageEventKind::Modified { .. });
     }
 
     #[test]
@@ -666,7 +667,7 @@ mod tests {
         assert_eq!(events[0].kind, StorageEventKind::Created);
 
         assert_eq!(events[1].path, "b");
-        assert!(matches!(events[1].kind, StorageEventKind::Modified { .. }));
+        assert_matches!(events[1].kind, StorageEventKind::Modified { .. });
 
         assert_eq!(events[2].path, "c");
         assert_eq!(events[2].kind, StorageEventKind::Removed);

--- a/crates/rw/src/commands/comment/identity.rs
+++ b/crates/rw/src/commands/comment/identity.rs
@@ -32,6 +32,7 @@ pub(crate) fn resolve_author(
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use std::assert_matches;
 
     #[test]
     fn both_set_returns_author() {
@@ -53,17 +54,17 @@ mod tests {
 
     #[test]
     fn id_without_name_is_error() {
-        assert!(matches!(
+        assert_matches!(
             resolve_author(Some("local:claude-code"), None),
             Err(CliError::Validation(_))
-        ));
+        );
     }
 
     #[test]
     fn name_without_id_is_error() {
-        assert!(matches!(
+        assert_matches!(
             resolve_author(None, Some("Claude Code")),
             Err(CliError::Validation(_))
-        ));
+        );
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
Upgrades the project to Rust 1.96.

## Changes

- **Toolchain & MSRV:** `rust-toolchain.toml` pin → `1.96.0`; workspace `rust-version` (and the workspace-excluded `rw-napi` crate) → `1.96`.
- **`assert_matches!` migration:** 28 test-code `assert!(matches!(X, PAT))` sites converted to the newly-stabilized `assert_matches!(X, PAT)` across 8 crates (each module imports `use std::assert_matches;`). Match guards and multi-line forms preserved; the macro prints the actual value on mismatch. The 3 doc-comment examples in `rw-renderer` are intentionally left as `assert!(matches!(…))`.
- **Clippy 1.96 cleanup:** clears the new pedantic/restriction warnings the newer toolchain surfaces in pre-existing `rw-renderer` test code — `Arc<Mutex<usize>>` counter → `Arc<AtomicUsize>`, dropped redundant `.to_string()` on string literals, `&'static str` return on a test directive, doc backticks, removed trailing comma.
- **CHANGELOG:** notes the MSRV bump (user-facing for downstream crates embedding `rw-renderer`).

## Verification

- `make test` — all Rust tests + 387/387 frontend tests pass.
- `make lint` — clippy clean (`--all-targets`, including `-D warnings`), svelte-check and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)