### PR TITLE
chore: adopt Cargo workspace resolver 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["crates/*"]
 exclude = ["crates/rw-napi"]
 

--- a/crates/rw-napi/Cargo.toml
+++ b/crates/rw-napi/Cargo.toml
@@ -7,6 +7,7 @@
 # path but then treats us as "under its tree but not a member". See
 # rust-lang/cargo#16911 and #6745.
 [workspace]
+resolver = "3"
 
 [package]
 name = "rw-napi"


### PR DESCRIPTION
## Summary

Bump the Cargo workspace resolver from **2** to **3** (stable since Rust 1.84, the default for edition 2024 projects).

The key gain is **MSRV-aware dependency resolution**: when selecting versions, Cargo now prefers the newest version compatible with the declared `rust-version = "1.96"` instead of always taking the latest. This stops a `cargo update` or a Renovate bump from silently raising `rw`'s effective minimum Rust version above the contract — which matters because the MSRV is a public contract for downstream crates embedding `rw-renderer`.

## Changes

- `Cargo.toml` — workspace `resolver = "2"` → `"3"`
- `crates/rw-napi/Cargo.toml` — explicit `resolver = "3"` on the standalone workspace for consistency

## Verification

- `cargo update --dry-run` under resolver 3 forces **no** lockfile changes — current resolution already satisfies the 1.96 MSRV, so the diff is config-only.
- Full Rust test suite (`cargo test --workspace` + doctests): **all green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)