### PR TITLE
fix(viewer): pin comment underline flush to highlight bottom

### DIFF
--- a/packages/viewer/src/styles/content.css
+++ b/packages/viewer/src/styles/content.css
@@ -304,15 +304,36 @@
  * data-strategy="fuzzy" marks comments anchored via the diff-match-patch
  * fallback (exact text drifted) and switches to a dashed underline — same
  * yellow, so the dash pattern is what tells reviewers the re-anchor may have
- * moved. Nested annotations share the 2px offset, so overlapping underlines
- * coincide into one line. */
+ * moved.
+ *
+ * The line is a background gradient pinned to background-position bottom so it
+ * sits flush with the bottom edge of the highlight box at any font size. Do NOT
+ * switch it back to text-decoration / text-underline-offset: those are
+ * baseline-relative, so the line drifts mid-box on larger headings and cuts
+ * through descenders. box-decoration-break: clone is required so each wrapped
+ * line fragment paints its own full background — without it the default "slice"
+ * model leaves the bottom line off every wrapped line but one. Nested
+ * annotations each pin their line to the shared box bottom, so overlapping
+ * underlines coincide into one line. */
 rw-annotation {
   background-color: var(--highlight-comment);
-  text-decoration: underline solid var(--highlight-comment-underline);
-  text-underline-offset: 2px;
+  background-image: linear-gradient(
+    var(--highlight-comment-underline),
+    var(--highlight-comment-underline)
+  );
+  background-repeat: no-repeat;
+  background-position: bottom;
+  background-size: 100% 2px;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 rw-annotation[data-strategy="fuzzy"] {
-  text-decoration: underline dashed var(--highlight-comment-underline);
+  /* Dashed equivalent: a horizontal repeating gradient at the box bottom. */
+  background-image: repeating-linear-gradient(
+    to right,
+    var(--highlight-comment-underline) 0 4px,
+    transparent 4px 7px
+  );
 }
 /* Active comment — stronger yellow on top of the per-comment background.
  * Toggled by the active-toggle $effect in PageContent.svelte. */


### PR DESCRIPTION
## Summary

Replaces the baseline-relative `text-decoration: underline` on `rw-annotation` (inline-comment highlights) with a **bottom-pinned background gradient**, so the underline sits flush with the bottom edge of the yellow highlight box at any font size.

## Why

`text-decoration` / `text-underline-offset` are baseline-relative, so the line drifted mid-box on larger headings and cut through descenders. Pinning a gradient to `background-position: bottom` ties the line to the same paint box as the highlight `background-color`, guaranteeing it stays flush.

## What changed (`packages/viewer/src/styles/content.css`)

- **Solid underline** → `linear-gradient` pinned `bottom`, `background-size: 100% 2px`.
- **`box-decoration-break: clone`** so every wrapped line fragment paints its own bottom line (multi-line comments are now underlined on each row, not just the last).
- **Nested/overlapping** annotations each pin to the shared box bottom, so overlapping underlines coincide into a single line (and the gradient adds zero layout cost, unlike a border).
- **Fuzzy/re-anchored** variant → `repeating-linear-gradient` for an exact, consistent dashed pattern.

## Verification

Checked in Chrome against a heading anchor and a paragraph that wraps to two lines:
- Heading: underline flush at the highlight bottom, below the descenders (no longer cuts through them).
- Wrapped paragraph: both lines carry the bottom underline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)