### PR TITLE
fix(renderer): guarantee unique heading anchor IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML frontmatter values that contain `:name[...]`-shaped text (e.g., `description: 'See :status[Done] for details'`) no longer trigger spurious "unknown inline directive" warnings or invoke registered directive handlers. Previously such patterns were scanned for inline directives during text-buffer flushing inside the metadata block, polluting `result.warnings` and firing handler side effects even though the rendered HTML correctly suppressed the directive output.
 - A transient panic inside `rw serve` (most realistically inside `storage.scan()` during a reload) no longer permanently bricks the server. Axum's per-request panic catch returned 500 for that one request, but `Site`'s internal `reload_lock` stayed poisoned and every later request panicked too — recovery required restarting the process. Subsequent reads now resume on the previous snapshot and the next reload trigger is honored normally. Internal caches in `FsStorage`, `S3Storage`, and the file-watcher debouncer got the same treatment so a panic in any of them no longer turns into a permanent secondary brick on the recovery path.
 - New files created under `docs/` while `rw serve` is running now reliably show up in the navigation sidebar without a manual browser refresh. The live-reload Created handler used to re-check `has_page` *after* invalidating, racing the just-triggered reload — when the post-event scan failed transiently (or hadn't yet picked up the file because of atomic-write timing on slow disks) the check would answer against the pre-event snapshot, drop the broadcast, and the sidebar would stay out of date until the next event arrived or the page was refreshed.
+- Heading anchor IDs are now guaranteed unique within a page. Previously a
+  heading whose slug coincided with another heading's auto-numbered suffix
+  (e.g. headings `Foo`, `Foo 1`, `Foo` all on one page) could emit two elements
+  with the same `id`, breaking in-page anchor links and TOC navigation; and a
+  heading containing no slug characters (e.g. `## ???`) produced an empty
+  `id=""`. Such headings now fall back to a `section` base and always receive a
+  distinct numeric suffix.
 
 ## [0.1.24] - 2026-04-10
 

--- a/crates/rw-renderer/src/toc.rs
+++ b/crates/rw-renderer/src/toc.rs
@@ -3,10 +3,10 @@
 //! [`TocEntry`] is the public output type collected in
 //! [`RenderResult::toc`](crate::RenderResult::toc).
 //! [`HeadingAccumulator`] is walker-private scratch that tracks
-//! cross-heading state (title, TOC entries, id-counts, and the
+//! cross-heading state (title, TOC entries, id de-duplication state, and the
 //! "have we seen the first H1?" flag) across an entire document render.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::util::slugify;
 
@@ -44,7 +44,9 @@ pub struct TocEntry {
     /// Plain-text heading content (inline formatting stripped).
     pub title: String,
     /// Slug-based anchor ID, matching the `id` attribute on the rendered heading.
-    /// Duplicate headings get a numeric suffix (e.g., `setup`, `setup-1`).
+    /// Guaranteed unique within the document: duplicate or colliding headings get
+    /// a numeric suffix (e.g., `setup`, `setup-1`), and headings with no slug
+    /// characters fall back to `section`.
     pub id: String,
 }
 
@@ -55,7 +57,8 @@ pub struct TocEntry {
 pub(crate) struct CompletedHeading {
     /// Heading level after Confluence's title-shift adjustment.
     pub adjusted_level: u8,
-    /// Slug-based anchor id, deduped via the accumulator's `id_counts`.
+    /// Slug-based anchor id, deduped to be unique within the document via the
+    /// accumulator's `used_ids`.
     pub id: String,
     /// Backend-formatted HTML body, ready to splice into `output` between
     /// the heading's open and close tags. Encoding/escaping is whatever the
@@ -85,8 +88,15 @@ pub(crate) struct HeadingAccumulator {
     seen_first_h1: bool,
     /// Table of contents entries.
     toc: Vec<TocEntry>,
-    /// Counter for generating unique heading IDs.
+    /// Starting-suffix hint per base slug, so repeated headings don't rescan
+    /// `base-1, base-2, …` from scratch each time. Uniqueness is enforced by
+    /// `used_ids`, not by this counter alone.
     id_counts: HashMap<String, usize>,
+    /// Every id already emitted in this render. A generated candidate is
+    /// retried with a higher suffix until it is absent here, guaranteeing
+    /// globally unique ids even when a synthesized `{base}-{n}` coincides
+    /// with another heading's slug.
+    used_ids: HashSet<String>,
 }
 
 impl HeadingAccumulator {
@@ -102,6 +112,7 @@ impl HeadingAccumulator {
             seen_first_h1: false,
             toc: Vec::new(),
             id_counts: HashMap::new(),
+            used_ids: HashSet::new(),
         }
     }
 
@@ -165,15 +176,29 @@ impl HeadingAccumulator {
     }
 
     /// Generate a unique slug-based id from heading plain text.
+    ///
+    /// Headings with no slug characters fall back to the base `section`.
+    /// The returned id is guaranteed not to equal any id previously returned
+    /// for this document: a numeric suffix is bumped until the candidate is
+    /// unused, even when it would collide with another heading's slug.
     fn generate_id(&mut self, text: &str) -> String {
-        let base_id = slugify(text);
-        let count = self.id_counts.entry(base_id.clone()).or_default();
-        let id = match *count {
-            0 => base_id,
-            n => format!("{base_id}-{n}"),
+        let mut base = slugify(text);
+        if base.is_empty() {
+            "section".clone_into(&mut base);
+        }
+        let mut n = self.id_counts.get(&base).copied().unwrap_or(0);
+        let mut candidate = if n == 0 {
+            base.clone()
+        } else {
+            format!("{base}-{n}")
         };
-        *count += 1;
-        id
+        while self.used_ids.contains(&candidate) {
+            n += 1;
+            candidate = format!("{base}-{n}");
+        }
+        self.id_counts.insert(base, n + 1);
+        self.used_ids.insert(candidate.clone());
+        candidate
     }
 
     /// Take the extracted title.
@@ -243,5 +268,65 @@ mod tests {
         assert_eq!(toc[0].level, 1, "H2 shifts to level 1 in Confluence mode");
         assert_eq!(toc[0].title, "Section");
         assert_eq!(toc[0].id, "section");
+    }
+
+    #[test]
+    fn test_generate_id_suffix_collision_is_unique() {
+        // "Foo 1" slugifies to "foo-1", which must NOT collide with the
+        // second "Foo" (which would otherwise also become "foo-1").
+        let mut acc = HeadingAccumulator::new(false, false);
+        let a = acc.complete_heading(2, "Foo", "Foo".to_owned());
+        let b = acc.complete_heading(2, "Foo 1", "Foo 1".to_owned());
+        let c = acc.complete_heading(2, "Foo", "Foo".to_owned());
+        assert_eq!(a.id, "foo");
+        assert_eq!(b.id, "foo-1");
+        assert_eq!(c.id, "foo-2", "second 'Foo' must not reuse 'foo-1'");
+    }
+
+    #[test]
+    fn test_generate_id_empty_slug_falls_back_to_section() {
+        // Headings with no slug characters must not produce empty ids.
+        let mut acc = HeadingAccumulator::new(false, false);
+        let a = acc.complete_heading(2, "???", "???".to_owned());
+        let b = acc.complete_heading(2, "!!!", "!!!".to_owned());
+        assert_eq!(a.id, "section");
+        assert_eq!(b.id, "section-1");
+    }
+
+    #[test]
+    fn test_generate_id_empty_slug_yields_to_real_section_heading() {
+        // A real "Section" heading claims "section"; the no-slug heading
+        // is suffixed (document order: real heading first here).
+        let mut acc = HeadingAccumulator::new(false, false);
+        let a = acc.complete_heading(2, "Section", "Section".to_owned());
+        let b = acc.complete_heading(2, "???", "???".to_owned());
+        assert_eq!(a.id, "section");
+        assert_eq!(b.id, "section-1");
+    }
+
+    #[test]
+    fn test_generate_id_real_slug_collides_with_section_fallback() {
+        // A real heading slugging to "section-1" must not be reused by the
+        // empty-slug fallback's "section" + "-1" suffix.
+        let mut acc = HeadingAccumulator::new(false, false);
+        let a = acc.complete_heading(2, "Section 1", "Section 1".to_owned());
+        let b = acc.complete_heading(2, "???", "???".to_owned());
+        let c = acc.complete_heading(2, "???", "???".to_owned());
+        assert_eq!(a.id, "section-1");
+        assert_eq!(b.id, "section");
+        assert_eq!(
+            c.id, "section-2",
+            "fallback must skip the taken 'section-1'"
+        );
+    }
+
+    #[test]
+    fn test_generate_id_repeated_headings_increment_via_hint() {
+        // Four identical headings increment monotonically (id_counts hint path).
+        let mut acc = HeadingAccumulator::new(false, false);
+        let ids: Vec<String> = (0..4)
+            .map(|_| acc.complete_heading(2, "Setup", "Setup".to_owned()).id)
+            .collect();
+        assert_eq!(ids, ["setup", "setup-1", "setup-2", "setup-3"]);
     }
 }


### PR DESCRIPTION
Fixes #402.

## Problem

`HeadingAccumulator::generate_id` deduped heading anchor IDs with a per-base-slug counter that never checked the synthesized `{base}-{n}` against ids other headings already emitted. Two failure modes resulted:

- **Colliding suffixes** — `## Foo` / `## Foo 1` / `## Foo` produced `foo`, `foo-1`, `foo-1` (two elements with the same `id`), breaking in-page `#fragment` anchors and TOC navigation.
- **Empty slugs** — a heading with no slug characters (`## ???`, `## 🎉`, image-only `## ![](icon.png)`) produced `id=""` (invalid HTML), and the next such heading cascaded to `id="-1"`, `id="-2"`. This is the case reported in #402.

## Fix

`generate_id` now records every emitted id in a `used_ids: HashSet<String>` and bumps the numeric suffix until the candidate is unused, so ids are **guaranteed globally unique within a document**. Empty slugs fall back to a `section` base and dedup through the same mechanism. The existing `id_counts` map is retained purely as a starting-suffix hint, keeping repeated headings amortized O(1).

Resulting behavior:
- `## Foo` / `## Foo 1` / `## Foo` → `foo`, `foo-1`, `foo-2`
- `## ???` / `## !!!` → `section`, `section-1`
- `## Section` / `## ???` → `section`, `section-1` (real heading wins; document-order dedup)

> Note: #402 suggested a `heading` / `h{level}` fallback base; this PR uses `section`. Functionally equivalent — both give empty-slug headings a stable, unique, non-empty id.

## Scope

Single function plus two struct fields in `crates/rw-renderer/src/toc.rs`; no public API or signature changes. Five unit tests cover suffix-collision, empty-slug fallback, fallback-vs-real-`Section`, the `section-1`-collision edge, and the hint-increment path.

## Verification

`cargo test -p rw-renderer` (lib + integration + doctests) green; `cargo clippy -p rw-renderer --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)