### PR TITLE
feat(viewer): show orphan comment quote inside first comment message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Orphaned inline comments shown in the page-comments timeline now render their original-passage quote inside the first comment message (between the author and the comment text) instead of as a detached block above the comment card, so the quote reads as part of the comment that refers to it.
 - The comments database (`.rw/comments/sqlite.db`) gains a versioned schema (`schema_versions` table). On startup, the binary applies any pending forward migrations idempotently. If the DB is at a schema version newer than the binary supports (e.g. you ran a newer `rw` and then tried to start an older one), startup fails cleanly with an "incompatible schema" error instead of corrupting reads — downgrades are not supported across schema versions.
 - **Breaking (`rw-renderer` Rust API):** GitHub Flavored Markdown (tables, strikethrough, task lists, and `[!NOTE]`-style alerts) is now always enabled and the `MarkdownRenderer::with_gfm` builder method has been removed. GFM was already on in every shipped `rw` code path, so no end-user `rw` behavior changes; only downstream crates that called `with_gfm(false)` to opt out need to migrate — there is no longer a way to disable GFM.
 - Minimum supported Rust version raised to 1.96 — downstream crates embedding `rw-renderer` (or any other `rw-*` crate) now need a 1.96+ toolchain to build

--- a/packages/viewer/e2e/comments.spec.ts
+++ b/packages/viewer/e2e/comments.spec.ts
@@ -723,6 +723,25 @@ test.describe("Page comments", () => {
     await expect(quote).toContainText("a sentence that definitely is not on this page");
     await expect(quote).toContainText("context after");
 
+    // The quote sits inside the comment card, between the author row and the
+    // body — scoped to the card, not the page-comments section.
+    const card = section.getByTestId("comment-thread");
+    await expect(card).toBeVisible();
+    await expect(card.getByTestId("orphan-quote")).toBeVisible();
+    await expect(card).toContainText("This paragraph needs a rewrite");
+
+    // The quote must come before the comment body in document order, so it
+    // reads as the opening of the first comment message, not a trailer.
+    const quoteBeforeBody = await card.evaluate((cardEl) => {
+      const q = cardEl.querySelector('[data-testid="orphan-quote"]');
+      const body = cardEl.querySelector('[data-testid="comment-body"]');
+      if (!q || !body) {
+        throw new Error("expected both orphan-quote and comment-body inside the card");
+      }
+      return Boolean(q.compareDocumentPosition(body) & Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+    expect(quoteBeforeBody).toBe(true);
+
     // The orphan must not inflate the inline sidebar's prev/next counter.
     // Create a real inline comment and check that the sidebar counter is 1/1.
     await createCommentViaUI(page, "code highlighting", "Real inline");

--- a/packages/viewer/src/components/comments/CommentThread.svelte
+++ b/packages/viewer/src/components/comments/CommentThread.svelte
@@ -3,6 +3,7 @@
   import Avatar from "$lib/ui/primitives/Avatar.svelte";
   import Badge from "$lib/ui/primitives/Badge.svelte";
   import Button from "$lib/ui/primitives/Button.svelte";
+  import Quote from "$lib/ui/primitives/Quote.svelte";
   import { formatRelativeTime } from "$lib/ui/hooks/formatRelativeTime";
   import { useElementSize } from "$lib/ui/hooks/useElementSize.svelte";
   import CommentForm from "./CommentForm.svelte";
@@ -31,6 +32,11 @@
     /** True when the comment was anchored via fuzzy matching — the original
      *  passage no longer appears verbatim, so the highlight may be approximate. */
     fuzzy?: boolean;
+    /** Quote of the original passage, shown between the author row and the
+     *  comment body for orphaned page comments whose anchor text no longer
+     *  appears on the page. Absent for inline (anchored) threads and native
+     *  page comments. */
+    quote?: { prefix?: string; exact: string; suffix?: string } | null;
   }
 
   let {
@@ -46,6 +52,7 @@
     nav,
     onAnchor,
     fuzzy = false,
+    quote = null,
   }: Props = $props();
 
   let outerRef: HTMLDivElement | undefined = $state();
@@ -77,6 +84,7 @@
 
 <div
   bind:this={outerRef}
+  data-testid="comment-thread"
   class="
     overflow-hidden rounded-md border px-3 pt-3 transition-colors
     {active
@@ -193,7 +201,18 @@
         {formatRelativeTime(new Date(comment.createdAt))}
       </span>
     </div>
+    {#if quote}
+      <Quote
+        data-testid="orphan-quote"
+        title="This comment was attached to a passage that no longer appears on the page."
+        class="mb-2"
+        prefix={quote.prefix}
+        exact={quote.exact}
+        suffix={quote.suffix}
+      />
+    {/if}
     <p
+      data-testid="comment-body"
       class="
         text-sm text-gray-900
         dark:text-neutral-100

--- a/packages/viewer/src/components/comments/PageComments.svelte
+++ b/packages/viewer/src/components/comments/PageComments.svelte
@@ -4,7 +4,6 @@
   import CommentThread from "./CommentThread.svelte";
   import CommentForm from "./CommentForm.svelte";
   import Alert from "$lib/ui/primitives/Alert.svelte";
-  import Quote from "$lib/ui/primitives/Quote.svelte";
 
   const { comments, page } = getRwContext();
 
@@ -101,28 +100,17 @@
     <div class="mb-6 space-y-4">
       {#each visibleThreads as thread (thread.id)}
         {@const quote = thread.selectors.length > 0 ? findQuote(thread.selectors) : null}
-        <div>
-          {#if quote}
-            <Quote
-              data-testid="orphan-quote"
-              title="This comment was attached to a passage that no longer appears on the page."
-              class="mb-2"
-              prefix={quote.prefix}
-              exact={quote.exact}
-              suffix={quote.suffix}
-            />
-          {/if}
-          <CommentThread
-            comment={thread}
-            replies={comments.replies(thread.id)}
-            active={false}
-            onResolve={handleResolve}
-            onReopen={handleReopen}
-            onReply={handleReply}
-            onDelete={handleDelete}
-            onRestore={handleRestore}
-          />
-        </div>
+        <CommentThread
+          comment={thread}
+          {quote}
+          replies={comments.replies(thread.id)}
+          active={false}
+          onResolve={handleResolve}
+          onReopen={handleReopen}
+          onReply={handleReply}
+          onDelete={handleDelete}
+          onRestore={handleRestore}
+        />
       {/each}
     </div>
   {/if}


### PR DESCRIPTION
Inline comments whose anchored passage no longer appears on the page fall back to the page-comments timeline, showing the original-passage quote so reviewers can still tell what the comment referred to. Previously that quote rendered as a detached block *above* the comment card; this moves it *inside* the first comment message — between the author row and the comment body — so it reads as part of the comment that refers to it.

## Changes
- `CommentThread` gains an optional `quote` prop and renders the `Quote` between the author row and the body.
- `PageComments` passes the quote down instead of rendering a sibling `Quote` above the card (the wrapper `<div>` is dropped).
- e2e asserts the quote is nested in the comment card and precedes the body in DOM order (throws on missing elements for a clear failure message).

## Testing
- `npm -w @rwdocs/viewer run test:e2e -- comments.spec.ts` → 23 passed
- `svelte-check` → 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)