### PR TITLE
refactor: remove with_gfm, always enable GFM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (`rw-renderer` Rust API):** GitHub Flavored Markdown (tables, strikethrough, task lists, and `[!NOTE]`-style alerts) is now always enabled and the `MarkdownRenderer::with_gfm` builder method has been removed. GFM was already on in every shipped `rw` code path, so no end-user `rw` behavior changes; only downstream crates that called `with_gfm(false)` to opt out need to migrate — there is no longer a way to disable GFM.
 - Minimum supported Rust version raised to 1.96 — downstream crates embedding `rw-renderer` (or any other `rw-*` crate) now need a 1.96+ toolchain to build
 - Page outline (TOC) sidebar widened from 240px to 320px so that opening a comment no longer narrows the article or shifts text sideways; the sidebar now appears at viewport widths ≥ 1304px instead of ≥ 1224px (narrower viewports get the floating "On this page" popover as before)
 - Page modification times (`lastModified` in API responses) now reflect the git commit time instead of the filesystem modification time — timestamps remain stable across `git checkout`, `git pull`, and branch switching

--- a/crates/rw-confluence/src/renderer.rs
+++ b/crates/rw-confluence/src/renderer.rs
@@ -33,7 +33,6 @@ const TOC_MACRO: &str = r#"<ac:structured-macro ac:name="toc" ac:schema-version=
 /// different output formats.
 #[derive(Debug)]
 pub(crate) struct PageRenderer {
-    gfm: bool,
     prepend_toc: bool,
     extract_title: bool,
     include_dirs: Vec<PathBuf>,
@@ -51,7 +50,6 @@ impl PageRenderer {
     #[must_use]
     pub(crate) fn new() -> Self {
         Self {
-            gfm: true,
             prepend_toc: false,
             extract_title: false,
             include_dirs: Vec::new(),
@@ -138,7 +136,7 @@ impl PageRenderer {
 
     /// Build the settings-only renderer.
     fn create_renderer(&self) -> MarkdownRenderer<ConfluenceBackend> {
-        let mut renderer = MarkdownRenderer::<ConfluenceBackend>::new().with_gfm(self.gfm);
+        let mut renderer = MarkdownRenderer::<ConfluenceBackend>::new();
         if self.extract_title {
             renderer = renderer.with_title_extraction();
         }

--- a/crates/rw-renderer/src/config.rs
+++ b/crates/rw-renderer/src/config.rs
@@ -1,7 +1,7 @@
 //! Settings for [`MarkdownRenderer`](crate::MarkdownRenderer).
 //!
 //! [`RenderConfig`] holds the configuration the renderer was built with —
-//! base paths, GFM/wikilink flags, sections, title resolver. It is non-generic
+//! base paths, the wikilink flag, sections, title resolver. It is non-generic
 //! on purpose: none of the read-only helpers reference the backend type `B`.
 //! Settings live for the lifetime of the renderer; per-render scratch state
 //! lives on `Walker` and is freshly constructed for every call.
@@ -66,8 +66,6 @@ pub(crate) struct RenderConfig {
     /// Origin prefix (with trailing slash) for files outside `source_dir`.
     /// Set by [`with_origin`](crate::MarkdownRenderer::with_origin).
     pub(crate) origin_prefix: Option<String>,
-    /// GFM features (tables, strikethrough, tasklists) enabled.
-    pub(crate) gfm: bool,
     /// `[[wikilink]]` parsing enabled.
     pub(crate) wikilinks: bool,
     /// Extract title from first H1.
@@ -79,12 +77,11 @@ pub(crate) struct RenderConfig {
 }
 
 impl RenderConfig {
-    /// Defaults: GFM on, no wikilinks, no title extraction.
+    /// Defaults: no wikilinks, no title extraction.
     pub(crate) fn new() -> Self {
         Self {
             base_path: None,
             origin_prefix: None,
-            gfm: true,
             wikilinks: false,
             extract_title: false,
             sections: None,
@@ -92,17 +89,15 @@ impl RenderConfig {
         }
     }
 
-    /// Returns pulldown-cmark `Options` reflecting the current GFM and
-    /// wikilink configuration.
+    /// Returns pulldown-cmark `Options`: the always-on GFM features and
+    /// metadata blocks, plus wikilinks when configured.
     #[must_use]
     pub(crate) fn parser_options(&self) -> Options {
-        let mut opts = Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
-        if self.gfm {
-            opts |= Options::ENABLE_TABLES
-                | Options::ENABLE_STRIKETHROUGH
-                | Options::ENABLE_TASKLISTS
-                | Options::ENABLE_GFM;
-        }
+        let mut opts = Options::ENABLE_YAML_STYLE_METADATA_BLOCKS
+            | Options::ENABLE_TABLES
+            | Options::ENABLE_STRIKETHROUGH
+            | Options::ENABLE_TASKLISTS
+            | Options::ENABLE_GFM;
         if self.wikilinks {
             opts |= Options::ENABLE_WIKILINKS;
         }
@@ -134,19 +129,6 @@ mod tests {
         assert!(opts.contains(Options::ENABLE_GFM));
         assert!(opts.contains(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS));
         assert!(!opts.contains(Options::ENABLE_WIKILINKS));
-    }
-
-    #[test]
-    fn parser_options_disables_gfm_when_flag_off() {
-        let mut c = cfg();
-        c.gfm = false;
-        let opts = c.parser_options();
-        assert!(!opts.contains(Options::ENABLE_TABLES));
-        assert!(!opts.contains(Options::ENABLE_STRIKETHROUGH));
-        assert!(!opts.contains(Options::ENABLE_TASKLISTS));
-        assert!(!opts.contains(Options::ENABLE_GFM));
-        // Metadata blocks always on, independent of GFM.
-        assert!(opts.contains(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS));
     }
 
     #[test]

--- a/crates/rw-renderer/src/renderer.rs
+++ b/crates/rw-renderer/src/renderer.rs
@@ -86,7 +86,8 @@ pub struct MarkdownRenderer<B: RenderBackend> {
 }
 
 impl<B: RenderBackend> MarkdownRenderer<B> {
-    /// Create a new renderer with GFM enabled by default.
+    /// Create a new renderer. GFM features (tables, strikethrough, task
+    /// lists, alerts) are always enabled.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -125,18 +126,6 @@ impl<B: RenderBackend> MarkdownRenderer<B> {
         let mut prefix = origin.into();
         prefix.push('/');
         self.config.origin_prefix = Some(prefix);
-        self
-    }
-
-    /// Enable or disable GitHub Flavored Markdown features.
-    ///
-    /// GFM is enabled by default. When enabled, the parser supports:
-    /// - Tables
-    /// - Strikethrough (`~~text~~`)
-    /// - Task lists (`- [ ] item`)
-    #[must_use]
-    pub fn with_gfm(mut self, enabled: bool) -> Self {
-        self.config.gfm = enabled;
         self
     }
 
@@ -850,18 +839,10 @@ mod tests {
     }
 
     #[test]
-    fn test_gfm_enabled_by_default() {
+    fn test_gfm_tables_always_rendered() {
         let renderer = MarkdownRenderer::<HtmlBackend>::new();
         let result = renderer.render("| A | B |\n|---|---|\n| 1 | 2 |", Pipeline::new());
         assert!(result.html.contains("<table>"));
-    }
-
-    #[test]
-    fn test_gfm_disabled() {
-        let renderer = MarkdownRenderer::<HtmlBackend>::new().with_gfm(false);
-        let result = renderer.render("| A | B |\n|---|---|\n| 1 | 2 |", Pipeline::new());
-        // Tables not rendered when GFM disabled
-        assert!(!result.html.contains("<table>"));
     }
 
     // Directive integration tests

--- a/crates/rw-renderer/src/search_document.rs
+++ b/crates/rw-renderer/src/search_document.rs
@@ -230,7 +230,6 @@ mod tests {
     #[test]
     fn alert_content_included() {
         let result = MarkdownRenderer::<SearchDocumentBackend>::new()
-            .with_gfm(true)
             .render("> [!WARNING]\n> Do not delete this file.", Pipeline::new());
         assert!(result.html.contains("Do not delete this file."));
         assert!(!result.html.contains('<'));

--- a/crates/rw-site/src/page.rs
+++ b/crates/rw-site/src/page.rs
@@ -450,15 +450,13 @@ impl PageRenderer {
         pipeline
     }
 
-    /// Apply settings shared between renderer creation paths: GFM, sections,
+    /// Apply settings shared between renderer creation paths: sections,
     /// wikilinks/title resolver.
     fn configure_renderer_settings<B: RenderBackend>(
         renderer: MarkdownRenderer<B>,
         ctx: &RenderContext,
     ) -> MarkdownRenderer<B> {
-        let mut renderer = renderer
-            .with_gfm(true)
-            .with_sections(Arc::clone(&ctx.sections));
+        let mut renderer = renderer.with_sections(Arc::clone(&ctx.sections));
 
         if let Some(snapshot) = &ctx.snapshot {
             renderer = renderer


### PR DESCRIPTION
## Summary

GitHub Flavored Markdown (tables, strikethrough, task lists, and `[!NOTE]`-style alerts) was already enabled in every shipped `rw` code path, with no config option, CLI flag, or `rw.toml` setting reaching the `MarkdownRenderer::with_gfm` toggle. This removes that dead configurability so GFM is always on.

- Remove the `MarkdownRenderer::with_gfm` builder method
- Remove the `RenderConfig.gfm` field; `parser_options()` now enables the GFM options unconditionally
- Remove the dead `gfm` field from the Confluence `PageRenderer`
- Drop the redundant `.with_gfm(true)` call sites
- Adjust tests to assert GFM is always on (drop the disable-path tests)

## Compatibility

**Breaking only for downstream crates** embedding `rw-renderer` that called `with_gfm(false)` — there is no longer a way to disable GFM. **No end-user `rw` behavior changes.** CHANGELOG updated with a breaking-change entry under the `rw-renderer` Rust API.

## Verification

- `make test` — 1116 Rust tests + frontend tests pass
- `make lint` — clippy clean, svelte-check 0 errors/0 warnings
- `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)