### PR TITLE
fix(viewer): render prose blockquotes upright instead of italic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `n`/`p` comment navigation getting stuck on orphaned comments (inline comments whose anchored text was later edited away). They now highlight when selected, and navigation continues to the next comment.
+- Markdown blockquotes are restyled for readability — upright (no italics), normal-weight body text with no decorative quotation marks, set off by the left border alone. Long multi-line quotes are much easier to read.
 
 ## [0.1.25] - 2026-06-19
 

--- a/packages/viewer/src/styles/content.css
+++ b/packages/viewer/src/styles/content.css
@@ -293,6 +293,23 @@
   }
 }
 
+/* Reset Tailwind Typography's blockquote styling to upright, normal-weight body
+   text with no decorative quotation marks (`quotes: none` makes the plugin's
+   open-quote/close-quote pseudo-elements render nothing); the left border is
+   kept. Must be @layer utilities (not components) to win the cascade against the
+   plugin's own utilities-layer blockquote rule. */
+@layer utilities {
+  .prose blockquote {
+    font-style: normal;
+    font-weight: 400;
+    quotes: none;
+    /* Match body text rather than the plugin's darker `--tw-prose-quotes`: the
+       left border already marks the quote, so a second text tone isn't needed.
+       `--tw-prose-body` auto-swaps to the inverted value in dark mode. */
+    color: var(--tw-prose-body);
+  }
+}
+
 /* Comment highlights — each comment range wraps its text in one or more
  * <rw-annotation> elements. Nested wrappers alpha-composite via the CSS box
  * model, so overlapping comments render as a darker yellow at the overlap


### PR DESCRIPTION
## Summary

Tailwind Typography styles markdown blockquotes as *italic* + medium-weight with decorative curly quotation marks, which is hard to read on long, multi-line quotes. This restyles them to **upright, normal-weight body text with no quote marks**, set off by the left border alone (matching the iA Writer / Bear single-tone reading style).

Specifically, the `.prose blockquote` override:
- `font-style: normal` + `font-weight: 400` — upright body weight
- `quotes: none` — suppresses the plugin's `open-quote`/`close-quote` pseudo-elements
- `color: var(--tw-prose-body)` — matches body text (instead of the plugin's darker `--tw-prose-quotes`); auto-inverts in dark mode

The override lives in `@layer utilities` (not `components`) because the typography plugin emits its blockquote rule into the utilities layer, which Tailwind orders after components — a components-layer override would silently lose the cascade regardless of specificity.

## Testing

- Verified in Chrome (light + dark): blockquote renders upright, no quote marks, left border kept, text color matches body (`getComputedStyle` confirmed `match: true` in both themes).
- `svelte-check`: 0 errors / 0 warnings; viewer build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)