### PR TITLE
fix(rw-site): never swallow a reload invalidate that races an in-flight scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   heading containing no slug characters (e.g. `## ???`) produced an empty
   `id=""`. Such headings now fall back to a `section` base and always receive a
   distinct numeric suffix.
+- `rw serve` no longer keeps serving stale page content after a file change that lands while a previous reload's storage scan is still running. The lazy-reload cache tracked validity in a separate flag that a finishing scan could set back to "valid", clobbering the concurrent change signal; the change was then lost until an unrelated later edit. Validity is now derived from a monotonic generation stamp, so a change can never be swallowed by an in-flight reload.
 
 ## [0.1.24] - 2026-04-10
 

--- a/crates/rw-site/src/site.rs
+++ b/crates/rw-site/src/site.rs
@@ -141,8 +141,11 @@ pub struct Site {
     reload_lock: Mutex<()>,
     /// Current site snapshot (atomically swappable).
     current_snapshot: RwLock<Arc<SiteSnapshot>>,
-    /// Cache validity flag.
-    cache_valid: AtomicBool,
+    /// The `generation` value that the currently-installed snapshot satisfies.
+    /// The cache is fresh iff `loaded_generation == generation`. Initialized to
+    /// `u64::MAX` (a sentinel meaning "never loaded") so the fast path always
+    /// misses until the first successful load stamps a real generation.
+    loaded_generation: AtomicU64,
     /// Whether the site has successfully loaded at least once.
     has_loaded: AtomicBool,
     /// Page rendering pipeline.
@@ -175,7 +178,7 @@ impl Site {
             generation: AtomicU64::new(0),
             reload_lock: Mutex::new(()),
             current_snapshot: RwLock::new(initial_snapshot),
-            cache_valid: AtomicBool::new(false),
+            loaded_generation: AtomicU64::new(u64::MAX),
             has_loaded: AtomicBool::new(false),
             renderer,
         }
@@ -282,41 +285,53 @@ impl Site {
 
     /// Returns the current snapshot, reloading from storage if stale.
     ///
-    /// Uses a double-checked locking pattern: the fast path (cache valid)
-    /// requires only an atomic load and an `RwLock` read; the slow path
-    /// acquires a `Mutex` to serialize reloads.
+    /// Validity is derived, not stored: the installed snapshot is fresh iff
+    /// `loaded_generation == generation`. The fast path is two atomic loads;
+    /// the slow path serializes reloads behind `reload_lock`.
     ///
-    /// On the **initial** load, storage errors propagate to the caller so
-    /// that misconfigured storage is surfaced immediately. On subsequent
-    /// reloads, errors are logged and the previous snapshot is kept. The
-    /// cache flag is normally restored so later reads serve that snapshot
-    /// via the fast path instead of repeatedly retrying an unreachable
-    /// backend — unless an [`invalidate`](Self::invalidate) raced with
-    /// the failing scan, in which case the next reader retries instead of
-    /// swallowing that signal.
+    /// On the **initial** load, storage errors propagate to the caller so that
+    /// misconfigured storage is surfaced immediately (and `loaded_generation`
+    /// stays at its sentinel, so the next reader retries). On subsequent
+    /// reloads, a scan error is logged and the previous snapshot is kept; the
+    /// snapshot is re-stamped to `pre_scan` so later reads ride the fast path
+    /// instead of hot-looping an unreachable backend — unless an
+    /// [`invalidate`](Self::invalidate) raced the failing scan, in which case
+    /// `generation` has already moved past `pre_scan` and the next reader
+    /// retries instead of swallowing the signal.
+    ///
+    /// Because a reloader only ever stamps `loaded_generation` to the
+    /// `generation` it observed *before* scanning, an `invalidate()` that races
+    /// an in-flight scan can never be swallowed: it bumps `generation` past
+    /// `pre_scan`, leaving `loaded_generation != generation`.
     ///
     /// # Errors
     ///
     /// Returns [`StorageError`] if the initial site load fails.
     pub(crate) fn reload_if_needed(&self) -> Result<Arc<SiteSnapshot>, StorageError> {
-        // Fast path: cache valid
-        if self.cache_valid.load(Ordering::Acquire) {
+        // Fast path: the installed snapshot already satisfies the latest
+        // generation. The two loads are not atomic together, but that only ever
+        // produces a benign spurious slow-path entry: a false *fresh* verdict is
+        // impossible because `loaded_generation` is only ever stamped to a
+        // `generation` value observed before a scan, so equality means the
+        // snapshot genuinely satisfies that generation.
+        if self.loaded_generation.load(Ordering::Acquire) == self.generation.load(Ordering::Acquire)
+        {
             return Ok(self.snapshot());
         }
 
-        // Slow path: acquire reload lock.
+        // Slow path: serialize reloads.
         let _guard = self.reload_lock.lock();
 
-        // Double-check after acquiring lock
-        if self.cache_valid.load(Ordering::Acquire) {
+        // Capture the generation this reload will satisfy, then double-check.
+        let pre_scan = self.generation.load(Ordering::Acquire);
+        if self.loaded_generation.load(Ordering::Acquire) == pre_scan {
             return Ok(self.snapshot());
         }
 
         let has_loaded = self.has_loaded.load(Ordering::Acquire);
-        let pre_scan_generation = self.generation.load(Ordering::Acquire);
-        let etag = pre_scan_generation.to_string();
+        let etag = pre_scan.to_string();
 
-        // Load state: skip bucket cache on initial load to verify storage connectivity
+        // Load state: skip bucket cache on initial load to verify storage connectivity.
         let state = if has_loaded {
             if let Some(cached) = SiteState::from_cache(self.site_bucket.as_ref(), &etag) {
                 cached
@@ -328,19 +343,12 @@ impl Site {
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "Failed to reload site from storage, keeping stale data");
-                        // Restore the fast path so subsequent reads return the
-                        // stale snapshot immediately. Without this, every read
-                        // would re-enter the slow path, serialize on the reload
-                        // mutex, and re-call the unreachable backend.
-                        //
-                        // Only restore it if no `invalidate()` raced with us
-                        // during the (potentially long) failing scan. If the
-                        // generation changed, an invalidate is pending and the
-                        // next reader must retry — otherwise we'd swallow that
-                        // signal and serve stale data even after recovery.
-                        if self.generation.load(Ordering::Acquire) == pre_scan_generation {
-                            self.cache_valid.store(true, Ordering::Release);
-                        }
+                        // Re-stamp the stale snapshot so subsequent reads ride
+                        // the fast path. If an invalidate raced this failing
+                        // scan, `generation` already moved past `pre_scan`, so
+                        // `loaded_generation != generation` and the next reader
+                        // retries instead of swallowing the signal.
+                        self.loaded_generation.store(pre_scan, Ordering::Release);
                         return Ok(self.snapshot());
                     }
                 }
@@ -355,7 +363,13 @@ impl Site {
         let snapshot = Arc::new(SiteSnapshot { state, sections });
 
         *self.current_snapshot.write() = Arc::clone(&snapshot);
-        self.cache_valid.store(true, Ordering::Release);
+        // Stamp the generation this snapshot satisfies. If an invalidate raced
+        // the scan, `generation > pre_scan` already, so `loaded_generation !=
+        // generation` and the next reader re-scans — the invalidate is never
+        // lost. The snapshot itself is published by the `current_snapshot`
+        // RwLock above; this Release store only governs the freshness verdict,
+        // pairing with the fast-path Acquire load of `loaded_generation`.
+        self.loaded_generation.store(pre_scan, Ordering::Release);
         self.has_loaded.store(true, Ordering::Release);
 
         Ok(snapshot)
@@ -393,14 +407,11 @@ impl Site {
     /// Readers that already hold a snapshot are unaffected — they continue
     /// using the previous data. This method is lock-free.
     pub fn invalidate(&self) {
-        // Bump generation BEFORE clearing the cache flag. The failure branch
-        // of `reload_if_needed` uses the generation as a "was an invalidate
-        // pending?" probe; if we cleared cache_valid first, a concurrent
-        // failing reload could observe the unchanged generation and restore
-        // cache_valid=true before our `fetch_add` lands, swallowing the
-        // invalidate signal.
+        // Monotonically bump the requested generation. Validity is derived from
+        // `loaded_generation == generation`, and a reload can only stamp
+        // `loaded_generation` to the generation it observed before scanning, so
+        // this increment can never be lost — even if it races an in-flight scan.
         self.generation.fetch_add(1, Ordering::Release);
-        self.cache_valid.store(false, Ordering::Release);
     }
 
     /// Renders a page to HTML by its URL path.
@@ -1540,6 +1551,62 @@ mod tests {
         assert!(!r3.from_cache, "A should re-render after B's title changed");
         assert!(r3.html.contains("New Title"), "r3 html: {}", r3.html);
         assert!(!r3.html.contains("Old Title"), "r3 html: {}", r3.html);
+    }
+
+    #[test]
+    fn test_invalidate_during_successful_scan_is_not_swallowed() {
+        // Regression: the success path of reload_if_needed must not blindly
+        // mark the cache valid. If an invalidate() lands *during* a successful
+        // scan, the freshly built snapshot is already stale w.r.t. that signal,
+        // so the next read must re-scan rather than ride the fast path.
+        //
+        // This is deterministic, not a threaded race: the scan_hook reenters
+        // invalidate() synchronously from inside scan() (while reload_if_needed
+        // is on the stack), reproducing the exact mid-scan ordering without
+        // timing dependence. Keep it that way — do not convert to threads.
+        use std::sync::Weak;
+
+        let storage = Arc::new(MockStorage::new().with_document("guide", "Guide"));
+        let site = Arc::new(Site::new(
+            Arc::clone(&storage) as Arc<dyn rw_storage::Storage>,
+            Arc::new(rw_cache::NullCache),
+            PageRendererConfig::default(),
+        ));
+
+        // Initial successful load: scan #1.
+        site.reload_if_needed().unwrap();
+        assert_eq!(storage.scan_count(), 1);
+
+        // Arrange: the NEXT scan fires invalidate() exactly once, mid-scan.
+        // Weak avoids a Site<->storage<->hook reference cycle.
+        let weak: Weak<Site> = Arc::downgrade(&site);
+        let fired = std::sync::atomic::AtomicBool::new(false);
+        storage.set_scan_hook(Some(Box::new(move || {
+            if !fired.swap(true, Ordering::SeqCst)
+                && let Some(site) = weak.upgrade()
+            {
+                site.invalidate();
+            }
+        })));
+
+        // Trigger the reload that the hook will invalidate mid-flight: scan #2.
+        site.invalidate();
+        site.reload_if_needed().unwrap();
+        assert_eq!(storage.scan_count(), 2);
+
+        // Clear the hook so the next scan is a normal success.
+        storage.set_scan_hook(None);
+
+        // The mid-scan invalidate must NOT have been swallowed: the next read
+        // re-scans (scan #3). On the buggy code the success path stored
+        // cache_valid=true and this read rode the fast path, leaving the count
+        // at 2.
+        site.reload_if_needed().unwrap();
+        assert_eq!(
+            storage.scan_count(),
+            3,
+            "invalidate() during a successful scan must force a re-scan"
+        );
     }
 
     #[test]

--- a/crates/rw-storage/src/mock.rs
+++ b/crates/rw-storage/src/mock.rs
@@ -13,6 +13,22 @@ use crate::event::{StorageEvent, StorageEventKind, StorageEventReceiver, WatchHa
 use crate::metadata::Metadata;
 use crate::storage::{Document, Storage, StorageError, StorageErrorKind};
 
+/// A one-shot/repeatable hook invoked inside a *successful* `scan()`.
+///
+/// Wrapped in a newtype with a manual `Debug` impl so `MockStorage` can keep
+/// `#[derive(Debug)]` (a boxed closure is not `Debug`). The closure is
+/// `Send + Sync` so `MockStorage` stays `Send + Sync`.
+#[derive(Default)]
+struct ScanHook(Option<Box<dyn FnMut() + Send + Sync>>);
+
+impl std::fmt::Debug for ScanHook {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ScanHook")
+            .field(&self.0.as_ref().map(|_| "<hook>"))
+            .finish()
+    }
+}
+
 /// Mock storage for testing.
 ///
 /// Stores documents and content in memory. Use the builder methods
@@ -51,6 +67,8 @@ pub struct MockStorage {
     event_sender: RwLock<Option<mpsc::Sender<StorageEvent>>>,
     /// Number of times `scan()` has been called (including failed calls).
     scan_count: AtomicUsize,
+    /// Optional hook run inside a successful `scan()` (test injection point).
+    scan_hook: RwLock<ScanHook>,
 }
 
 impl Default for MockStorage {
@@ -65,6 +83,7 @@ impl Default for MockStorage {
             has_changed: RwLock::new(None),
             event_sender: RwLock::new(None),
             scan_count: AtomicUsize::new(0),
+            scan_hook: RwLock::new(ScanHook::default()),
         }
     }
 }
@@ -300,6 +319,17 @@ impl MockStorage {
         *self.has_changed.write() = value;
     }
 
+    /// Install (or clear with `None`) a hook invoked inside a successful
+    /// `scan()`, after the panic/error checks pass and before documents are
+    /// read. Used to simulate an `invalidate()` racing an in-flight scan.
+    ///
+    /// The hook must not call back into this `MockStorage` — the `scan_hook`
+    /// write lock is held for the duration of the call (`parking_lot::RwLock`
+    /// is not reentrant), so re-entering would deadlock.
+    pub fn set_scan_hook(&self, hook: Option<Box<dyn FnMut() + Send + Sync>>) {
+        self.scan_hook.write().0 = hook;
+    }
+
     /// Emit a storage event.
     ///
     /// Only works if `watch()` has been called first.
@@ -346,6 +376,9 @@ impl Storage for MockStorage {
         );
         if let Some(kind) = self.scan_error.read().as_ref() {
             return Err(StorageError::new(*kind).with_backend("Mock"));
+        }
+        if let Some(hook) = self.scan_hook.write().0.as_mut() {
+            hook();
         }
         let guard = self.documents.read();
         Ok(guard
@@ -691,6 +724,38 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.kind, StorageErrorKind::Unavailable);
         assert_eq!(err.backend, Some("Mock"));
+    }
+
+    #[test]
+    fn test_scan_hook_fires_on_successful_scan() {
+        use std::sync::Arc;
+
+        let storage = MockStorage::new().with_document("guide", "Guide");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_hook = Arc::clone(&calls);
+        storage.set_scan_hook(Some(Box::new(move || {
+            calls_in_hook.fetch_add(1, Ordering::Relaxed);
+        })));
+
+        storage.scan().unwrap();
+        storage.scan().unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn test_scan_hook_not_fired_on_error() {
+        use std::sync::Arc;
+
+        let storage = MockStorage::new().with_scan_error(StorageErrorKind::Unavailable);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_hook = Arc::clone(&calls);
+        storage.set_scan_hook(Some(Box::new(move || {
+            calls_in_hook.fetch_add(1, Ordering::Relaxed);
+        })));
+
+        assert!(storage.scan().is_err());
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`Site::reload_if_needed` tracked cache validity in a separate `AtomicBool` (`cache_valid`). The **failure** branch guarded its `cache_valid = true` restore with a generation probe, but the **success tail** stored `cache_valid = true` unconditionally.

`invalidate()` is lock-free and can run concurrently with a slow scan holding `reload_lock`. If an `invalidate()` lands during a successful scan, it bumps `generation` and sets `cache_valid = false` — but the finishing scan then stores `cache_valid = true`, **clobbering** the signal. Nothing rechecks `generation` on the fast path, so the change is lost until the next unrelated `invalidate()`. In `rw serve` this means stale page content served indefinitely after a file change that races a reload.

## Fix

Make validity a **derived comparison** instead of a clobberable boolean:

- Delete `cache_valid: AtomicBool`; add `loaded_generation: AtomicU64` — the `generation` the installed snapshot satisfies (sentinel `u64::MAX` = never loaded).
- Validity is now `loaded_generation == generation`.
- `invalidate()` collapses to a single monotonic `generation.fetch_add(1, Release)`.
- A reloader only ever stamps `loaded_generation` to the `generation` it observed **before** scanning. Since `invalidate()` only ever *increments* `generation`, a racing invalidate leaves `loaded_generation != generation` and the next reader re-scans — it can never be swallowed.

This is simpler than the original: the hand-coded failure-branch generation probe is gone (subsumed by the comparison), and `invalidate()` no longer needs its delicate two-store ordering.

## Testing

- New deterministic regression test `test_invalidate_during_successful_scan_is_not_swallowed` fires `invalidate()` synchronously mid-scan via a new `MockStorage::set_scan_hook` seam. It **fails on the parent commit** (`scan_count` 2 vs expected 3) and passes with the fix.
- All existing concurrency/reload tests pass unchanged: 122 (rw-site) + 67 (rw-storage) + doctests.
- `cargo fmt --check` clean; clippy clean for the changed crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
