### PR TITLE
fix(viewer): keep orphaned comments active during n/p navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `n`/`p` comment navigation getting stuck on orphaned comments (inline comments whose anchored text was later edited away). They now highlight when selected, and navigation continues to the next comment.
+
 ## [0.1.25] - 2026-06-19
 
 ### Added

--- a/packages/viewer/e2e/comment-navigation.spec.ts
+++ b/packages/viewer/e2e/comment-navigation.spec.ts
@@ -75,6 +75,36 @@ async function createPageComment(page: Page, body: string) {
   await section.getByRole("button", { name: "Comment", exact: true }).click();
 }
 
+/** Create a top-level comment whose stored selectors cannot anchor to the
+ *  current document — the viewer treats it as an orphaned inline comment and
+ *  surfaces it in the page-comments timeline. Returns the new comment id. */
+async function createOrphanComment(page: Page, documentId: string, body: string): Promise<string> {
+  return page.evaluate(
+    async ({ docId, text }) => {
+      const res = await fetch("/_api/comments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          documentId: docId,
+          body: text,
+          selectors: [
+            {
+              type: "TextQuoteSelector",
+              exact: "a passage that is definitely not present anywhere on this page",
+              prefix: "",
+              suffix: "",
+            },
+          ],
+        }),
+      });
+      if (!res.ok) throw new Error(`failed to create orphan comment: ${res.status}`);
+      const created = await res.json();
+      return created.id as string;
+    },
+    { docId: documentId, text: body },
+  );
+}
+
 async function resolveAllComments(page: Page, documentId: string) {
   await page.evaluate(async (docId) => {
     const res = await fetch(`/_api/comments?documentId=${encodeURIComponent(docId)}`);
@@ -174,6 +204,61 @@ test.describe("Comment keyboard navigation", () => {
 
     await page.keyboard.press("n"); // wraps → inline (1 of 2)
     await expect(liveRegion(page)).toContainText("Comment 1 of 2");
+    expect(await activeHighlightId(page)).toBe(firstActive);
+  });
+
+  test("n steps onto orphaned-inline comments, highlighting each and advancing", async ({
+    page,
+  }) => {
+    // One anchored inline thread + two orphaned-inline threads (stored selectors
+    // that no longer match any text — what a content edit looks like to the
+    // viewer). Orphans render in the page-comments timeline and are valid n/p
+    // targets; they must highlight and let navigation continue.
+    await createInlineComment(page, ANCHOR_TEXT, "inline one");
+    // Created in order, so orphan A sorts before orphan B in the timeline (open
+    // page/orphan threads order by createdAt) and thus in n/p order after the
+    // inline thread.
+    await createOrphanComment(page, PAGE_DOC_ID, "orphan A body");
+    await createOrphanComment(page, PAGE_DOC_ID, "orphan B body");
+    await reloadIdle(page);
+
+    // Locate each timeline card by its unique body text (the cards carry the
+    // semantic data-testid; data-linked is the tint state with no role/text
+    // equivalent, so it's asserted as an attribute on the located card).
+    const section = page.getByRole("region", { name: "Comments" });
+    const orphanACard = section.getByTestId("comment-thread").filter({ hasText: "orphan A body" });
+    const orphanBCard = section.getByTestId("comment-thread").filter({ hasText: "orphan B body" });
+    await expect(orphanACard).toBeVisible();
+    await expect(orphanBCard).toBeVisible();
+    // Baseline: nothing is tinted before navigation, so the data-linked checks
+    // below are differential (they'd fail if the tint were applied uncondi-
+    // tionally rather than following the active comment).
+    await expect(orphanACard).not.toHaveAttribute("data-linked", "true");
+    await expect(orphanBCard).not.toHaveAttribute("data-linked", "true");
+
+    // idle → inline (1 of 3)
+    await page.keyboard.press("n");
+    await expect(liveRegion(page)).toContainText("Comment 1 of 3");
+    const firstActive = await activeHighlightId(page);
+    expect(firstActive).not.toBeNull();
+
+    // → first orphan (2 of 3): no inline highlight, but the timeline card is tinted.
+    await page.keyboard.press("n");
+    await expect(liveRegion(page)).toContainText("Comment 2 of 3");
+    expect(await activeHighlightId(page)).toBeNull();
+    await expect(orphanACard).toHaveAttribute("data-linked", "true");
+
+    // → second orphan (3 of 3): stepping onto an orphan keeps it active, so
+    // navigation advances to the next thread instead of re-entering from idle,
+    // and the tint moves from orphan A to orphan B.
+    await page.keyboard.press("n");
+    await expect(liveRegion(page)).toContainText("Comment 3 of 3");
+    await expect(orphanBCard).toHaveAttribute("data-linked", "true");
+    await expect(orphanACard).not.toHaveAttribute("data-linked", "true");
+
+    // wraps → inline (1 of 3)
+    await page.keyboard.press("n");
+    await expect(liveRegion(page)).toContainText("Comment 1 of 3");
     expect(await activeHighlightId(page)).toBe(firstActive);
   });
 

--- a/packages/viewer/src/components/PageContent.svelte
+++ b/packages/viewer/src/components/PageContent.svelte
@@ -12,6 +12,7 @@
     classifyCommentTarget,
     type CommentTargetKind,
   } from "$lib/comments/deeplink";
+  import { isNewlyOrphaned } from "$lib/comments/navigation";
   import LoadingSkeleton from "$lib/ui/primitives/LoadingSkeleton.svelte";
   import Alert from "$lib/ui/primitives/Alert.svelte";
   import Button from "$lib/ui/primitives/Button.svelte";
@@ -264,15 +265,6 @@
     comments.anchorStrategies = strategyMap;
     comments.orphanIds = orphanIds;
 
-    // If the active thread just lost its anchor (e.g. live-reload rewrote the
-    // page and the passage is gone), drop activeId — the sidebar filters out
-    // orphans, so activeThread would resolve to undefined and leave the panel
-    // open but empty. Clearing sends focus back to the main view; the orphan
-    // is still reachable from the page comments timeline.
-    if (comments.activeId && orphanIds.has(comments.activeId)) {
-      comments.activeId = null;
-    }
-
     // Order inline threads by their live DOM position, not by stored
     // TextPositionSelector.start — stored positions reflect the document
     // as it was at comment creation time and are stale after edits.
@@ -282,6 +274,26 @@
     return () => {
       unwrapAll(container);
     };
+  });
+
+  // De-activate a thread that *spontaneously* lost its anchor (e.g. live-reload
+  // rewrote the page and the active passage is gone): the sidebar filters out
+  // orphans, so the open panel would otherwise resolve to nothing. Only a
+  // genuine non-orphan → orphan transition clears activeId — navigating *onto*
+  // an already-orphaned comment (it lives in the page-comments timeline and is
+  // a valid n/p target) keeps it active so it highlights and stepping continues.
+  // Must stay separate from the wrap effect above: that effect reads activeId,
+  // so folding this in would re-wrap the article DOM on every n/p keypress.
+  // `prevOrphans` is a deliberately non-reactive local: this effect re-runs on
+  // orphanIds / activeId changes, not on its own bookkeeping write.
+  let prevOrphans = new Set<string>();
+  $effect(() => {
+    const orphans = comments.orphanIds;
+    const activeId = comments.activeId;
+    if (isNewlyOrphaned(activeId, orphans, prevOrphans)) {
+      comments.activeId = null;
+    }
+    prevOrphans = orphans;
   });
 
   $effect(() => {

--- a/packages/viewer/src/lib/comments/navigation.test.ts
+++ b/packages/viewer/src/lib/comments/navigation.test.ts
@@ -1,6 +1,6 @@
 // packages/viewer/src/lib/comments/navigation.test.ts
 import { describe, it, expect } from "vitest";
-import { resolveNavTarget, sortByOrder } from "./navigation";
+import { resolveNavTarget, sortByOrder, isNewlyOrphaned } from "./navigation";
 
 describe("resolveNavTarget", () => {
   const list = ["a", "b", "c"];
@@ -57,5 +57,29 @@ describe("sortByOrder", () => {
     const items = [{ id: "b" }, { id: "a" }];
     sortByOrder(items, ["a", "b"]);
     expect(items.map((i) => i.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("isNewlyOrphaned", () => {
+  it("returns false when there is no active comment", () => {
+    expect(isNewlyOrphaned(null, new Set(["a"]), new Set())).toBe(false);
+  });
+
+  it("returns true when the active comment just became an orphan", () => {
+    // Was anchored last pass (not in prev), now orphaned (in current).
+    expect(isNewlyOrphaned("a", new Set(["a"]), new Set())).toBe(true);
+  });
+
+  it("returns false when the active comment was already an orphan", () => {
+    // Navigating onto an existing orphan is not a transition.
+    expect(isNewlyOrphaned("a", new Set(["a"]), new Set(["a"]))).toBe(false);
+  });
+
+  it("returns false when the active comment is not an orphan now", () => {
+    expect(isNewlyOrphaned("a", new Set(["b"]), new Set(["b"]))).toBe(false);
+  });
+
+  it("returns false when an orphan re-anchored (left the current set)", () => {
+    expect(isNewlyOrphaned("a", new Set(), new Set(["a"]))).toBe(false);
   });
 });

--- a/packages/viewer/src/lib/comments/navigation.ts
+++ b/packages/viewer/src/lib/comments/navigation.ts
@@ -29,3 +29,17 @@ export function sortByOrder<T extends { id: string }>(items: T[], order: string[
   const rank = new Map(order.map((id, i) => [id, i]));
   return items.toSorted((a, b) => (rank.get(a.id) ?? Infinity) - (rank.get(b.id) ?? Infinity));
 }
+
+/** True when `activeId` names a comment that is in the current orphan set but
+ *  was NOT in the previous one — i.e. an open thread that just lost its anchor
+ *  (a content edit / live-reload removed the passage). A comment that was
+ *  already an orphan is not a transition — returns false, leaving the caller to
+ *  keep it active (orphans live in the page-comments timeline and are valid n/p
+ *  targets). Returns false when `activeId` is null. */
+export function isNewlyOrphaned(
+  activeId: string | null,
+  currentOrphans: ReadonlySet<string>,
+  previousOrphans: ReadonlySet<string>,
+): boolean {
+  return activeId != null && currentOrphans.has(activeId) && !previousOrphans.has(activeId);
+}


### PR DESCRIPTION
## Problem

Pressing `n`/`p` to step through comment threads got stuck when it reached an **orphaned inline comment** — one whose anchored passage was edited away, so it's surfaced in the page-comments timeline below the article. Landing on such a comment reset `activeId` in the same reactive flush, so:

- the timeline card never received its highlight, and
- the next `n`/`p` re-entered from idle and snapped back to the first thread, never advancing past the orphan.

## Root cause

`PageContent.svelte`'s large DOM-wrapping `$effect` carried a guard that nulled `activeId` whenever the active comment was in `orphanIds`. Because that effect reads `activeId`, it ran on every navigation and fired the guard the instant `n`/`p` stepped onto an orphan. The guard's real purpose was narrower: de-activate a thread that *spontaneously* loses its anchor on live-reload.

## Fix

Lift the clear into a dedicated `$effect` that clears `activeId` only on a genuine **non-orphan → orphan transition** (the live-reload case), via a new pure helper `isNewlyOrphaned`. Navigating onto an already-orphaned comment keeps it active, so it highlights and stepping continues. As a side benefit, the wrap effect no longer reads `activeId`, so navigation stops re-wrapping the article DOM on every keypress.

## Tests

- Unit tests for `isNewlyOrphaned` (transition vs. already-orphan vs. re-anchored vs. null).
- E2E regression in `comment-navigation.spec.ts`: one inline + two orphaned threads; `n` steps inline → orphan A → orphan B, each highlighting and advancing. Verified it **fails without the fix and passes with it**; the full navigation spec (incl. the existing native-page-comment case) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)