### PR TITLE
chore(rw-server): inherit thiserror from workspace

### DIFF
--- a/crates/rw-server/Cargo.toml
+++ b/crates/rw-server/Cargo.toml
@@ -42,7 +42,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Utilities
-thiserror = "2"
+thiserror = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 md-5 = "0.11"


### PR DESCRIPTION
`rw-server` was the only crate pinning `thiserror = "2"` directly instead of `{ workspace = true }`. Every other crate inherits thiserror from `[workspace.dependencies]`.

This change makes `rw-server` inherit it too, so a future version bump in the workspace applies uniformly and `rw-server` can't silently diverge.

No version change today (the workspace already pins `thiserror = "2"`); `cargo build -p rw-server` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)