### PR TITLE
fix: clear make lint warnings

### DIFF
--- a/crates/rw-confluence/src/comment_preservation/parser.rs
+++ b/crates/rw-confluence/src/comment_preservation/parser.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::io::BufRead;
 
+use quick_xml::XmlVersion;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::reader::Reader;
 
@@ -215,7 +216,7 @@ impl ConfluenceXmlParser {
                 continue;
             }
 
-            let value = attr.unescape_value().map_or_else(
+            let value = attr.normalized_value(XmlVersion::Implicit1_0).map_or_else(
                 |_| String::from_utf8_lossy(&attr.value).into_owned(),
                 std::borrow::Cow::into_owned,
             );

--- a/crates/rw-storage-fs/src/source.rs
+++ b/crates/rw-storage-fs/src/source.rs
@@ -67,7 +67,10 @@ pub(crate) fn classify_relpath(
     filename: &str,
     meta_filename: &str,
 ) -> Option<Classification> {
-    if filename.ends_with(".md") {
+    if Path::new(filename)
+        .extension()
+        .is_some_and(|ext| ext == "md")
+    {
         return Some(Classification::Content {
             url_path: file_path_to_url(rel_path),
         });

--- a/packages/viewer/src/components/comments/PageComments.svelte
+++ b/packages/viewer/src/components/comments/PageComments.svelte
@@ -158,7 +158,7 @@
   <CommentForm onSubmit={handleNewComment} placeholder="Write a comment..." />
 
   {#if hasResolved}
-    <div class="mt-6 mb-6">
+    <div class="my-6">
       <button
         type="button"
         onclick={() => (showResolved = !showResolved)}


### PR DESCRIPTION
Three lint cleanups, no user-facing behavior change.

- **rw-storage-fs** (`source.rs`): classify `.md` via `Path::extension()` instead of `ends_with(".md")`, silencing `clippy::case_sensitive_file_extension_comparisons` (pedantic). Stays case-sensitive — behavior unchanged.
- **rw-confluence** (`comment_preservation/parser.rs`): replace deprecated `Attribute::unescape_value()` with `normalized_value(XmlVersion::Implicit1_0)`. The deprecated method delegates to exactly this call, so behavior is byte-identical (Confluence comment round-tripping unaffected).
- **viewer** (`PageComments.svelte`): collapse Tailwind `mt-6 mb-6` to canonical `my-6` (`better-tailwindcss/enforce-canonical-classes`). Visually identical.

## Verification
- `make lint` exits 0 with zero warnings (was 3: clippy, deprecation, Tailwind)
- `cargo test -p rw-storage-fs -p rw-confluence` green
- 391/391 viewer tests pass
- `make format` made no changes

No CHANGELOG entry — lint/clippy cleanup is not user-facing per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)